### PR TITLE
Fix onboarding black-screen on Linux/WebKitGTK when WebGL is unavailable

### DIFF
--- a/src/components/onboarding/WelcomePage.tsx
+++ b/src/components/onboarding/WelcomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { Component, type ReactNode, useState, useEffect } from 'react';
 import { CircleArrowRight } from 'lucide-react';
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -7,6 +7,16 @@ import { useTheme } from '../../themes/ThemeContext';
 import { TempestLogo } from '../../assets/TempestLogo';
 
 interface Props { onComplete: () => void; }
+
+// A decorative WebGL effect must never take down the app. WebKitGTK (Linux)
+// exposes OffscreenCanvas but not an OffscreenCanvas WebGL context, so metal-fx
+// throws "WebGL not supported" on mount. Isolate it and fall back to the plain
+// child button so onboarding still renders.
+class GfxBoundary extends Component<{ fallback: ReactNode; children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() { return { failed: true }; }
+  render() { return this.state.failed ? this.props.fallback : this.props.children; }
+}
 
 // ── Page 0 — Welcome ────────────────────────────────────────────
 export default function WelcomePage({ onComplete }: Props) {
@@ -31,12 +41,23 @@ export default function WelcomePage({ onComplete }: Props) {
         }}>
           Run your AI coding agents in parallel with 64% fewer tokens and deeper codebase understanding
         </p>
-        <MetalFx className="ob-metal" preset="chromatic" strength={0.78} theme={isDark ? 'light' : 'dark'} borderRadius={8} ringCssPx={3}>
-          <button className="ob-blank-btn" onClick={onComplete}>
-            Get Started
-            <CircleArrowRight size={21} />
-          </button>
-        </MetalFx>
+        <GfxBoundary
+          fallback={
+            <div className="ob-metal">
+              <button className="ob-blank-btn" onClick={onComplete}>
+                Get Started
+                <CircleArrowRight size={21} />
+              </button>
+            </div>
+          }
+        >
+          <MetalFx className="ob-metal" preset="chromatic" strength={0.78} theme={isDark ? 'light' : 'dark'} borderRadius={8} ringCssPx={3}>
+            <button className="ob-blank-btn" onClick={onComplete}>
+              Get Started
+              <CircleArrowRight size={21} />
+            </button>
+          </MetalFx>
+        </GfxBoundary>
       </div>
 
       <div className="ob-box" />


### PR DESCRIPTION
## Problem

On Linux, Tempest shows a **solid black window on first launch** and never reaches onboarding. JS runs and the SQLite DB is created, but the whole React tree fails to mount.

The uncaught error is:

```
Error: metal-fx: WebGL not supported
```

thrown from `<MetalFx>` on `WelcomePage`. Because it is uncaught during mount, React unwinds the entire tree, leaving only the app's dark background (hence black, not white).

## Root cause

`metal-fx` initializes its context like this:

```js
const n = typeof OffscreenCanvas !== "undefined";
if (n) {
  const o = new OffscreenCanvas(t, t);
  r = o.getContext("webgl", { ... });   // null on WebKitGTK
} else {
  // regular <canvas> fallback, never reached
}
if (!r) throw new Error("metal-fx: WebGL not supported");
```

WebKitGTK (the webview Tauri uses on Linux) **exposes `OffscreenCanvas` but does not back it with a WebGL context**, so `getContext("webgl")` returns `null`. Since `OffscreenCanvas` is defined, metal-fx takes the offscreen branch and never tries a regular `<canvas>` (which does support WebGL here), then throws. This affects essentially every Linux WebKitGTK build, not one specific GPU.

## Fix

A decorative effect should never take down the app. This wraps the `<MetalFx>` usage on `WelcomePage` in a small error boundary that falls back to the same button inside a plain `.ob-metal` container, so onboarding renders whether or not WebGL is available. No behavior change on platforms where metal-fx works (macOS/Windows).

## Verified

- Arch Linux, WebKitGTK 4.1 (2.52.5), Mesa 26, Wayland, built from source with `tauri build`.
- Before: black window on first launch.
- After: onboarding renders with a styled Get Started button; clicking it proceeds normally.

## Note for maintainers

The deeper fix likely belongs in `metal-fx`: when `OffscreenCanvas.getContext("webgl")` returns null, fall back to a regular `<canvas>` before giving up. This PR guards the app side so Linux users are unblocked regardless.
