### PR TITLE
fix: diff pane push flow - commit locally, then choose branch

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -732,6 +732,67 @@ async fn git_push_branch(repo_path: String, commit_message: Option<String>) -> R
         .map_err(|e| e.to_string())
 }
 
+// ── Push (no auto-commit) ────────────────────────────────────────────────────
+
+#[tauri::command]
+fn git_push_current_branch(repo_path: String) -> Result<String, String> {
+    let dir = std::path::Path::new(&repo_path);
+
+    let branch_out = run_git(dir, &["symbolic-ref", "--short", "HEAD"])?;
+    if !branch_out.status.success() {
+        return Err(git_stderr(&branch_out));
+    }
+    let branch = String::from_utf8_lossy(&branch_out.stdout).trim().to_string();
+    if branch.is_empty() {
+        return Err("Could not determine current branch".to_string());
+    }
+
+    let push_out = run_git(dir, &["push", "-u", "origin", &branch])?;
+    if !push_out.status.success() {
+        return Err(git_stderr(&push_out));
+    }
+
+    let remote_out = run_git(dir, &["remote", "get-url", "origin"])?;
+    if !remote_out.status.success() {
+        return Err(git_stderr(&remote_out));
+    }
+    let remote_url = String::from_utf8_lossy(&remote_out.stdout).trim().to_string();
+
+    serde_json::to_string(&serde_json::json!({ "remoteUrl": remote_url, "branch": branch }))
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn git_create_push_branch(repo_path: String, branch_name: String) -> Result<String, String> {
+    let branch_name = branch_name.trim().to_string();
+    if branch_name.is_empty() {
+        return Err("Branch name cannot be empty".to_string());
+    }
+
+    let dir = std::path::Path::new(&repo_path);
+
+    let checkout_out = run_git(dir, &["checkout", "-b", &branch_name])?;
+    if !checkout_out.status.success() {
+        return Err(format!("Failed to create branch: {}", git_stderr(&checkout_out)));
+    }
+
+    let push_out = run_git(dir, &["push", "-u", "origin", &branch_name])?;
+    if !push_out.status.success() {
+        // Switch back to original branch on push failure so the repo isn't left detached
+        let _ = run_git(dir, &["checkout", "-"]);
+        return Err(git_stderr(&push_out));
+    }
+
+    let remote_out = run_git(dir, &["remote", "get-url", "origin"])?;
+    if !remote_out.status.success() {
+        return Err(git_stderr(&remote_out));
+    }
+    let remote_url = String::from_utf8_lossy(&remote_out.stdout).trim().to_string();
+
+    serde_json::to_string(&serde_json::json!({ "remoteUrl": remote_url, "branch": branch_name }))
+        .map_err(|e| e.to_string())
+}
+
 // ── Staging ──────────────────────────────────────────────────────────────────
 
 #[tauri::command]
@@ -1402,6 +1463,8 @@ pub fn run() {
             git_branch_delete,
             git_diff,
             git_push_branch,
+            git_push_current_branch,
+            git_create_push_branch,
             git_stage,
             git_unstage,
             git_discard,

--- a/src/components/DiffPane.css
+++ b/src/components/DiffPane.css
@@ -155,6 +155,62 @@
 
 .dp-push-btn:disabled { opacity: 0.4; cursor: default; }
 
+.dp-push-btn--outline {
+  background: transparent;
+  border-color: var(--tempest-border-subtle);
+  color: var(--tempest-fg-muted);
+}
+
+.dp-push-btn--outline:hover:not(:disabled) {
+  background: var(--tempest-bg-hover);
+  border-color: var(--tempest-border-default);
+  color: var(--tempest-fg-default);
+  opacity: 1;
+}
+
+.dp-branch-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.dp-branch-cancel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--tempest-fg-subtle);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.1s ease, background 0.1s ease;
+}
+
+.dp-branch-cancel:hover {
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-default);
+}
+
+.dp-branch-input {
+  width: 130px;
+  height: 26px;
+  border: 1px solid var(--tempest-border-subtle);
+  border-radius: 5px;
+  background: var(--tempest-bg-editor);
+  color: var(--tempest-fg-default);
+  font-size: 11px;
+  font-family: "Geist Mono", monospace;
+  padding: 0 8px;
+  outline: none;
+  transition: border-color 0.12s ease;
+}
+
+.dp-branch-input:focus { border-color: var(--tempest-accent-blue); }
+.dp-branch-input::placeholder { color: var(--tempest-fg-subtle); opacity: 0.6; }
+
 .dp-push-error {
   flex-shrink: 0;
   padding: 6px 12px;

--- a/src/components/DiffPane.tsx
+++ b/src/components/DiffPane.tsx
@@ -5,7 +5,6 @@ import {
   RefreshCw, GitBranch, GitPullRequest, Loader, Check,
   Plus, Minus, X, AlertTriangle,
 } from "lucide-react";
-import { getSettings } from "../store/appSettings";
 import { useAttribution, setAttribution, COAUTHOR_LINE } from "../store/attribution";
 import "./DiffPane.css";
 
@@ -94,9 +93,13 @@ export function DiffPane({ cwd, hidden, gitRevision }: Props) {
   const [commitState, setCommitState] = useState<"idle" | "committing" | "done" | "error">("idle");
   const coauthor = useAttribution();
 
+  const [currentBranch, setCurrentBranch] = useState("");
   const [pushState, setPushState] = useState<"idle" | "pushing" | "done">("idle");
-  const [pushAction, setPushAction] = useState<"push" | "pr" | null>(null);
   const [pushError, setPushError] = useState<string | null>(null);
+
+  const [showBranchInput, setShowBranchInput] = useState(false);
+  const [newBranchName, setNewBranchName] = useState("");
+  const [branchPushState, setBranchPushState] = useState<"idle" | "pushing" | "done" | "error">("idle");
 
   const [discardTarget, setDiscardTarget] = useState<string | null>(null);
 
@@ -106,7 +109,11 @@ export function DiffPane({ cwd, hidden, gitRevision }: Props) {
     setLoading(true);
     setError(null);
     try {
-      const entries = await invoke<FileEntry[]>("git_status", { path: cwd });
+      const [entries, branch] = await Promise.all([
+        invoke<FileEntry[]>("git_status", { path: cwd }),
+        invoke<string>("get_git_branch", { path: cwd }).catch(() => ""),
+      ]);
+      setCurrentBranch(branch);
       const filtered = entries.filter((e) => !e.path.includes(".tempest-pid"));
       const s: FileEntry[] = [];
       const u: FileEntry[] = [];
@@ -222,28 +229,43 @@ export function DiffPane({ cwd, hidden, gitRevision }: Props) {
 
   // ── Push ─────────────────────────────────────────────────────────────────
 
-  const runPush = useCallback((openPr: boolean) => {
+  const pushToCurrent = useCallback(() => {
     setPushState("pushing");
-    setPushAction(openPr ? "pr" : "push");
     setPushError(null);
-    invoke<string>("git_push_branch", {
-      repoPath: cwd,
-      commitMessage: getSettings().commitMessageTemplate || null,
-    })
-      .then((raw) => {
-        const { remoteUrl, branch } = JSON.parse(raw) as { remoteUrl: string; branch: string };
-        if (openPr) openUrl(buildPrUrl(remoteUrl, branch)).catch(() => {});
+    invoke<string>("git_push_current_branch", { repoPath: cwd })
+      .then(() => {
         setPushState("done");
         load();
-        setTimeout(() => { setPushState("idle"); setPushAction(null); }, 2000);
+        setTimeout(() => setPushState("idle"), 2000);
       })
       .catch((e) => {
         setPushState("idle");
-        setPushAction(null);
         setPushError(String(e));
         setTimeout(() => setPushError(null), 4000);
       });
   }, [cwd, load]);
+
+  const pushToNewBranch = useCallback(() => {
+    if (!newBranchName.trim() || branchPushState === "pushing") return;
+    setBranchPushState("pushing");
+    setPushError(null);
+    invoke<string>("git_create_push_branch", { repoPath: cwd, branchName: newBranchName.trim() })
+      .then((raw) => {
+        const { remoteUrl, branch } = JSON.parse(raw) as { remoteUrl: string; branch: string };
+        setCurrentBranch(branch);
+        setShowBranchInput(false);
+        setNewBranchName("");
+        setBranchPushState("done");
+        openUrl(buildPrUrl(remoteUrl, branch)).catch(() => {});
+        load();
+        setTimeout(() => setBranchPushState("idle"), 2000);
+      })
+      .catch((e) => {
+        setBranchPushState("error");
+        setPushError(String(e));
+        setTimeout(() => { setBranchPushState("idle"); setPushError(null); }, 4000);
+      });
+  }, [cwd, newBranchName, branchPushState, load]);
 
   // ── Render ───────────────────────────────────────────────────────────────
 
@@ -262,30 +284,65 @@ export function DiffPane({ cwd, hidden, gitRevision }: Props) {
           <RefreshCw size={13} />
         </button>
         <div className="dp-header-push">
-          <button
-            className="dp-push-btn"
-            disabled={pushState === "pushing"}
-            onClick={() => runPush(false)}
-          >
-            {pushState === "pushing" && pushAction === "push"
-              ? <Loader size={12} className="dp-spin" />
-              : pushState === "done" && pushAction === "push"
-              ? <Check size={12} />
-              : <GitBranch size={12} />}
-            Push
-          </button>
-          <button
-            className="dp-push-btn dp-push-btn--pr"
-            disabled={pushState === "pushing"}
-            onClick={() => runPush(true)}
-          >
-            {pushState === "pushing" && pushAction === "pr"
-              ? <Loader size={12} className="dp-spin" />
-              : pushState === "done" && pushAction === "pr"
-              ? <Check size={12} />
-              : <GitPullRequest size={12} />}
-            Open PR
-          </button>
+          {!showBranchInput ? (
+            <>
+              <button
+                className="dp-push-btn"
+                disabled={pushState === "pushing"}
+                onClick={pushToCurrent}
+                title={`Push commits to ${currentBranch || "current branch"}`}
+              >
+                {pushState === "pushing"
+                  ? <Loader size={12} className="dp-spin" />
+                  : pushState === "done"
+                  ? <Check size={12} />
+                  : <GitBranch size={12} />}
+                Push{currentBranch ? ` to ${currentBranch}` : ""}
+              </button>
+              <button
+                className="dp-push-btn dp-push-btn--outline"
+                onClick={() => setShowBranchInput(true)}
+                title="Create a new branch and push"
+              >
+                <GitPullRequest size={12} />
+                New Branch
+              </button>
+            </>
+          ) : (
+            <div className="dp-branch-row">
+              <button
+                className="dp-branch-cancel"
+                onClick={() => { setShowBranchInput(false); setNewBranchName(""); }}
+                title="Cancel"
+              >
+                <X size={12} />
+              </button>
+              <input
+                className="dp-branch-input"
+                placeholder="branch-name"
+                value={newBranchName}
+                onChange={(e) => setNewBranchName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") pushToNewBranch();
+                  if (e.key === "Escape") { setShowBranchInput(false); setNewBranchName(""); }
+                }}
+                autoFocus
+              />
+              <button
+                className="dp-push-btn"
+                disabled={!newBranchName.trim() || branchPushState === "pushing"}
+                onClick={pushToNewBranch}
+                title="Create branch, push, and open PR"
+              >
+                {branchPushState === "pushing"
+                  ? <Loader size={12} className="dp-spin" />
+                  : branchPushState === "done"
+                  ? <Check size={12} />
+                  : <GitPullRequest size={12} />}
+                Push & PR
+              </button>
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
- Add git_push_current_branch (push only, no auto-commit)
- Add git_create_push_branch (create branch + push + open PR)
- Header now shows "Push to <branch>" with current branch name
- New Branch button opens inline input to create a branch and push
- Removes the old auto-commit-on-push behavior from the diff pane