### PR TITLE
Automations with visual builder, DB schema, and UI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ npm run dev        # development with hot reload
 npm run build      # production build -> dist-installers/
 ```
 
+## Star History
+
+[![Star Trail](https://star-trail.fun/api/chart/tempestai-dev/tempest)](https://star-trail.fun/tempestai-dev/tempest)
+
 ## Community
 
 [X (Twitter)](https://x.com/usetempest) — @usetempest

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:web": "npm run dev --workspace=tempest-web",
     "dev:docs": "npm run dev --workspace=tempest-docs",
     "build": "tauri build && node scripts/collect-artifacts.mjs",
-    "postinstall": "node scripts/install-atlas.mjs && node scripts/install-claude-bridge.mjs",
+    "postinstall": "node scripts/install-atlas.mjs && node scripts/install-claude-bridge.mjs && node scripts/install-eve.mjs",
     "build:frontend": "tsc && vite build",
     "build:web": "npm run build --workspace=tempest-web",
     "build:docs": "npm run build --workspace=tempest-docs",

--- a/scripts/install-eve.mjs
+++ b/scripts/install-eve.mjs
@@ -1,0 +1,17 @@
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const dir = join(root, 'src-tauri', 'resources', 'eve')
+
+if (!existsSync(join(dir, 'package.json'))) process.exit(0)
+
+try {
+  execSync('npm install eve --save-exact --no-audit --no-fund --silent', { cwd: dir, stdio: 'inherit' })
+  console.log('Eve staged → src-tauri/resources/eve/node_modules/')
+} catch (e) {
+  // Non-fatal: automations stay unavailable until deps install.
+  console.warn('Eve install skipped:', e?.message ?? e)
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4468,6 +4468,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tiny_http",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3358,6 +3358,7 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4448,6 +4449,7 @@ dependencies = [
 name = "tempest"
 version = "0.1.9"
 dependencies = [
+ "base64 0.22.1",
  "dashmap",
  "dbiso",
  "getrandom 0.2.17",
@@ -4467,6 +4469,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tiny_http",
+ "ureq",
  "url",
  "uuid",
 ]
@@ -4993,6 +4996,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5322,6 +5343,24 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,8 @@ minisign-verify = "0.2"
 tiny_http = "0.12"
 # OS entropy for the per-run hook-server auth token.
 getrandom = "0.2"
+# UUID generation for automation IDs
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,10 @@ tiny_http = "0.12"
 getrandom = "0.2"
 # UUID generation for automation IDs
 uuid = { version = "1", features = ["v4"] }
+# Blocking HTTP for the automations "Try it" tool preview — small, sync, no
+# runtime pulled in. Only reached from the try_http_request Tauri command.
+ureq = { version = "2", features = ["json"] }
+base64 = "0.22"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/resources/eve/package-lock.json
+++ b/src-tauri/resources/eve/package-lock.json
@@ -1,0 +1,813 @@
+{
+  "name": "@tempest/eve-runtime",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@tempest/eve-runtime",
+      "dependencies": {
+        "eve": "0.30.6"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.41.tgz",
+      "integrity": "sha512-DPkDmmA336kqmIp62on550/6Q6JHvldsnvN1SmkwU8QGrVt1PzFxqyKUn0C5EGGmSBpvF1ohZNtvWNl8gEVugA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.5",
+        "@ai-sdk/provider-utils": "5.0.21",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.5.tgz",
+      "integrity": "sha512-9WAerTaPU2jcVi8dh8x27tySEuLur1Kfg7Go74GuCmsC/2MDSvrTkrK8ZrXWjryEevKfcPPmO1enveE7eqlzoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.21.tgz",
+      "integrity": "sha512-Q4z27c5vqKuXZN65QuF7FVm+uvm3qxEioiQ+8c3s5xXlhbE1Y/SLGBB4BuF+UWia4KaDu2HmNpdR1RGW02/eGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.5",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ai": {
+      "version": "7.0.52",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.52.tgz",
+      "integrity": "sha512-sEgRnYA+ddJ1rJSz1uKBjkGbOXhXdon1nvno49fVk3tabnlf8v5SaceLBpPDMtmDuLKQFztc/YbRsoCQoPzKZw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.41",
+        "@ai-sdk/provider": "4.0.5",
+        "@ai-sdk/provider-utils": "5.0.21"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/db0": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
+      "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@electric-sql/pglite": "*",
+        "@libsql/client": "*",
+        "better-sqlite3": "*",
+        "drizzle-orm": "*",
+        "mysql2": "*",
+        "sqlite3": "*"
+      },
+      "peerDependenciesMeta": {
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/env-runner": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/env-runner/-/env-runner-0.1.16.tgz",
+      "integrity": "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==",
+      "license": "MIT",
+      "dependencies": {
+        "crossws": "^0.4.8",
+        "exsolve": "^1.1.0",
+        "httpxy": "^0.5.4",
+        "srvx": "^0.11.19"
+      },
+      "bin": {
+        "env-runner": "dist/cli.mjs"
+      },
+      "peerDependencies": {
+        "@netlify/runtime": "^4.1.23",
+        "@vercel/queue": ">=0.2.0",
+        "miniflare": "^4.20260515.0",
+        "wrangler": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@netlify/runtime": {
+          "optional": true
+        },
+        "@vercel/queue": {
+          "optional": true
+        },
+        "miniflare": {
+          "optional": true
+        },
+        "wrangler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eve": {
+      "version": "0.30.6",
+      "resolved": "https://registry.npmjs.org/eve/-/eve-0.30.6.tgz",
+      "integrity": "sha512-sSO04d1vcPtI/Nf3nQfUAfIG7BrZNLih1Kr70Fab87llaIjGQOwXs0C5LYSfTnrdcZwD+wEWjZ8EDhFIQcp6Ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "nitro": "3.0.260610-beta",
+        "undici": "8.9.0"
+      },
+      "bin": {
+        "eve": "bin/eve.js"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0",
+        "ai": "^7.0.38",
+        "braintrust": "^3.0.0",
+        "just-bash": "^3.0.0",
+        "microsandbox": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "braintrust": {
+          "optional": true
+        },
+        "just-bash": {
+          "optional": true
+        },
+        "microsandbox": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eve/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "license": "MIT"
+    },
+    "node_modules/h3": {
+      "version": "2.0.1-rc.22",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
+      "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.8.1",
+        "srvx": "^0.11.15"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "license": "MIT"
+    },
+    "node_modules/httpxy": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/nf3": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/nf3/-/nf3-0.3.23.tgz",
+      "integrity": "sha512-RWVLAWozmVD3AaDmaU3qMGB3v+yNlH5d9qqStI4e/WLlNQVnJ4YErGDbYCIrGFyrHdbF6I6Baf0Ae6c7tFYmSg==",
+      "license": "MIT"
+    },
+    "node_modules/nitro": {
+      "version": "3.0.260610-beta",
+      "resolved": "https://registry.npmjs.org/nitro/-/nitro-3.0.260610-beta.tgz",
+      "integrity": "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.4.2",
+        "crossws": "^0.4.6",
+        "db0": "^0.3.4",
+        "env-runner": "^0.1.12",
+        "h3": "2.0.1-rc.22",
+        "hookable": "^6.1.1",
+        "nf3": "^0.3.17",
+        "ocache": "^0.1.5",
+        "ofetch": "2.0.0-alpha.3",
+        "ohash": "^2.0.11",
+        "rolldown": "^1.1.0",
+        "srvx": "^0.11.16",
+        "unenv": "2.0.0-rc.24",
+        "unstorage": "2.0.0-alpha.7"
+      },
+      "bin": {
+        "nitro": "dist/cli/index.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@vercel/queue": "^0.3.0",
+        "dotenv": "*",
+        "giget": "*",
+        "jiti": "^2.7.0",
+        "rollup": "^4.61.1",
+        "vite": "^7 || ^8",
+        "xml2js": "^0.6.2",
+        "zephyr-agent": "^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vercel/queue": {
+          "optional": true
+        },
+        "dotenv": {
+          "optional": true
+        },
+        "giget": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "xml2js": {
+          "optional": true
+        },
+        "zephyr-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ocache": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ocache/-/ocache-0.1.5.tgz",
+      "integrity": "sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==",
+      "license": "MIT",
+      "dependencies": {
+        "ohash": "^2.0.11"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
+      }
+    },
+    "node_modules/rou3": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
+      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "license": "MIT"
+    },
+    "node_modules/srvx": {
+      "version": "0.11.22",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.22.tgz",
+      "integrity": "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==",
+      "license": "MIT",
+      "bin": {
+        "srvx": "bin/srvx.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "2.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-2.0.0-alpha.7.tgz",
+      "integrity": "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.11.0",
+        "@azure/cosmos": "^4.9.1",
+        "@azure/data-tables": "^13.3.2",
+        "@azure/identity": "^4.13.0",
+        "@azure/keyvault-secrets": "^4.10.0",
+        "@azure/storage-blob": "^12.31.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.13.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.36.2",
+        "@vercel/blob": ">=0.27.3",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1.0.1",
+        "aws4fetch": "^1.0.20",
+        "chokidar": "^4 || ^5",
+        "db0": ">=0.3.4",
+        "idb-keyval": "^6.2.2",
+        "ioredis": "^5.9.3",
+        "lru-cache": "^11.2.6",
+        "mongodb": "^6 || ^7",
+        "ofetch": "*",
+        "uploadthing": "^7.7.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "chokidar": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "lru-cache": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "ofetch": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/src-tauri/resources/eve/package.json
+++ b/src-tauri/resources/eve/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@tempest/eve-runtime",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "eve": "0.30.6"
+  }
+}

--- a/src-tauri/src/automations.rs
+++ b/src-tauri/src/automations.rs
@@ -182,59 +182,695 @@ fn write_agent_ts(dir: &std::path::Path, data: &serde_json::Value) -> Result<(),
     std::fs::write(dir.join("agent.ts"), ts).map_err(|e| e.to_string())
 }
 
+// ── New tool shape (P1–P3): request builder → generated fetch() body ────────
+// Mirrors src/components/Automations/builder/graph.ts. The visual builder is
+// the only authoring surface; this writer compiles it to plain TS the agent
+// runtime executes.
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct KV {
+    pub key: String,
+    pub value: String,
+    pub enabled: bool,
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum HttpAuth {
+    None,
+    Bearer { token: String },
+    Basic { user: String, pass: String },
+    #[serde(rename_all = "camelCase")]
+    ApiKey {
+        #[serde(rename = "in")]
+        in_: String,       // "header" | "query"
+        name: String,
+        value: String,
+    },
+}
+impl Default for HttpAuth { fn default() -> Self { HttpAuth::None } }
+
+#[derive(Deserialize, Clone)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum HttpBody {
+    None,
+    Json { fields: Vec<KV> },
+    Form { fields: Vec<KV> },
+    Raw { #[serde(rename = "contentType")] content_type: String, text: String },
+}
+impl Default for HttpBody { fn default() -> Self { HttpBody::None } }
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    #[serde(rename = "queryParams")]
+    pub query_params: Vec<KV>,
+    pub headers: Vec<KV>,
+    pub auth: HttpAuth,
+    pub body: HttpBody,
+}
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct ToolInputField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: String,       // "string" | "number" | "boolean" | "enum"
+    pub required: bool,
+    #[serde(rename = "enumValues")]
+    pub enum_values: Option<Vec<String>>,
+    pub description: Option<String>,
+}
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct ToolInputSchema {
+    pub fields: Vec<ToolInputField>,
+}
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct ResponseMap {
+    pub kind: String,             // "raw" | "pick"
+    pub pick: Option<String>,
+}
+
+fn zod_line(f: &ToolInputField) -> String {
+    let base = match f.type_.as_str() {
+        "number" => "z.number()".to_string(),
+        "boolean" => "z.boolean()".to_string(),
+        "enum" => {
+            let vs = f.enum_values.clone().unwrap_or_default();
+            if vs.is_empty() {
+                "z.string()".to_string()
+            } else {
+                let inner: Vec<String> = vs.iter().map(|v| format!("{:?}", v)).collect();
+                format!("z.enum([{}])", inner.join(", "))
+            }
+        }
+        _ => "z.string()".to_string(),
+    };
+    let with_desc = match &f.description {
+        Some(d) if !d.is_empty() => format!("{base}.describe({:?})", d),
+        _ => base,
+    };
+    if f.required { with_desc } else { format!("{with_desc}.optional()") }
+}
+
+fn zod_schema(schema: &ToolInputSchema) -> String {
+    if schema.fields.is_empty() {
+        return "z.object({})".to_string();
+    }
+    let mut lines = Vec::with_capacity(schema.fields.len());
+    for f in &schema.fields {
+        // Non-identifier names get JSON-quoted so `2foo` etc. don't break the object literal.
+        let key = if f.name.chars().next().map_or(false, |c| c.is_ascii_alphabetic() || c == '_')
+            && f.name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            f.name.clone()
+        } else {
+            format!("{:?}", f.name)
+        };
+        lines.push(format!("    {}: {},", key, zod_line(f)));
+    }
+    format!("z.object({{\n{}\n  }})", lines.join("\n"))
+}
+
+// Emit a TS runtime helper that expands `{{input.<name>}}` inside a string
+// against an `input` object. Shared by URL, headers, param values, body fields.
+const CHIP_HELPER: &str = r#"const __sub = (s, input) =>
+      typeof s === "string"
+        ? s.replace(/\{\{\s*input\.([A-Za-z0-9_]+)\s*\}\}/g, (_, k) => String(input?.[k] ?? ""))
+        : s;"#;
+
+// Emit a TS helper that navigates a JSONPath-ish string ("data.items[0].name").
+const PICK_HELPER: &str = r#"const __pick = (obj, path) => {
+      if (!path) return obj;
+      const parts = path.replace(/\[(\d+)\]/g, ".$1").split(".").filter(Boolean);
+      let cur = obj;
+      for (const p of parts) {
+        if (cur == null) return undefined;
+        cur = cur[p];
+      }
+      return cur;
+    };"#;
+
+fn json_body_ts(rows: &[KV]) -> String {
+    let mut out = String::from("{\n");
+    for r in rows.iter().filter(|r| r.enabled && !r.key.is_empty()) {
+        // Values are always chip-substituted strings; the model can put JSON-literal
+        // scalars in via chips too (e.g. `{{input.count}}` → coerced by JSON.stringify).
+        out.push_str(&format!("      {:?}: __sub({:?}, input),\n", r.key, r.value));
+    }
+    out.push_str("    }");
+    out
+}
+
 fn write_tool(dir: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
     let name = slugify(field_str_or(data, "name", "tool"));
     let description = field_str_or(data, "description", "A tool.");
-    let preset = field_str_or(data, "preset", "custom");
 
-    let body = if preset == "http" {
-        let method = field_str_or(data, "httpMethod", "GET");
-        let url = field_str_or(data, "httpUrl", "");
+    let request: HttpRequest = data.get("request")
+        .cloned()
+        .map(|v| serde_json::from_value(v).unwrap_or_default())
+        .unwrap_or_default();
+    let input: ToolInputSchema = data.get("input")
+        .cloned()
+        .map(|v| serde_json::from_value(v).unwrap_or_default())
+        .unwrap_or_default();
+    let response: ResponseMap = data.get("response")
+        .cloned()
+        .map(|v| serde_json::from_value(v).unwrap_or_default())
+        .unwrap_or_default();
+
+    let method = if request.method.is_empty() { "GET".to_string() } else { request.method.clone() };
+    let url_lit = format!("{:?}", request.url);
+    let schema = zod_schema(&input);
+
+    // Auth: append to headers or query as needed, using the same chip substitution.
+    let (auth_header_pairs, auth_query_pairs): (Vec<(String, String)>, Vec<(String, String)>) = match &request.auth {
+        HttpAuth::None => (vec![], vec![]),
+        HttpAuth::Bearer { token } => (vec![("Authorization".into(), format!("Bearer {}", token))], vec![]),
+        HttpAuth::Basic { user, pass } => {
+            // Basic auth needs runtime encoding — emit as a header-computing snippet
+            // rather than raw base64 at compile time (chips inside user/pass work).
+            (vec![("Authorization".into(), format!("__basic:{}:{}", user, pass))], vec![])
+        }
+        HttpAuth::ApiKey { in_, name, value } => {
+            if in_ == "query" { (vec![], vec![(name.clone(), value.clone())]) }
+            else { (vec![(name.clone(), value.clone())], vec![]) }
+        }
+    };
+
+    // Combined header rows: user-declared + auth-injected.
+    let mut header_rows: Vec<KV> = request.headers.iter()
+        .filter(|r| r.enabled && !r.key.is_empty())
+        .cloned()
+        .collect();
+    for (k, v) in &auth_header_pairs {
+        // Basic auth marker → runtime btoa; other headers substituted normally.
+        header_rows.push(KV { key: k.clone(), value: v.clone(), enabled: true });
+    }
+    let mut query_rows: Vec<KV> = request.query_params.iter()
+        .filter(|r| r.enabled && !r.key.is_empty())
+        .cloned()
+        .collect();
+    for (k, v) in &auth_query_pairs {
+        query_rows.push(KV { key: k.clone(), value: v.clone(), enabled: true });
+    }
+
+    let headers_ts = if header_rows.is_empty() {
+        "{}".to_string()
+    } else {
+        let mut s = String::from("{\n");
+        for r in &header_rows {
+            if r.value.starts_with("__basic:") {
+                // Runtime btoa so chips inside user/pass still work.
+                let rest = &r.value["__basic:".len()..];
+                let split = rest.find(':').unwrap_or(rest.len());
+                let user = &rest[..split];
+                let pass = if split < rest.len() { &rest[split+1..] } else { "" };
+                s.push_str(&format!(
+                    "      {:?}: \"Basic \" + btoa(__sub({:?}, input) + \":\" + __sub({:?}, input)),\n",
+                    r.key, user, pass
+                ));
+            } else {
+                s.push_str(&format!("      {:?}: __sub({:?}, input),\n", r.key, r.value));
+            }
+        }
+        s.push_str("    }");
+        s
+    };
+
+    let query_ts = if query_rows.is_empty() {
+        String::new()
+    } else {
+        let mut s = String::from("    const __qs = new URLSearchParams();\n");
+        for r in &query_rows {
+            s.push_str(&format!("    __qs.append({:?}, __sub({:?}, input));\n", r.key, r.value));
+        }
+        s
+    };
+
+    // Body serialization by kind.
+    let (body_prep, body_expr, content_type_header): (String, String, Option<String>) = match &request.body {
+        HttpBody::None => (String::new(), "undefined".into(), None),
+        HttpBody::Json { fields } => {
+            let obj = json_body_ts(fields);
+            let prep = format!("    const __body = JSON.stringify({});\n", obj);
+            (prep, "__body".into(), Some("application/json".into()))
+        }
+        HttpBody::Form { fields } => {
+            let mut s = String::from("    const __form = new URLSearchParams();\n");
+            for r in fields.iter().filter(|r| r.enabled && !r.key.is_empty()) {
+                s.push_str(&format!("    __form.append({:?}, __sub({:?}, input));\n", r.key, r.value));
+            }
+            (s, "__form.toString()".into(), Some("application/x-www-form-urlencoded".into()))
+        }
+        HttpBody::Raw { content_type, text } => {
+            let prep = format!("    const __body = __sub({:?}, input);\n", text);
+            (prep, "__body".into(), Some(content_type.clone()))
+        }
+    };
+
+    // Response return: raw text (try JSON parse) or picked field.
+    let return_ts = if response.kind == "pick" {
+        let path = response.pick.clone().unwrap_or_default();
         format!(
-            r#"import {{ defineTool }} from "eve/tools";
-import {{ z }} from "zod";
-
-export default defineTool({{
-  description: {desc:?},
-  inputSchema: z.object({{
-    body: z.string().optional(),
-  }}),
-  async execute(input) {{
-    const res = await fetch({url:?}, {{
-      method: {method:?},
-      body: {method_is_body_bearing} ? input.body : undefined,
-    }});
-    const text = await res.text();
-    return {{ status: res.status, body: text }};
-  }},
-}});
-"#,
-            desc = description,
-            url = url,
-            method = method,
-            method_is_body_bearing = matches!(method, "POST" | "PUT" | "PATCH")
+            r#"    const __text = await res.text();
+    let __data;
+    try {{ __data = JSON.parse(__text); }} catch {{ __data = __text; }}
+    return __pick(__data, {:?});"#,
+            path
         )
     } else {
-        let input_schema = field_str_or(data, "customInputSchema", "z.object({})");
-        let execute = field_str_or(data, "customExecute", "return {};");
-        format!(
-            r#"import {{ defineTool }} from "eve/tools";
+        r#"    const __text = await res.text();
+    try { return JSON.parse(__text); } catch { return __text; }"#.to_string()
+    };
+
+    // Only inject the content-type when the user didn't already set one.
+    let ct_line = match content_type_header {
+        Some(ct) => format!("    if (!__headers[\"Content-Type\"] && !__headers[\"content-type\"]) __headers[\"Content-Type\"] = {:?};\n", ct),
+        None => String::new(),
+    };
+    let final_url = if query_rows.is_empty() {
+        "__url".into()
+    } else {
+        "__url + (__url.includes(\"?\") ? \"&\" : \"?\") + __qs.toString()".to_string()
+    };
+    let body_bearing = matches!(method.as_str(), "POST" | "PUT" | "PATCH" | "DELETE");
+
+    let ts = format!(
+        r#"import {{ defineTool }} from "eve/tools";
 import {{ z }} from "zod";
+
+// Auto-generated from the visual builder. Do not edit by hand — your changes
+// will be overwritten on the next build.
 
 export default defineTool({{
   description: {desc:?},
   inputSchema: {schema},
-  async execute(input, ctx) {{
+  async execute(input) {{
+    {chip_helper}
+    {pick_helper}
+    const __url = __sub({url_lit}, input);
+    const __headers = {headers_ts};
+{query_ts}{ct_line}{body_prep}    const res = await fetch({final_url}, {{
+      method: {method_lit},
+      headers: __headers,
+      body: {body_bearing_ts},
+    }});
+{return_ts}
+  }},
+}});
+"#,
+        desc = description,
+        schema = schema,
+        chip_helper = CHIP_HELPER,
+        pick_helper = if response.kind == "pick" { PICK_HELPER } else { "" },
+        url_lit = url_lit,
+        headers_ts = headers_ts,
+        query_ts = query_ts,
+        ct_line = ct_line,
+        body_prep = body_prep,
+        final_url = final_url,
+        method_lit = format!("{:?}", method),
+        body_bearing_ts = if body_bearing { body_expr.as_str() } else { "undefined" },
+        return_ts = return_ts,
+    );
+    std::fs::write(dir.join(format!("{name}.ts")), ts).map_err(|e| e.to_string())
+}
+
+
+// ── P6/P7: flow compiler ────────────────────────────────────────────────────
+// A `flow` node compiles to `agent/tools/<name>.ts` whose `execute()` body is
+// the linear step-tree rendered as async TS. Every step reads/writes the same
+// `__scope` object, which starts as `{ ...input }` and accumulates set-vars,
+// call-results (via assignTo), and loop iteration variables. Chip resolution
+// reuses the same `__sub` helper the plain-tool writer emits.
+//
+// Kept as strings-of-TS rather than a proper AST — the compiler is one file,
+// and the generated code is disposable. If the grammar ever grows past what
+// concatenation supports (nested closures, hygiene issues), promote to a real
+// AST then. ponytail: string-concat compiler, upgrade to AST if grammar grows.
+
+#[derive(Deserialize, Clone)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum FlowStep {
+    #[serde(rename_all = "camelCase")]
+    Call {
+        #[allow(dead_code)] id: String,
+        assign_to: String,
+        request: HttpRequest,
+    },
+    #[serde(rename_all = "camelCase")]
+    If {
+        #[allow(dead_code)] id: String,
+        condition: Condition,
+        then: Vec<FlowStep>,
+        #[serde(rename = "else")] else_: Vec<FlowStep>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Switch {
+        #[allow(dead_code)] id: String,
+        cases: Vec<SwitchCase>,
+        default: Vec<FlowStep>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Set { #[allow(dead_code)] id: String, vars: Vec<SetVar> },
+    #[serde(rename_all = "camelCase")]
+    Return { #[allow(dead_code)] id: String, value: String },
+    #[serde(rename_all = "camelCase")]
+    Loop {
+        #[allow(dead_code)] id: String,
+        shape: String,               // "for-each" | "while"
+        list_chip: String,
+        item_var: String,
+        condition: Condition,
+        body: Vec<FlowStep>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Parallel {
+        #[allow(dead_code)] id: String,
+        mode: String,                 // "all" | "race"
+        branches: Vec<Vec<FlowStep>>,
+    },
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    pub left: String,
+    pub op: String,
+    pub right: String,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct SetVar { pub name: String, pub value: String }
+
+#[derive(Deserialize, Clone)]
+pub struct SwitchCase {
+    #[allow(dead_code)]
+    pub label: String,
+    pub condition: Condition,
+    pub steps: Vec<FlowStep>,
+}
+
+fn ts_str_expr(s: &str) -> String {
+    // Wrap the (chip-containing) string so runtime __sub resolves it.
+    format!("__sub({:?}, __scope)", s)
+}
+
+fn compile_condition(c: &Condition) -> String {
+    let l = ts_str_expr(&c.left);
+    let r = ts_str_expr(&c.right);
+    // Numeric ops coerce via Number(); the string ops stay as-is.
+    match c.op.as_str() {
+        "equals"        => format!("({l} === {r})"),
+        "not-equals"    => format!("({l} !== {r})"),
+        "contains"      => format!("({l}).includes({r})"),
+        "not-contains"  => format!("!({l}).includes({r})"),
+        "gt"            => format!("(Number({l}) > Number({r}))"),
+        "gte"           => format!("(Number({l}) >= Number({r}))"),
+        "lt"            => format!("(Number({l}) < Number({r}))"),
+        "lte"           => format!("(Number({l}) <= Number({r}))"),
+        "is-empty"      => format!("(({l}) == null || ({l}) === \"\")"),
+        "is-not-empty"  => format!("!(({l}) == null || ({l}) === \"\")"),
+        "matches"       => format!("new RegExp({r}).test({l})"),
+        _               => "false".into(),
+    }
+}
+
+fn compile_call(c: &HttpRequest, assign_to: &str, indent: &str) -> String {
+    // Reuses the exact same runtime shape as write_tool — we hand-inline it
+    // because the flow compiler doesn't invoke defineTool for each step.
+    let mut out = String::new();
+    let method = if c.method.is_empty() { "GET".to_string() } else { c.method.clone() };
+    let body_bearing = matches!(method.as_str(), "POST" | "PUT" | "PATCH" | "DELETE");
+
+    out.push_str(&format!("{indent}{{\n"));
+    out.push_str(&format!("{indent}  const __url = __sub({:?}, __scope);\n", c.url));
+
+    // Headers (with auth folded in)
+    out.push_str(&format!("{indent}  const __headers = {{}};\n"));
+    for h in c.headers.iter().filter(|h| h.enabled && !h.key.is_empty()) {
+        out.push_str(&format!(
+            "{indent}  __headers[{:?}] = __sub({:?}, __scope);\n",
+            h.key, h.value
+        ));
+    }
+    match &c.auth {
+        HttpAuth::None => {}
+        HttpAuth::Bearer { token } => {
+            out.push_str(&format!(
+                "{indent}  __headers[\"Authorization\"] = \"Bearer \" + __sub({:?}, __scope);\n",
+                token
+            ));
+        }
+        HttpAuth::Basic { user, pass } => {
+            out.push_str(&format!(
+                "{indent}  __headers[\"Authorization\"] = \"Basic \" + btoa(__sub({:?}, __scope) + \":\" + __sub({:?}, __scope));\n",
+                user, pass
+            ));
+        }
+        HttpAuth::ApiKey { in_, name, value } if in_ == "header" => {
+            out.push_str(&format!(
+                "{indent}  __headers[{:?}] = __sub({:?}, __scope);\n",
+                name, value
+            ));
+        }
+        _ => {}
+    }
+
+    // Query
+    let mut has_qs = !c.query_params.iter().all(|q| q.key.is_empty() || !q.enabled);
+    if let HttpAuth::ApiKey { in_, .. } = &c.auth { if in_ == "query" { has_qs = true; } }
+    if has_qs {
+        out.push_str(&format!("{indent}  const __qs = new URLSearchParams();\n"));
+        for q in c.query_params.iter().filter(|q| q.enabled && !q.key.is_empty()) {
+            out.push_str(&format!(
+                "{indent}  __qs.append({:?}, __sub({:?}, __scope));\n",
+                q.key, q.value
+            ));
+        }
+        if let HttpAuth::ApiKey { in_, name, value } = &c.auth {
+            if in_ == "query" {
+                out.push_str(&format!(
+                    "{indent}  __qs.append({:?}, __sub({:?}, __scope));\n",
+                    name, value
+                ));
+            }
+        }
+    }
+
+    // Body
+    match &c.body {
+        HttpBody::None => {}
+        HttpBody::Json { fields } => {
+            out.push_str(&format!("{indent}  const __body_obj = {{}};\n"));
+            for f in fields.iter().filter(|f| f.enabled && !f.key.is_empty()) {
+                out.push_str(&format!(
+                    "{indent}  __body_obj[{:?}] = __sub({:?}, __scope);\n",
+                    f.key, f.value
+                ));
+            }
+            out.push_str(&format!("{indent}  const __body = JSON.stringify(__body_obj);\n"));
+            out.push_str(&format!("{indent}  if (!__headers[\"Content-Type\"]) __headers[\"Content-Type\"] = \"application/json\";\n"));
+        }
+        HttpBody::Form { fields } => {
+            out.push_str(&format!("{indent}  const __form = new URLSearchParams();\n"));
+            for f in fields.iter().filter(|f| f.enabled && !f.key.is_empty()) {
+                out.push_str(&format!(
+                    "{indent}  __form.append({:?}, __sub({:?}, __scope));\n",
+                    f.key, f.value
+                ));
+            }
+            out.push_str(&format!("{indent}  const __body = __form.toString();\n"));
+            out.push_str(&format!("{indent}  if (!__headers[\"Content-Type\"]) __headers[\"Content-Type\"] = \"application/x-www-form-urlencoded\";\n"));
+        }
+        HttpBody::Raw { content_type, text } => {
+            out.push_str(&format!("{indent}  const __body = __sub({:?}, __scope);\n", text));
+            out.push_str(&format!(
+                "{indent}  if (!__headers[\"Content-Type\"]) __headers[\"Content-Type\"] = {:?};\n",
+                content_type
+            ));
+        }
+    }
+
+    let final_url = if has_qs {
+        "__url + (__url.includes(\"?\") ? \"&\" : \"?\") + __qs.toString()".to_string()
+    } else {
+        "__url".to_string()
+    };
+    let body_expr = match (&c.body, body_bearing) {
+        (HttpBody::None, _) | (_, false) => "undefined".to_string(),
+        _ => "__body".to_string(),
+    };
+
+    out.push_str(&format!(
+        "{indent}  const __res = await fetch({}, {{ method: {:?}, headers: __headers, body: {} }});\n",
+        final_url, method, body_expr
+    ));
+    out.push_str(&format!("{indent}  const __text = await __res.text();\n"));
+    out.push_str(&format!(
+        "{indent}  let __data; try {{ __data = JSON.parse(__text); }} catch {{ __data = __text; }}\n"
+    ));
+    if !assign_to.is_empty() {
+        out.push_str(&format!("{indent}  __scope[{:?}] = __data;\n", assign_to));
+    }
+    out.push_str(&format!("{indent}}}\n"));
+    out
+}
+
+fn compile_step(step: &FlowStep, indent: &str) -> String {
+    let inner = format!("{indent}  ");
+    match step {
+        FlowStep::Call { assign_to, request, .. } => compile_call(request, assign_to, indent),
+        FlowStep::If { condition, then, else_, .. } => {
+            let mut out = format!("{indent}if ({}) {{\n", compile_condition(condition));
+            for s in then { out.push_str(&compile_step(s, &inner)); }
+            out.push_str(&format!("{indent}}}"));
+            if !else_.is_empty() {
+                out.push_str(" else {\n");
+                for s in else_ { out.push_str(&compile_step(s, &inner)); }
+                out.push_str(&format!("{indent}}}"));
+            }
+            out.push('\n');
+            out
+        }
+        FlowStep::Switch { cases, default, .. } => {
+            // Chained if/else if/else in declared order.
+            let mut out = String::new();
+            let mut first = true;
+            for c in cases {
+                let head = if first { "if" } else { "else if" };
+                out.push_str(&format!("{indent}{head} ({}) {{\n", compile_condition(&c.condition)));
+                for s in &c.steps { out.push_str(&compile_step(s, &inner)); }
+                out.push_str(&format!("{indent}}}"));
+                first = false;
+            }
+            if !default.is_empty() {
+                if !first { out.push_str(" else {\n"); }
+                else { out.push_str(&format!("{indent}{{\n")); }
+                for s in default { out.push_str(&compile_step(s, &inner)); }
+                out.push_str(&format!("{indent}}}"));
+            }
+            out.push('\n');
+            out
+        }
+        FlowStep::Set { vars, .. } => {
+            let mut out = String::new();
+            for v in vars {
+                out.push_str(&format!(
+                    "{indent}__scope[{:?}] = __sub({:?}, __scope);\n",
+                    v.name, v.value
+                ));
+            }
+            out
+        }
+        FlowStep::Return { value, .. } => {
+            format!("{indent}return __sub({:?}, __scope);\n", value)
+        }
+        FlowStep::Loop { shape, list_chip, item_var, condition, body, .. } => {
+            let mut out = String::new();
+            if shape == "for-each" {
+                // Chip may resolve to a JSON string; try JSON.parse then fall back
+                // to a comma-split for the naive case.
+                out.push_str(&format!(
+                    "{indent}{{\n{indent}  const __raw = __sub({:?}, __scope);\n",
+                    list_chip
+                ));
+                out.push_str(&format!("{indent}  let __arr;\n"));
+                out.push_str(&format!(
+                    "{indent}  try {{ __arr = typeof __raw === \"string\" ? JSON.parse(__raw) : __raw; }} catch {{ __arr = String(__raw).split(\",\"); }}\n"
+                ));
+                out.push_str(&format!(
+                    "{indent}  for (const __item of (Array.isArray(__arr) ? __arr : [])) {{\n"
+                ));
+                out.push_str(&format!("{indent}    __scope[{:?}] = __item;\n", item_var));
+                for s in body { out.push_str(&compile_step(s, &format!("{indent}    "))); }
+                out.push_str(&format!("{indent}  }}\n{indent}}}\n"));
+            } else {
+                // while
+                out.push_str(&format!("{indent}while ({}) {{\n", compile_condition(condition)));
+                for s in body { out.push_str(&compile_step(s, &inner)); }
+                out.push_str(&format!("{indent}}}\n"));
+            }
+            out
+        }
+        FlowStep::Parallel { mode, branches, .. } => {
+            // Each branch becomes an async IIFE against a scope clone; results are
+            // collected and (for `all`) merged back into scope keys `branchN`.
+            let joiner = if mode == "race" { "Promise.race" } else { "Promise.all" };
+            let mut out = format!("{indent}{{\n{indent}  const __branches = [\n");
+            for b in branches {
+                out.push_str(&format!("{indent}    (async () => {{\n"));
+                out.push_str(&format!("{indent}      const __scope_branch = {{ ...__scope }};\n"));
+                // Redirect nested steps to write to the branch scope by swapping identifiers.
+                // Simpler: re-emit as literal `__scope` and rely on outer var — but we want
+                // isolation, so shadow the name with a `const __scope = __scope_branch`.
+                out.push_str(&format!("{indent}      const __scope = __scope_branch;\n"));
+                for s in b { out.push_str(&compile_step(s, &format!("{indent}      "))); }
+                out.push_str(&format!("{indent}      return __scope;\n"));
+                out.push_str(&format!("{indent}    }})(),\n"));
+            }
+            out.push_str(&format!("{indent}  ];\n"));
+            out.push_str(&format!("{indent}  const __out = await {joiner}(__branches);\n"));
+            // Merge each branch's scope into the parent as `branchN`.
+            if mode != "race" {
+                out.push_str(&format!("{indent}  __out.forEach((s, i) => {{ __scope[\"branch\" + i] = s; }});\n"));
+            } else {
+                out.push_str(&format!("{indent}  __scope[\"raceWinner\"] = __out;\n"));
+            }
+            out.push_str(&format!("{indent}}}\n"));
+            out
+        }
+    }
+}
+
+fn write_flow(dir: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
+    let name = slugify(field_str_or(data, "name", "flow"));
+    let description = field_str_or(data, "description", "A visual flow.");
+    let input: ToolInputSchema = data.get("input")
+        .cloned()
+        .map(|v| serde_json::from_value(v).unwrap_or_default())
+        .unwrap_or_default();
+    let steps: Vec<FlowStep> = data.get("steps")
+        .cloned()
+        .map(|v| serde_json::from_value(v).unwrap_or_default())
+        .unwrap_or_default();
+
+    let schema = zod_schema(&input);
+
+    let mut body = String::new();
+    for s in &steps { body.push_str(&compile_step(s, "    ")); }
+
+    let ts = format!(
+        r#"import {{ defineTool }} from "eve/tools";
+import {{ z }} from "zod";
+
+// Auto-generated from the visual flow builder. Do not edit by hand — your
+// changes will be overwritten on the next build.
+
+export default defineTool({{
+  description: {desc:?},
+  inputSchema: {schema},
+  async execute(input) {{
+    {chip_helper}
+    const __scope = {{ ...input }};
 {body}
   }},
 }});
 "#,
-            desc = description,
-            schema = input_schema,
-            body = indent(execute, 4),
-        )
-    };
-    std::fs::write(dir.join(format!("{name}.ts")), body).map_err(|e| e.to_string())
+        desc = description,
+        schema = schema,
+        chip_helper = CHIP_HELPER,
+        body = body,
+    );
+    std::fs::write(dir.join(format!("{name}.ts")), ts).map_err(|e| e.to_string())
 }
 
 fn write_skill(dir: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
@@ -298,10 +934,187 @@ fn write_schedule(dir: &std::path::Path, data: &serde_json::Value, index: usize)
     std::fs::write(dir.join(format!("{name}.md")), md).map_err(|e| e.to_string())
 }
 
-fn indent(s: &str, spaces: usize) -> String {
-    let pad = " ".repeat(spaces);
-    s.lines().map(|l| format!("{pad}{l}")).collect::<Vec<_>>().join("\n")
+// ── P8: trigger-channel writer ──────────────────────────────────────────────
+// Every trigger-channel node shares one payload shape (`fields`, `secrets`,
+// `prompt`). We branch on the node kind to pick the right eve channel file
+// name and its option layout. Secret refs (`{{secrets.<slug>}}`) get rewritten
+// to `process.env.<slug>` and their raw values are dumped into a project-local
+// `.env` — the graph JSON never carries plaintext secrets in the compiled TS.
+//
+// P5 (webhook/slack/github) is deferred; when we come back, the same helper
+// covers them — each just needs its own branch below.
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct ChannelSecret { pub slug: String, pub value: String }
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct TriggerChannelData {
+    pub fields: Vec<KV>,
+    pub secrets: Vec<ChannelSecret>,
+    #[allow(dead_code)]
+    pub prompt: String,
 }
+
+// Chip form for env references: `{{secrets.<slug>}}` → `process.env.<slug>`.
+// Anything else passes through as a plain string literal.
+fn ts_config_value(v: &str) -> String {
+    let trimmed = v.trim();
+    if let Some(inner) = trimmed.strip_prefix("{{").and_then(|s| s.strip_suffix("}}")) {
+        let inner = inner.trim();
+        if let Some(slug) = inner.strip_prefix("secrets.") {
+            let slug = slug.trim();
+            // Uppercase env vars are the JS convention; keep the slug case-preserved
+            // so users can match it exactly in the .env — no surprises.
+            return format!("process.env[{:?}] ?? \"\"", slug);
+        }
+    }
+    format!("{:?}", v)
+}
+
+fn lookup_field<'a>(fields: &'a [KV], key: &str) -> Option<&'a str> {
+    fields.iter().find(|f| f.key == key).map(|f| f.value.as_str())
+}
+
+fn write_trigger_channel(
+    channels_dir: &std::path::Path,
+    kind: &str,
+    data: &serde_json::Value,
+    index: usize,
+) -> Result<Vec<(String, String)>, String> {
+    let td: TriggerChannelData = serde_json::from_value(data.clone()).unwrap_or_default();
+    // Collect (slug, value) pairs so the caller can write one merged .env.
+    let env_pairs: Vec<(String, String)> = td.secrets.iter()
+        .filter(|s| !s.slug.is_empty())
+        .map(|s| (s.slug.clone(), s.value.clone()))
+        .collect();
+
+    let filename = format!("{}-{index}.ts", kind.trim_start_matches("trigger-"));
+    let path = channels_dir.join(&filename);
+
+    let ts = match kind {
+        "trigger-linear" => {
+            let api_key = lookup_field(&td.fields, "apiKey").unwrap_or("{{secrets.LINEAR_API_KEY}}");
+            let webhook_secret = lookup_field(&td.fields, "webhookSecret").unwrap_or("");
+            let mut extra = String::new();
+            if !webhook_secret.is_empty() {
+                extra.push_str(&format!("  webhookSecret: {},\n", ts_config_value(webhook_secret)));
+            }
+            format!(
+                r#"import {{ linearChannel }} from "eve/channels/linear";
+
+export default linearChannel({{
+  apiKey: {api},
+{extra}}});
+"#,
+                api = ts_config_value(api_key),
+                extra = extra,
+            )
+        }
+        "trigger-discord" => {
+            let token = lookup_field(&td.fields, "botToken").unwrap_or("{{secrets.DISCORD_BOT_TOKEN}}");
+            let public_key = lookup_field(&td.fields, "publicKey").unwrap_or("");
+            let mut extra = String::new();
+            if !public_key.is_empty() {
+                extra.push_str(&format!("  publicKey: {},\n", ts_config_value(public_key)));
+            }
+            format!(
+                r#"import {{ discordChannel }} from "eve/channels/discord";
+
+export default discordChannel({{
+  botToken: {token},
+{extra}}});
+"#,
+                token = ts_config_value(token),
+                extra = extra,
+            )
+        }
+        "trigger-telegram" => {
+            let token = lookup_field(&td.fields, "botToken").unwrap_or("{{secrets.TELEGRAM_BOT_TOKEN}}");
+            format!(
+                r#"import {{ telegramChannel }} from "eve/channels/telegram";
+
+export default telegramChannel({{
+  botToken: {token},
+}});
+"#,
+                token = ts_config_value(token),
+            )
+        }
+        "trigger-teams" => {
+            let app_id = lookup_field(&td.fields, "appId").unwrap_or("");
+            let app_password = lookup_field(&td.fields, "appPassword").unwrap_or("{{secrets.TEAMS_APP_PASSWORD}}");
+            format!(
+                r#"import {{ teamsChannel }} from "eve/channels/teams";
+
+export default teamsChannel({{
+  appId: {app_id},
+  appPassword: {pwd},
+}});
+"#,
+                app_id = ts_config_value(app_id),
+                pwd = ts_config_value(app_password),
+            )
+        }
+        "trigger-photon" => {
+            let api_key = lookup_field(&td.fields, "apiKey").unwrap_or("{{secrets.PHOTON_API_KEY}}");
+            format!(
+                r#"import {{ photonChannel }} from "eve/channels/photon";
+
+export default photonChannel({{
+  apiKey: {key},
+}});
+"#,
+                key = ts_config_value(api_key),
+            )
+        }
+        "trigger-poll" => {
+            // Tiny custom channel + a schedule that hits `/poll`. The schedule
+            // fires the internal route; the route calls `send(...)` with the
+            // fetched payload only when it changes.
+            let url = lookup_field(&td.fields, "url").unwrap_or("");
+            let interval_min = lookup_field(&td.fields, "intervalMinutes").unwrap_or("15");
+            let only_on_change = lookup_field(&td.fields, "onlyOnChange").unwrap_or("true");
+            format!(
+                r#"import {{ defineChannel, POST }} from "eve/channels";
+
+// Auto-generated HTTP-poll trigger. The paired `schedules/poll-{index}.md`
+// pings this route every {interval} minutes; the route fetches the endpoint
+// and forwards the (changed) body as a user message.
+
+let __lastBody: string | null = null;
+
+export default defineChannel({{
+  routes: [
+    POST("/tick", async (_req, {{ send }}) => {{
+      const res = await fetch({url_lit});
+      const body = await res.text();
+      if ({only_on_change} && body === __lastBody) return new Response("no-change");
+      __lastBody = body;
+      await send(body, {{ auth: null, continuationToken: "poll" }});
+      return new Response("ok");
+    }}),
+  ],
+}});
+"#,
+                url_lit = ts_config_value(url),
+                interval = interval_min,
+                only_on_change = if only_on_change == "false" { "false" } else { "true" },
+                index = index,
+            )
+        }
+        _ => {
+            // Unknown trigger kind — skip silently. Adding a new channel is a
+            // matter of adding one branch here.
+            return Ok(env_pairs);
+        }
+    };
+
+    std::fs::write(&path, ts).map_err(|e| e.to_string())?;
+    Ok(env_pairs)
+}
+
 
 /// Generate Eve project files from the graph JSON (visual builder source of truth).
 /// Called before `eve build`. Empty/malformed graph falls back to a minimal
@@ -341,17 +1154,24 @@ fn generate_eve_project(
 
     // Group sub-nodes into their Eve slot directories.
     let mut tools = Vec::new();
+    let mut flows = Vec::new();
     let mut skills = Vec::new();
     let mut connections = Vec::new();
     let mut subagents = Vec::new();
     let mut schedules = Vec::new();
+    // Trigger channels: (kind, data). Compiled into agent/channels/<slug>.ts.
+    let mut trigger_channels: Vec<(&str, &serde_json::Value)> = Vec::new();
     for n in &g.nodes {
         match n.kind.as_str() {
             "tool" => tools.push(&n.data),
+            "flow" => flows.push(&n.data),
             "skill" => skills.push(&n.data),
             "connection" => connections.push(&n.data),
             "subagent" => subagents.push(&n.data),
             "trigger-schedule" => schedules.push(&n.data),
+            k if k.starts_with("trigger-") && k != "trigger-manual" && k != "trigger-schedule" => {
+                trigger_channels.push((k, &n.data));
+            }
             _ => {}
         }
     }
@@ -362,8 +1182,10 @@ fn generate_eve_project(
         Ok(dir)
     }
 
-    let tools_dir = ensure(agent_dir.join("tools"), tools.is_empty())?;
+    let tools_dir = ensure(agent_dir.join("tools"), tools.is_empty() && flows.is_empty())?;
     for d in &tools { write_tool(&tools_dir, d)?; }
+    // Flow nodes compile into the same `tools/` directory as generated tool files.
+    for d in &flows { write_flow(&tools_dir, d)?; }
 
     let skills_dir = ensure(agent_dir.join("skills"), skills.is_empty())?;
     for d in &skills { write_skill(&skills_dir, d)?; }
@@ -390,6 +1212,44 @@ export default eveChannel({
 });
 "#;
     std::fs::write(channels_dir.join("eve.ts"), eve_channel).map_err(|e| e.to_string())?;
+
+    // P8: write one channel file per trigger-channel node and collect all
+    // per-node secret bags into a single project-local .env.
+    let mut all_env: Vec<(String, String)> = Vec::new();
+    for (i, (kind, data)) in trigger_channels.iter().enumerate() {
+        let pairs = write_trigger_channel(&channels_dir, kind, data, i)?;
+        all_env.extend(pairs);
+        // For `trigger-poll`, pair the channel with a schedule that pokes it.
+        if *kind == "trigger-poll" {
+            let interval_min = data.get("fields")
+                .and_then(|v| v.as_array())
+                .and_then(|arr| arr.iter().find(|kv| kv.get("key").and_then(|k| k.as_str()) == Some("intervalMinutes")))
+                .and_then(|kv| kv.get("value").and_then(|v| v.as_str()))
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(15)
+                .max(1);
+            let cron = format!("*/{} * * * *", interval_min);
+            let sched_dir = agent_dir.join("schedules");
+            std::fs::create_dir_all(&sched_dir).map_err(|e| e.to_string())?;
+            let md = format!(
+                "---\ncron: \"{cron}\"\n---\n\nFire the paired HTTP-poll channel by POSTing to `/tick` on channel `poll-{i}`.\n"
+            );
+            std::fs::write(sched_dir.join(format!("poll-{i}.md")), md).map_err(|e| e.to_string())?;
+        }
+    }
+
+    // Merge collected secrets into `.env` at the project root — dedupe by slug
+    // (later wins). Written every build; users edit values in the modal.
+    if !all_env.is_empty() {
+        let mut deduped: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        for (k, v) in all_env { deduped.insert(k, v); }
+        let env_body: String = deduped.iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(path.join(".env"), format!("{env_body}\n"))
+            .map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }
@@ -772,4 +1632,237 @@ pub fn get_automation_process(
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(e.to_string()),
     }
+}
+
+// ── Try-it (P3) ─────────────────────────────────────────────────────────────
+// Fires the tool's HTTP request with a sample input map so the builder's
+// response tree can render. Runs synchronously via ureq — no CORS worry
+// because the call goes out from the Tauri process, not the webview.
+
+#[derive(Serialize)]
+pub struct TryHttpResult {
+    pub status: u16,
+    pub headers: std::collections::HashMap<String, String>,
+    pub body: String,
+    pub ms: u128,
+}
+
+#[derive(Deserialize)]
+pub struct TryHttpArgs {
+    pub request: HttpRequest,
+    #[serde(default)]
+    pub sample: serde_json::Value,
+}
+
+fn sub_chips(s: &str, sample: &serde_json::Value) -> String {
+    // Same grammar as the generated TS helper.
+    let re_start = "{{";
+    if !s.contains(re_start) { return s.to_string(); }
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'{' && bytes[i+1] == b'{' {
+            if let Some(end) = s[i+2..].find("}}") {
+                let inner = s[i+2..i+2+end].trim();
+                if let Some(rest) = inner.strip_prefix("input.") {
+                    let key = rest.trim();
+                    let v = sample.get(key).cloned().unwrap_or(serde_json::Value::Null);
+                    let text = match v {
+                        serde_json::Value::String(s) => s,
+                        serde_json::Value::Null => String::new(),
+                        other => other.to_string(),
+                    };
+                    out.push_str(&text);
+                    i += 2 + end + 2;
+                    continue;
+                }
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+#[tauri::command(async)]
+pub fn try_http_request(args: TryHttpArgs) -> Result<TryHttpResult, String> {
+    use base64::Engine;
+
+    let start = std::time::Instant::now();
+    let req = args.request;
+    let sample = args.sample;
+
+    // URL + query
+    let mut url = sub_chips(&req.url, &sample);
+    if url.is_empty() {
+        return Err("URL is empty".to_string());
+    }
+
+    let mut query: Vec<(String, String)> = req.query_params.iter()
+        .filter(|r| r.enabled && !r.key.is_empty())
+        .map(|r| (r.key.clone(), sub_chips(&r.value, &sample)))
+        .collect();
+
+    // Auth
+    let mut headers: Vec<(String, String)> = req.headers.iter()
+        .filter(|r| r.enabled && !r.key.is_empty())
+        .map(|r| (r.key.clone(), sub_chips(&r.value, &sample)))
+        .collect();
+    match &req.auth {
+        HttpAuth::None => {}
+        HttpAuth::Bearer { token } => {
+            headers.push(("Authorization".into(), format!("Bearer {}", sub_chips(token, &sample))));
+        }
+        HttpAuth::Basic { user, pass } => {
+            let raw = format!("{}:{}", sub_chips(user, &sample), sub_chips(pass, &sample));
+            let enc = base64::engine::general_purpose::STANDARD.encode(raw.as_bytes());
+            headers.push(("Authorization".into(), format!("Basic {}", enc)));
+        }
+        HttpAuth::ApiKey { in_, name, value } => {
+            let v = sub_chips(value, &sample);
+            if in_ == "query" {
+                query.push((name.clone(), v));
+            } else {
+                headers.push((name.clone(), v));
+            }
+        }
+    }
+
+    // Body
+    let (body_bytes, ct_default): (Option<Vec<u8>>, Option<&str>) = match &req.body {
+        HttpBody::None => (None, None),
+        HttpBody::Json { fields } => {
+            let mut obj = serde_json::Map::new();
+            for r in fields.iter().filter(|r| r.enabled && !r.key.is_empty()) {
+                obj.insert(r.key.clone(), serde_json::Value::String(sub_chips(&r.value, &sample)));
+            }
+            let s = serde_json::Value::Object(obj).to_string();
+            (Some(s.into_bytes()), Some("application/json"))
+        }
+        HttpBody::Form { fields } => {
+            let mut parts = Vec::new();
+            for r in fields.iter().filter(|r| r.enabled && !r.key.is_empty()) {
+                parts.push(format!("{}={}",
+                    urlencoding_encode(&r.key),
+                    urlencoding_encode(&sub_chips(&r.value, &sample))));
+            }
+            (Some(parts.join("&").into_bytes()), Some("application/x-www-form-urlencoded"))
+        }
+        HttpBody::Raw { content_type, text } => {
+            let body = sub_chips(text, &sample);
+            (Some(body.into_bytes()), Some(if content_type.is_empty() { "text/plain" } else { content_type.as_str() }))
+        }
+    };
+
+    // Append query string to URL manually so ureq's method-generic call is simple.
+    if !query.is_empty() {
+        let qs: String = query.iter()
+            .map(|(k, v)| format!("{}={}", urlencoding_encode(k), urlencoding_encode(v)))
+            .collect::<Vec<_>>().join("&");
+        if url.contains('?') { url.push('&'); } else { url.push('?'); }
+        url.push_str(&qs);
+    }
+
+    // Default content-type only if user didn't set one.
+    let has_ct = headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("content-type"));
+    if !has_ct {
+        if let Some(ct) = ct_default {
+            headers.push(("Content-Type".into(), ct.to_string()));
+        }
+    }
+
+    let method = if req.method.is_empty() { "GET" } else { req.method.as_str() };
+    let mut r = ureq::request(method, &url);
+    for (k, v) in &headers { r = r.set(k, v); }
+
+    let resp = if let Some(bytes) = body_bytes {
+        r.send_bytes(&bytes)
+    } else {
+        r.call()
+    };
+
+    // ureq treats 4xx/5xx as errors — unwrap the response either way.
+    let response = match resp {
+        Ok(r) => r,
+        Err(ureq::Error::Status(_, r)) => r,
+        Err(e) => return Err(format!("Request failed: {e}")),
+    };
+
+    let status = response.status();
+    let mut out_headers = std::collections::HashMap::new();
+    for name in response.headers_names() {
+        if let Some(v) = response.header(&name) {
+            out_headers.insert(name, v.to_string());
+        }
+    }
+    let body = response.into_string()
+        .unwrap_or_else(|e| format!("<failed to read body: {e}>"));
+
+    Ok(TryHttpResult {
+        status,
+        headers: out_headers,
+        body,
+        ms: start.elapsed().as_millis(),
+    })
+}
+
+#[cfg(test)]
+mod flow_compiler_tests {
+    // ponytail: one self-check that fails loudly if the step compiler
+    // stops emitting the shapes downstream TS relies on.
+    use super::*;
+    use serde_json::json;
+
+    fn compile(graph: serde_json::Value) -> String {
+        // Skip pulling in tempfile — one throwaway UUID dir under the OS temp
+        // root is enough for the self-check.
+        let dir = std::env::temp_dir()
+            .join(format!("tempest-flow-test-{}", uuid::Uuid::new_v4()));
+        let d = dir.join("agent").join("tools");
+        std::fs::create_dir_all(&d).unwrap();
+        write_flow(&d, &graph).unwrap();
+        let out = std::fs::read_to_string(d.join("t.ts")).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+        out
+    }
+
+    #[test]
+    fn compiles_if_call_return() {
+        let ts = compile(json!({
+            "name": "t",
+            "description": "test",
+            "input": { "fields": [{ "name": "city", "type": "string", "required": true }] },
+            "steps": [
+                { "id": "s1", "kind": "call", "assignTo": "weather",
+                  "request": { "method": "GET", "url": "https://x.example/{{input.city}}",
+                               "queryParams": [], "headers": [],
+                               "auth": { "kind": "none" }, "body": { "kind": "none" } } },
+                { "id": "s2", "kind": "if",
+                  "condition": { "left": "{{input.weather}}", "op": "contains", "right": "rain" },
+                  "then": [{ "id": "s3", "kind": "return", "value": "bring umbrella" }],
+                  "else": [{ "id": "s4", "kind": "return", "value": "no umbrella" }] },
+            ],
+        }));
+        assert!(ts.contains("defineTool"), "missing defineTool wrapper");
+        assert!(ts.contains("__scope[\"weather\"]"), "assignTo not emitted: {ts}");
+        assert!(ts.contains("if ("), "if step not emitted: {ts}");
+        assert!(ts.contains("return __sub("), "return not routed through __sub: {ts}");
+    }
+}
+
+// Minimal application/x-www-form-urlencoded encoder — avoids pulling in another
+// dep. Encodes anything outside unreserved chars.
+fn urlencoding_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(*b, b'-' | b'_' | b'.' | b'~') {
+            out.push(*b as char);
+        } else if *b == b' ' {
+            out.push('+');
+        } else {
+            out.push_str(&format!("%{:02X}", b));
+        }
+    }
+    out
 }

--- a/src-tauri/src/automations.rs
+++ b/src-tauri/src/automations.rs
@@ -70,60 +70,76 @@ fn find_free_port() -> Result<u16, String> {
     Ok(port)
 }
 
-/// Generate Eve project files from the graph JSON (visual builder source of truth).
-/// Writes agent.ts, instructions.md, tools/*.ts, channels/*.ts, schedules/*.ts, sandbox.ts.
-/// Called before `eve build`.
-fn generate_eve_project(
-    path: &std::path::Path,
-    _graph: &str,
-    sandbox_mode: &str,
-) -> Result<(), String> {
-    // Create agent/ directory
-    let agent_dir = path.join("agent");
-    std::fs::create_dir_all(&agent_dir).map_err(|e| e.to_string())?;
+/// Graph JSON schema — mirrors src/components/Automations/builder/graph.ts.
+/// The visual builder is the source of truth; we deserialize and materialize
+/// Eve project files. Untagged enum matches serde's `#[serde(tag = "kind")]`
+/// pattern on the TS side (a `kind` discriminator + `data` payload).
+mod graph {
+    use serde::Deserialize;
 
-    // Minimal agent.ts: use default model
-    let agent_ts = r#"import { defineAgent } from "eve";
+    #[derive(Deserialize, Default)]
+    #[serde(default)]
+    pub struct Graph {
+        pub nodes: Vec<Node>,
+        #[allow(dead_code)]
+        pub edges: Vec<Edge>,
+    }
 
-export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
-});
-"#;
-    std::fs::write(agent_dir.join("agent.ts"), agent_ts)
-        .map_err(|e| e.to_string())?;
+    #[derive(Deserialize)]
+    pub struct Node {
+        pub kind: String,
+        pub data: serde_json::Value,
+    }
 
-    // Minimal instructions.md
-    let instructions_md = "# Agent\n\nAn automated Eve agent.\n";
-    std::fs::write(agent_dir.join("instructions.md"), instructions_md)
-        .map_err(|e| e.to_string())?;
+    #[derive(Deserialize)]
+    #[allow(dead_code)]
+    pub struct Edge {
+        pub source: String,
+        pub target: String,
+        pub kind: String,
+    }
+}
 
-    // Sandbox config based on platform
-    let sandbox_ts = match sandbox_mode {
-        "docker" => {
-            r#"import { defineSandbox } from "eve/sandbox";
+fn slugify(s: &str) -> String {
+    let out: String = s
+        .trim()
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let collapsed: String = out.split('-').filter(|p| !p.is_empty()).collect::<Vec<_>>().join("-");
+    if collapsed.is_empty() { "item".into() } else { collapsed }
+}
+
+fn field_str<'a>(v: &'a serde_json::Value, key: &str) -> &'a str {
+    v.get(key).and_then(|x| x.as_str()).unwrap_or("")
+}
+
+fn field_str_or<'a>(v: &'a serde_json::Value, key: &str, default: &'a str) -> &'a str {
+    let s = field_str(v, key);
+    if s.is_empty() { default } else { s }
+}
+
+fn sandbox_ts_for(mode: &str) -> &'static str {
+    match mode {
+        "docker" => r#"import { defineSandbox } from "eve/sandbox";
 import { docker } from "eve/sandbox/docker";
-import { justbash } from "eve/sandbox/justbash";
 
 export default defineSandbox({
   backend: docker(),
 });
-"#
-        }
-        "none" => {
-            r#"import { defineSandbox } from "eve/sandbox";
+"#,
+        "none" => r#"import { defineSandbox } from "eve/sandbox";
 import { justbash } from "eve/sandbox/justbash";
 
 export default defineSandbox({
   backend: justbash(),
 });
-"#
-        }
+"#,
         _ => {
-            // "auto" — platform-specific
             if cfg!(windows) {
                 r#"import { defineSandbox } from "eve/sandbox";
 import { docker } from "eve/sandbox/docker";
-import { justbash } from "eve/sandbox/justbash";
 
 export default defineSandbox({
   backend: docker(),
@@ -132,7 +148,6 @@ export default defineSandbox({
             } else {
                 r#"import { defineSandbox } from "eve/sandbox";
 import { microsandbox } from "eve/sandbox/microsandbox";
-import { docker } from "eve/sandbox/docker";
 
 export default defineSandbox({
   backend: microsandbox(),
@@ -140,9 +155,241 @@ export default defineSandbox({
 "#
             }
         }
+    }
+}
+
+fn write_agent_ts(dir: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
+    let model = field_str_or(data, "model", "anthropic/claude-sonnet-5");
+    let reasoning = field_str(data, "reasoning");
+    let max_in = data.get("maxInputTokens").and_then(|v| v.as_u64());
+    let max_out = data.get("maxOutputTokens").and_then(|v| v.as_u64());
+
+    let mut fields: Vec<String> = vec![format!("  model: {:?}", model)];
+    if !reasoning.is_empty() {
+        fields.push(format!("  reasoning: {:?}", reasoning));
+    }
+    if max_in.is_some() || max_out.is_some() {
+        let mut limits = Vec::new();
+        if let Some(v) = max_in { limits.push(format!("    maxInputTokensPerSession: {}", v)); }
+        if let Some(v) = max_out { limits.push(format!("    maxOutputTokensPerSession: {}", v)); }
+        fields.push(format!("  limits: {{\n{},\n  }}", limits.join(",\n")));
+    }
+
+    let ts = format!(
+        "import {{ defineAgent }} from \"eve\";\n\nexport default defineAgent({{\n{},\n}});\n",
+        fields.join(",\n")
+    );
+    std::fs::write(dir.join("agent.ts"), ts).map_err(|e| e.to_string())
+}
+
+fn write_tool(dir: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
+    let name = slugify(field_str_or(data, "name", "tool"));
+    let description = field_str_or(data, "description", "A tool.");
+    let preset = field_str_or(data, "preset", "custom");
+
+    let body = if preset == "http" {
+        let method = field_str_or(data, "httpMethod", "GET");
+        let url = field_str_or(data, "httpUrl", "");
+        format!(
+            r#"import {{ defineTool }} from "eve/tools";
+import {{ z }} from "zod";
+
+export default defineTool({{
+  description: {desc:?},
+  inputSchema: z.object({{
+    body: z.string().optional(),
+  }}),
+  async execute(input) {{
+    const res = await fetch({url:?}, {{
+      method: {method:?},
+      body: {method_is_body_bearing} ? input.body : undefined,
+    }});
+    const text = await res.text();
+    return {{ status: res.status, body: text }};
+  }},
+}});
+"#,
+            desc = description,
+            url = url,
+            method = method,
+            method_is_body_bearing = matches!(method, "POST" | "PUT" | "PATCH")
+        )
+    } else {
+        let input_schema = field_str_or(data, "customInputSchema", "z.object({})");
+        let execute = field_str_or(data, "customExecute", "return {};");
+        format!(
+            r#"import {{ defineTool }} from "eve/tools";
+import {{ z }} from "zod";
+
+export default defineTool({{
+  description: {desc:?},
+  inputSchema: {schema},
+  async execute(input, ctx) {{
+{body}
+  }},
+}});
+"#,
+            desc = description,
+            schema = input_schema,
+            body = indent(execute, 4),
+        )
     };
-    std::fs::write(agent_dir.join("sandbox.ts"), sandbox_ts)
+    std::fs::write(dir.join(format!("{name}.ts")), body).map_err(|e| e.to_string())
+}
+
+fn write_skill(dir: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
+    let name = slugify(field_str_or(data, "name", "skill"));
+    let md = field_str_or(data, "markdown", "# Skill\n");
+    std::fs::write(dir.join(format!("{name}.md")), md).map_err(|e| e.to_string())
+}
+
+fn write_connection(dir: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
+    let name = slugify(field_str_or(data, "name", "connection"));
+    let kind = field_str_or(data, "kind", "mcp");
+    let url = field_str_or(data, "url", "");
+    let ts = if kind == "openapi" {
+        format!(
+            r#"import {{ defineConnection }} from "eve/connections";
+
+export default defineConnection({{
+  type: "openapi",
+  url: {url:?},
+}});
+"#,
+            url = url
+        )
+    } else {
+        format!(
+            r#"import {{ defineConnection }} from "eve/connections";
+
+export default defineConnection({{
+  type: "mcp",
+  url: {url:?},
+}});
+"#,
+            url = url
+        )
+    };
+    std::fs::write(dir.join(format!("{name}.ts")), ts).map_err(|e| e.to_string())
+}
+
+fn write_subagent(root: &std::path::Path, data: &serde_json::Value) -> Result<(), String> {
+    let name = slugify(field_str_or(data, "name", "subagent"));
+    let dir = root.join(&name);
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+
+    let model = field_str_or(data, "model", "anthropic/claude-sonnet-5");
+    let description = field_str_or(data, "description", "A specialist child agent.");
+    let agent_ts = format!(
+        "import {{ defineAgent }} from \"eve\";\n\nexport default defineAgent({{\n  model: {model:?},\n  description: {desc:?},\n}});\n",
+        model = model, desc = description
+    );
+    std::fs::write(dir.join("agent.ts"), agent_ts).map_err(|e| e.to_string())?;
+
+    let instructions = field_str_or(data, "instructions", "# Subagent\n");
+    std::fs::write(dir.join("instructions.md"), instructions).map_err(|e| e.to_string())
+}
+
+fn write_schedule(dir: &std::path::Path, data: &serde_json::Value, index: usize) -> Result<(), String> {
+    let cron = field_str_or(data, "cron", "0 * * * *");
+    let prompt = field_str_or(data, "prompt", "Run the scheduled task.");
+    let name = format!("schedule-{index}");
+    let md = format!("---\ncron: \"{cron}\"\n---\n\n{prompt}\n");
+    std::fs::write(dir.join(format!("{name}.md")), md).map_err(|e| e.to_string())
+}
+
+fn indent(s: &str, spaces: usize) -> String {
+    let pad = " ".repeat(spaces);
+    s.lines().map(|l| format!("{pad}{l}")).collect::<Vec<_>>().join("\n")
+}
+
+/// Generate Eve project files from the graph JSON (visual builder source of truth).
+/// Called before `eve build`. Empty/malformed graph falls back to a minimal
+/// runnable agent so Build never breaks on a fresh automation.
+fn generate_eve_project(
+    path: &std::path::Path,
+    graph_json: &str,
+    sandbox_mode: &str,
+) -> Result<(), String> {
+    let g: graph::Graph = serde_json::from_str(graph_json).unwrap_or_default();
+
+    let agent_dir = path.join("agent");
+    std::fs::create_dir_all(&agent_dir).map_err(|e| e.to_string())?;
+
+    // Agent + instructions come from the (single) agent node, or defaults.
+    let agent_node = g.nodes.iter().find(|n| n.kind == "agent");
+    let agent_data = agent_node.map(|n| &n.data);
+
+    if let Some(data) = agent_data {
+        write_agent_ts(&agent_dir, data)?;
+        let instructions = field_str_or(data, "instructions", "# Agent\n\nAn automated Eve agent.\n");
+        std::fs::write(agent_dir.join("instructions.md"), instructions)
+            .map_err(|e| e.to_string())?;
+    } else {
+        write_agent_ts(&agent_dir, &serde_json::json!({}))?;
+        std::fs::write(agent_dir.join("instructions.md"), "# Agent\n\nAn automated Eve agent.\n")
+            .map_err(|e| e.to_string())?;
+    }
+
+    // Sandbox: agent's stored preference wins over the DB column.
+    let effective_sandbox = agent_data
+        .and_then(|d| d.get("sandbox"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(sandbox_mode);
+    std::fs::write(agent_dir.join("sandbox.ts"), sandbox_ts_for(effective_sandbox))
         .map_err(|e| e.to_string())?;
+
+    // Group sub-nodes into their Eve slot directories.
+    let mut tools = Vec::new();
+    let mut skills = Vec::new();
+    let mut connections = Vec::new();
+    let mut subagents = Vec::new();
+    let mut schedules = Vec::new();
+    for n in &g.nodes {
+        match n.kind.as_str() {
+            "tool" => tools.push(&n.data),
+            "skill" => skills.push(&n.data),
+            "connection" => connections.push(&n.data),
+            "subagent" => subagents.push(&n.data),
+            "trigger-schedule" => schedules.push(&n.data),
+            _ => {}
+        }
+    }
+
+    fn ensure(dir: std::path::PathBuf, empty: bool) -> Result<std::path::PathBuf, String> {
+        if empty { return Ok(dir); }
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        Ok(dir)
+    }
+
+    let tools_dir = ensure(agent_dir.join("tools"), tools.is_empty())?;
+    for d in &tools { write_tool(&tools_dir, d)?; }
+
+    let skills_dir = ensure(agent_dir.join("skills"), skills.is_empty())?;
+    for d in &skills { write_skill(&skills_dir, d)?; }
+
+    let conns_dir = ensure(agent_dir.join("connections"), connections.is_empty())?;
+    for d in &connections { write_connection(&conns_dir, d)?; }
+
+    let subs_dir = ensure(agent_dir.join("subagents"), subagents.is_empty())?;
+    for d in &subagents { write_subagent(&subs_dir, d)?; }
+
+    let sched_dir = ensure(agent_dir.join("schedules"), schedules.is_empty())?;
+    for (i, d) in schedules.iter().enumerate() { write_schedule(&sched_dir, d, i)?; }
+
+    // Always write the eve channel with CORS enabled so the Tempest webview can
+    // reach the running agent on http://localhost:{port} without preflight rejection.
+    let channels_dir = agent_dir.join("channels");
+    std::fs::create_dir_all(&channels_dir).map_err(|e| e.to_string())?;
+    let eve_channel = r#"import { eveChannel } from "eve/channels/eve";
+import { localDev } from "eve/channels/auth";
+
+export default eveChannel({
+  auth: [localDev()],
+  cors: true,
+});
+"#;
+    std::fs::write(channels_dir.join("eve.ts"), eve_channel).map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src-tauri/src/automations.rs
+++ b/src-tauri/src/automations.rs
@@ -1,0 +1,514 @@
+//! Eve sidecar — lifecycle helpers for the Automations engine.
+//! Phase 2: CRUD commands, project generation, build/start/stop lifecycle.
+
+use std::path::PathBuf;
+use serde::{Serialize, Deserialize};
+
+/// Returns the Eve CLI entry script path.
+/// Dev:     src-tauri/resources/eve/node_modules/.bin/eve
+/// Release: <exe>/resources/eve/node_modules/.bin/eve
+///
+/// npm (v7+) creates the no-extension `eve` shim on all platforms alongside
+/// `eve.cmd` / `eve.ps1`. Calling `node <path>` works because Node strips
+/// the shebang line before parsing.
+pub fn eve_bin(_app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let base = {
+        #[cfg(debug_assertions)]
+        {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("resources")
+                .join("eve")
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+            exe.parent()
+                .ok_or("no exe dir")?
+                .join("resources")
+                .join("eve")
+        }
+    };
+    Ok(base.join("node_modules").join(".bin").join("eve"))
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Automation {
+    pub id: String,
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
+    pub name: String,
+    pub slug: String,
+    pub path: String,
+    pub graph: String,
+    #[serde(rename = "sandboxMode")]
+    pub sandbox_mode: String,
+    pub enabled: bool,
+    #[serde(rename = "builtAt")]
+    pub built_at: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ProcessInfo {
+    pub port: u16,
+    pub pid: u32,
+}
+
+/// Find a free port by binding a TcpListener on 0.0.0.0:0, reading the
+/// assigned port, and dropping the listener.
+fn find_free_port() -> Result<u16, String> {
+    use std::net::TcpListener;
+    let listener = TcpListener::bind("0.0.0.0:0")
+        .map_err(|e| format!("Failed to bind port: {e}"))?;
+    let port = listener.local_addr()
+        .map_err(|e| format!("Failed to get port: {e}"))?
+        .port();
+    drop(listener);
+    Ok(port)
+}
+
+/// Generate Eve project files from the graph JSON (visual builder source of truth).
+/// Writes agent.ts, instructions.md, tools/*.ts, channels/*.ts, schedules/*.ts, sandbox.ts.
+/// Called before `eve build`.
+fn generate_eve_project(
+    path: &std::path::Path,
+    _graph: &str,
+    sandbox_mode: &str,
+) -> Result<(), String> {
+    // Create agent/ directory
+    let agent_dir = path.join("agent");
+    std::fs::create_dir_all(&agent_dir).map_err(|e| e.to_string())?;
+
+    // Minimal agent.ts: use default model
+    let agent_ts = r#"import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "anthropic/claude-sonnet-5",
+});
+"#;
+    std::fs::write(agent_dir.join("agent.ts"), agent_ts)
+        .map_err(|e| e.to_string())?;
+
+    // Minimal instructions.md
+    let instructions_md = "# Agent\n\nAn automated Eve agent.\n";
+    std::fs::write(agent_dir.join("instructions.md"), instructions_md)
+        .map_err(|e| e.to_string())?;
+
+    // Sandbox config based on platform
+    let sandbox_ts = match sandbox_mode {
+        "docker" => {
+            r#"import { defineSandbox } from "eve/sandbox";
+import { docker } from "eve/sandbox/docker";
+import { justbash } from "eve/sandbox/justbash";
+
+export default defineSandbox({
+  backend: docker(),
+});
+"#
+        }
+        "none" => {
+            r#"import { defineSandbox } from "eve/sandbox";
+import { justbash } from "eve/sandbox/justbash";
+
+export default defineSandbox({
+  backend: justbash(),
+});
+"#
+        }
+        _ => {
+            // "auto" — platform-specific
+            if cfg!(windows) {
+                r#"import { defineSandbox } from "eve/sandbox";
+import { docker } from "eve/sandbox/docker";
+import { justbash } from "eve/sandbox/justbash";
+
+export default defineSandbox({
+  backend: docker(),
+});
+"#
+            } else {
+                r#"import { defineSandbox } from "eve/sandbox";
+import { microsandbox } from "eve/sandbox/microsandbox";
+import { docker } from "eve/sandbox/docker";
+
+export default defineSandbox({
+  backend: microsandbox(),
+});
+"#
+            }
+        }
+    };
+    std::fs::write(agent_dir.join("sandbox.ts"), sandbox_ts)
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+#[tauri::command(async)]
+pub fn list_automations(
+    state: tauri::State<'_, super::DbState>,
+    workspace_id: String,
+) -> Result<Vec<Automation>, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    conn.prepare(
+        "SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at \
+         FROM automations WHERE workspace_id = ?1 ORDER BY created_at"
+    )
+        .and_then(|mut stmt| {
+            stmt.query_map(rusqlite::params![&workspace_id], |r| {
+                Ok(Automation {
+                    id: r.get(0)?,
+                    workspace_id: r.get(1)?,
+                    name: r.get(2)?,
+                    slug: r.get(3)?,
+                    path: r.get(4)?,
+                    graph: r.get(5)?,
+                    sandbox_mode: r.get(6)?,
+                    enabled: r.get(7)?,
+                    built_at: r.get(8)?,
+                    created_at: r.get(9)?,
+                    updated_at: r.get(10)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command(async)]
+pub fn get_automation(
+    state: tauri::State<'_, super::DbState>,
+    id: String,
+) -> Result<Automation, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    conn.query_row(
+        "SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at \
+         FROM automations WHERE id = ?1",
+        rusqlite::params![&id],
+        |r| {
+            Ok(Automation {
+                id: r.get(0)?,
+                workspace_id: r.get(1)?,
+                name: r.get(2)?,
+                slug: r.get(3)?,
+                path: r.get(4)?,
+                graph: r.get(5)?,
+                sandbox_mode: r.get(6)?,
+                enabled: r.get(7)?,
+                built_at: r.get(8)?,
+                created_at: r.get(9)?,
+                updated_at: r.get(10)?,
+            })
+        }
+    )
+        .map_err(|e| format!("Automation not found: {e}"))
+}
+
+#[tauri::command(async)]
+pub fn create_automation(
+    state: tauri::State<'_, super::DbState>,
+    workspace_id: String,
+    name: String,
+    graph: Option<String>,
+) -> Result<Automation, String> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let slug = name.to_lowercase().replace(' ', "-");
+    let graph = graph.unwrap_or_else(|| "{}".to_string());
+    let path = format!(".tempest/automations/{}", slug);
+
+    {
+        let conn = state.0.lock().map_err(|e| e.to_string())?;
+        conn.execute(
+            "INSERT INTO automations (id, workspace_id, name, slug, path, graph, sandbox_mode, enabled) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![&id, &workspace_id, &name, &slug, &path, &graph, "auto", 1],
+        )
+            .map_err(|e| e.to_string())?;
+    }
+
+    get_automation(state, id)
+}
+
+#[derive(serde::Deserialize)]
+pub struct UpdateAutomationRequest {
+    pub name: Option<String>,
+    pub graph: Option<String>,
+    #[serde(rename = "sandboxMode")]
+    pub sandbox_mode: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+#[tauri::command(async)]
+pub fn update_automation(
+    state: tauri::State<'_, super::DbState>,
+    id: String,
+    req: UpdateAutomationRequest,
+) -> Result<Automation, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+
+    if let Some(name) = &req.name {
+        conn.execute(
+            "UPDATE automations SET name = ?1, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?2",
+            rusqlite::params![name, &id],
+        )
+            .map_err(|e| e.to_string())?;
+    }
+    if let Some(graph) = &req.graph {
+        conn.execute(
+            "UPDATE automations SET graph = ?1, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?2",
+            rusqlite::params![graph, &id],
+        )
+            .map_err(|e| e.to_string())?;
+    }
+    if let Some(sandbox_mode) = &req.sandbox_mode {
+        conn.execute(
+            "UPDATE automations SET sandbox_mode = ?1, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?2",
+            rusqlite::params![sandbox_mode, &id],
+        )
+            .map_err(|e| e.to_string())?;
+    }
+    if let Some(enabled) = req.enabled {
+        conn.execute(
+            "UPDATE automations SET enabled = ?1, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?2",
+            rusqlite::params![if enabled { 1 } else { 0 }, &id],
+        )
+            .map_err(|e| e.to_string())?;
+    }
+
+    drop(conn);
+    get_automation(state, id)
+}
+
+#[tauri::command(async)]
+pub fn delete_automation(
+    state: tauri::State<'_, super::DbState>,
+    id: String,
+) -> Result<(), String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "DELETE FROM automations WHERE id = ?1",
+        rusqlite::params![&id],
+    )
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[derive(Serialize)]
+pub struct BuildResult {
+    pub success: bool,
+    pub output: String,
+    #[serde(rename = "durationMs")]
+    pub duration_ms: u128,
+}
+
+#[tauri::command(async)]
+pub fn build_automation(
+    state: tauri::State<'_, super::DbState>,
+    app: tauri::AppHandle,
+    id: String,
+) -> Result<BuildResult, String> {
+    let start = std::time::Instant::now();
+
+    // Load automation
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    let automation = conn.query_row(
+        "SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at \
+         FROM automations WHERE id = ?1",
+        rusqlite::params![&id],
+        |r| {
+            Ok(Automation {
+                id: r.get(0)?,
+                workspace_id: r.get(1)?,
+                name: r.get(2)?,
+                slug: r.get(3)?,
+                path: r.get(4)?,
+                graph: r.get(5)?,
+                sandbox_mode: r.get(6)?,
+                enabled: r.get(7)?,
+                built_at: r.get(8)?,
+                created_at: r.get(9)?,
+                updated_at: r.get(10)?,
+            })
+        }
+    )
+        .map_err(|e| format!("Automation not found: {e}"))?;
+
+    // Generate Eve project files
+    let project_path = std::path::Path::new(&automation.path);
+    std::fs::create_dir_all(&project_path).map_err(|e| e.to_string())?;
+    generate_eve_project(project_path, &automation.graph, &automation.sandbox_mode)?;
+
+    // Create package.json if absent
+    let package_json_path = project_path.join("package.json");
+    if !package_json_path.exists() {
+        let pkg = serde_json::json!({
+            "name": automation.slug,
+            "type": "module"
+        });
+        std::fs::write(
+            &package_json_path,
+            serde_json::to_string_pretty(&pkg).map_err(|e| e.to_string())?
+        )
+            .map_err(|e| e.to_string())?;
+    }
+
+    // Run `node eve build`
+    let eve = eve_bin(&app)?;
+    let output = std::process::Command::new("node")
+        .arg(&eve)
+        .arg("build")
+        .current_dir(project_path)
+        .output()
+        .map_err(|e| format!("Failed to spawn eve build: {e}"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let success = output.status.success();
+    let combined_output = if stdout.is_empty() { stderr } else { stdout };
+
+    // Update built_at on success
+    if success {
+        let conn = state.0.lock().map_err(|e| e.to_string())?;
+        let _ = conn.execute(
+            "UPDATE automations SET built_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?1",
+            rusqlite::params![&automation.id],
+        );
+    }
+
+    Ok(BuildResult {
+        success,
+        output: combined_output,
+        duration_ms: start.elapsed().as_millis(),
+    })
+}
+
+#[tauri::command(async)]
+pub fn start_automation(
+    state: tauri::State<'_, super::DbState>,
+    app: tauri::AppHandle,
+    id: String,
+) -> Result<ProcessInfo, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+
+    // Check not already running
+    let existing = conn.query_row(
+        "SELECT COUNT(*) FROM automation_processes WHERE automation_id = ?1",
+        rusqlite::params![&id],
+        |r| r.get::<_, i64>(0)
+    )
+        .unwrap_or(0);
+    if existing > 0 {
+        return Err("Automation is already running".to_string());
+    }
+
+    let automation = conn.query_row(
+        "SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at \
+         FROM automations WHERE id = ?1",
+        rusqlite::params![&id],
+        |r| {
+            Ok(Automation {
+                id: r.get(0)?,
+                workspace_id: r.get(1)?,
+                name: r.get(2)?,
+                slug: r.get(3)?,
+                path: r.get(4)?,
+                graph: r.get(5)?,
+                sandbox_mode: r.get(6)?,
+                enabled: r.get(7)?,
+                built_at: r.get(8)?,
+                created_at: r.get(9)?,
+                updated_at: r.get(10)?,
+            })
+        }
+    )
+        .map_err(|e| format!("Automation not found: {e}"))?;
+    let port = find_free_port()?;
+    let eve = eve_bin(&app)?;
+
+    // Spawn `node eve start --port N --no-ui`
+    let child = std::process::Command::new("node")
+        .arg(&eve)
+        .arg("start")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--no-ui")
+        .current_dir(&automation.path)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn eve start: {e}"))?;
+
+    let pid = child.id();
+
+    // Store in DB (conn is borrowed, can't be used here anyway)
+    let proc_id = uuid::Uuid::new_v4().to_string();
+    conn.execute(
+        "INSERT INTO automation_processes (id, automation_id, port, pid) VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![&proc_id, &id, port as i32, pid as i32],
+    )
+        .map_err(|e| e.to_string())?;
+
+    // Detach the child so it stays alive after this function returns
+    drop(child);
+
+    Ok(ProcessInfo { port, pid })
+}
+
+#[tauri::command(async)]
+pub fn stop_automation(
+    state: tauri::State<'_, super::DbState>,
+    id: String,
+) -> Result<(), String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+
+    let proc_row = conn.query_row(
+        "SELECT pid FROM automation_processes WHERE automation_id = ?1",
+        rusqlite::params![&id],
+        |r| r.get::<_, i32>(0)
+    )
+        .map_err(|_| "Process not running".to_string())?;
+
+    let pid = proc_row as u32;
+    #[cfg(windows)]
+    {
+        let _ = std::process::Command::new("taskkill")
+            .args(&["/PID", &pid.to_string(), "/F"])
+            .output();
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = std::process::Command::new("kill")
+            .arg("-9")
+            .arg(pid.to_string())
+            .output();
+    }
+
+    conn.execute(
+        "DELETE FROM automation_processes WHERE automation_id = ?1",
+        rusqlite::params![&id],
+    )
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+#[tauri::command(async)]
+pub fn get_automation_process(
+    state: tauri::State<'_, super::DbState>,
+    id: String,
+) -> Result<Option<ProcessInfo>, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+
+    let result = conn.query_row(
+        "SELECT port, pid FROM automation_processes WHERE automation_id = ?1",
+        rusqlite::params![&id],
+        |r| Ok((r.get::<_, u16>(0)?, r.get::<_, u32>(1)?))
+    );
+
+    match result {
+        Ok((port, pid)) => Ok(Some(ProcessInfo { port, pid })),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}

--- a/src-tauri/src/automations.rs
+++ b/src-tauri/src/automations.rs
@@ -35,7 +35,7 @@ pub fn eve_bin(_app: &tauri::AppHandle) -> Result<PathBuf, String> {
 pub struct Automation {
     pub id: String,
     #[serde(rename = "workspaceId")]
-    pub workspace_id: String,
+    pub workspace_id: Option<String>,
     pub name: String,
     pub slug: String,
     pub path: String,
@@ -397,30 +397,42 @@ export default eveChannel({
 #[tauri::command(async)]
 pub fn list_automations(
     state: tauri::State<'_, super::DbState>,
-    workspace_id: String,
+    workspace_id: Option<String>,
 ) -> Result<Vec<Automation>, String> {
     let conn = state.0.lock().map_err(|e| e.to_string())?;
-    conn.prepare(
-        "SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at \
-         FROM automations WHERE workspace_id = ?1 ORDER BY created_at"
-    )
+    // workspace_id: None → global (unbound) automations.
+    let (sql, ws): (&str, Option<String>) = match workspace_id {
+        Some(id) => (
+            "SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at \
+             FROM automations WHERE workspace_id = ?1 ORDER BY created_at",
+            Some(id),
+        ),
+        None => (
+            "SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at \
+             FROM automations WHERE workspace_id IS NULL ORDER BY created_at",
+            None,
+        ),
+    };
+    conn.prepare(sql)
         .and_then(|mut stmt| {
-            stmt.query_map(rusqlite::params![&workspace_id], |r| {
-                Ok(Automation {
-                    id: r.get(0)?,
-                    workspace_id: r.get(1)?,
-                    name: r.get(2)?,
-                    slug: r.get(3)?,
-                    path: r.get(4)?,
-                    graph: r.get(5)?,
-                    sandbox_mode: r.get(6)?,
-                    enabled: r.get(7)?,
-                    built_at: r.get(8)?,
-                    created_at: r.get(9)?,
-                    updated_at: r.get(10)?,
-                })
-            })?
-            .collect::<Result<Vec<_>, _>>()
+            let mapper = |r: &rusqlite::Row| Ok(Automation {
+                id: r.get(0)?,
+                workspace_id: r.get(1)?,
+                name: r.get(2)?,
+                slug: r.get(3)?,
+                path: r.get(4)?,
+                graph: r.get(5)?,
+                sandbox_mode: r.get(6)?,
+                enabled: r.get(7)?,
+                built_at: r.get(8)?,
+                created_at: r.get(9)?,
+                updated_at: r.get(10)?,
+            });
+            let rows: Result<Vec<Automation>, _> = match &ws {
+                Some(id) => stmt.query_map(rusqlite::params![id], mapper)?.collect(),
+                None => stmt.query_map([], mapper)?.collect(),
+            };
+            rows
         })
         .map_err(|e| e.to_string())
 }
@@ -457,12 +469,14 @@ pub fn get_automation(
 #[tauri::command(async)]
 pub fn create_automation(
     state: tauri::State<'_, super::DbState>,
-    workspace_id: String,
+    workspace_id: Option<String>,
     name: String,
     graph: Option<String>,
 ) -> Result<Automation, String> {
     let id = uuid::Uuid::new_v4().to_string();
-    let slug = name.to_lowercase().replace(' ', "-");
+    // Append a short id suffix so identical names never collide on the unique index,
+    // and the on-disk path stays a filesystem-safe unique directory name.
+    let slug = format!("{}-{}", slugify(&name), &id[..6]);
     let graph = graph.unwrap_or_else(|| "{}".to_string());
     let path = format!(".tempest/automations/{}", slug);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use tauri::Emitter;
 use hephaestus::Isolate;
 
 mod agent_hooks;
+mod automations;
 mod canvas_mcp;
 mod claude_bridge;
 mod service_proxy;
@@ -1250,6 +1251,31 @@ CREATE TABLE IF NOT EXISTS thread_edges (
   created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 CREATE INDEX IF NOT EXISTS idx_thread_edges_thread ON thread_edges(thread_id);
+
+-- ── Automations (Eve agent projects) ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS automations (
+  id           TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  slug         TEXT NOT NULL,
+  path         TEXT NOT NULL,
+  graph        TEXT NOT NULL,
+  sandbox_mode TEXT NOT NULL DEFAULT 'auto',
+  enabled      INTEGER NOT NULL DEFAULT 1,
+  built_at     TEXT,
+  created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(workspace_id, slug)
+);
+CREATE INDEX IF NOT EXISTS idx_automations_workspace ON automations(workspace_id);
+
+CREATE TABLE IF NOT EXISTS automation_processes (
+  id             TEXT PRIMARY KEY,
+  automation_id  TEXT NOT NULL UNIQUE REFERENCES automations(id) ON DELETE CASCADE,
+  port           INTEGER NOT NULL,
+  pid            INTEGER NOT NULL,
+  started_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
 ";
 
 fn init_db(handle: &tauri::AppHandle) -> Result<rusqlite::Connection, String> {
@@ -4108,6 +4134,15 @@ pub fn run() {
             db_list_thread_edges,
             db_upsert_thread_edge,
             db_delete_thread_edge,
+            automations::list_automations,
+            automations::get_automation,
+            automations::create_automation,
+            automations::update_automation,
+            automations::delete_automation,
+            automations::build_automation,
+            automations::start_automation,
+            automations::stop_automation,
+            automations::get_automation_process,
             claude_bridge::claude_stream_start,
             claude_bridge::claude_permission_decision,
             claude_bridge::claude_stream_cancel,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4185,6 +4185,7 @@ pub fn run() {
             automations::start_automation,
             automations::stop_automation,
             automations::get_automation_process,
+            automations::try_http_request,
             claude_bridge::claude_stream_start,
             claude_bridge::claude_permission_decision,
             claude_bridge::claude_stream_cancel,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1255,7 +1255,7 @@ CREATE INDEX IF NOT EXISTS idx_thread_edges_thread ON thread_edges(thread_id);
 -- ── Automations (Eve agent projects) ──────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS automations (
   id           TEXT PRIMARY KEY,
-  workspace_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  workspace_id TEXT REFERENCES projects(id) ON DELETE CASCADE, -- NULL = global (unbound)
   name         TEXT NOT NULL,
   slug         TEXT NOT NULL,
   path         TEXT NOT NULL,
@@ -1264,10 +1264,12 @@ CREATE TABLE IF NOT EXISTS automations (
   enabled      INTEGER NOT NULL DEFAULT 1,
   built_at     TEXT,
   created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  UNIQUE(workspace_id, slug)
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 CREATE INDEX IF NOT EXISTS idx_automations_workspace ON automations(workspace_id);
+-- Partial unique indexes: slug unique per project, and unique across the global scope.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_automations_ws_slug ON automations(workspace_id, slug) WHERE workspace_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_automations_global_slug ON automations(slug) WHERE workspace_id IS NULL;
 
 CREATE TABLE IF NOT EXISTS automation_processes (
   id             TEXT PRIMARY KEY,
@@ -1288,6 +1290,46 @@ fn init_db(handle: &tauri::AppHandle) -> Result<rusqlite::Connection, String> {
     // (CREATE TABLE IF NOT EXISTS never alters an existing table). The dup-column
     // error on already-migrated DBs is expected and ignored.
     let _ = conn.execute("ALTER TABLE sessions ADD COLUMN placement TEXT NOT NULL DEFAULT 'tab'", []);
+
+    // Migrate: allow NULL workspace_id on automations (global scope).
+    // SQLite can't drop NOT NULL directly, so we recreate the table when the
+    // old constraint is still present. Safe on empty DBs (INSERT SELECT is a no-op).
+    let workspace_notnull: i32 = conn.query_row(
+        "SELECT notnull FROM pragma_table_info('automations') WHERE name = 'workspace_id'",
+        [],
+        |r| r.get(0),
+    ).unwrap_or(0);
+    if workspace_notnull == 1 {
+        // Turn FKs off around the rebuild so cascade-on-DROP doesn't touch
+        // automation_processes; re-enable after.
+        let _ = conn.execute_batch("PRAGMA foreign_keys = OFF;");
+        let _ = conn.execute_batch("
+            BEGIN;
+            CREATE TABLE automations_new (
+              id           TEXT PRIMARY KEY,
+              workspace_id TEXT REFERENCES projects(id) ON DELETE CASCADE,
+              name         TEXT NOT NULL,
+              slug         TEXT NOT NULL,
+              path         TEXT NOT NULL,
+              graph        TEXT NOT NULL,
+              sandbox_mode TEXT NOT NULL DEFAULT 'auto',
+              enabled      INTEGER NOT NULL DEFAULT 1,
+              built_at     TEXT,
+              created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+              updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            );
+            INSERT INTO automations_new
+              SELECT id, workspace_id, name, slug, path, graph, sandbox_mode, enabled, built_at, created_at, updated_at
+              FROM automations;
+            DROP TABLE automations;
+            ALTER TABLE automations_new RENAME TO automations;
+            CREATE INDEX IF NOT EXISTS idx_automations_workspace ON automations(workspace_id);
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_automations_ws_slug ON automations(workspace_id, slug) WHERE workspace_id IS NOT NULL;
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_automations_global_slug ON automations(slug) WHERE workspace_id IS NULL;
+            COMMIT;
+        ");
+        let _ = conn.execute_batch("PRAGMA foreign_keys = ON;");
+    }
     Ok(conn)
 }
 

--- a/src/components/Automations/AutomationsList.tsx
+++ b/src/components/Automations/AutomationsList.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { invoke } from "@tauri-apps/api/core";
+import { ChevronDown, Check, ExternalLink, Loader, Plus, Trash2, Workflow } from "lucide-react";
+import type { StoredProject } from "../../store/openProjects";
+import { Tooltip } from "../Tooltip";
+
+interface Automation {
+  id: string;
+  workspaceId: string;
+  name: string;
+  slug: string;
+  path: string;
+  graph: string;
+  sandboxMode: string;
+  enabled: boolean;
+  builtAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ProcessInfo {
+  port: number;
+  pid: number;
+}
+
+interface Props {
+  projects: StoredProject[];
+  project: StoredProject;
+  onSelectProject: (id: string) => void;
+  onOpen: (id: string, name: string) => void;
+}
+
+function timeAgo(iso: string): string {
+  const s = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (s < 60) return "just now";
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86400)}d ago`;
+}
+
+export function AutomationsList({ projects, project, onSelectProject, onOpen }: Props) {
+  const [automations, setAutomations] = useState<Automation[]>([]);
+  const [processes, setProcesses] = useState<Record<string, ProcessInfo>>({});
+  const [loading, setLoading] = useState(true);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  async function load(projectId: string) {
+    setLoading(true);
+    try {
+      const list = await invoke<Automation[]>("list_automations", { workspaceId: projectId });
+      setAutomations(list);
+      const pairs = await Promise.all(
+        list.map(a =>
+          invoke<ProcessInfo | null>("get_automation_process", { id: a.id })
+            .then(p => [a.id, p] as const)
+            .catch(() => [a.id, null] as const)
+        )
+      );
+      const procs: Record<string, ProcessInfo> = {};
+      for (const [id, p] of pairs) if (p) procs[id] = p;
+      setProcesses(procs);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(project.id); }, [project.id]);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    function onOut(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) setPickerOpen(false);
+    }
+    document.addEventListener("mousedown", onOut);
+    return () => document.removeEventListener("mousedown", onOut);
+  }, [pickerOpen]);
+
+  useEffect(() => {
+    if (creating) setTimeout(() => nameInputRef.current?.focus(), 0);
+  }, [creating]);
+
+  async function handleCreate() {
+    const name = newName.trim();
+    if (!name) return;
+    setSaving(true);
+    try {
+      const a = await invoke<Automation>("create_automation", { workspaceId: project.id, name });
+      setAutomations(prev => [...prev, a]);
+      setCreating(false);
+      setNewName("");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteId) return;
+    setDeleting(true);
+    try {
+      await invoke("delete_automation", { id: deleteId });
+      setAutomations(prev => prev.filter(a => a.id !== deleteId));
+      setProcesses(prev => { const next = { ...prev }; delete next[deleteId!]; return next; });
+      setDeleteId(null);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function handleStop(id: string) {
+    await invoke("stop_automation", { id }).catch(() => {});
+    setProcesses(prev => { const next = { ...prev }; delete next[id]; return next; });
+  }
+
+  function dot(a: Automation) {
+    if (processes[a.id]) return <span className="am-dot am-dot--running" />;
+    if (a.builtAt) return <span className="am-dot am-dot--built" />;
+    return <span className="am-dot am-dot--idle" />;
+  }
+
+  function meta(a: Automation) {
+    const p = processes[a.id];
+    if (p) return <span className="am-meta am-meta--running">running :{p.port}</span>;
+    if (a.builtAt) return <span className="am-meta am-meta--built">built · {timeAgo(a.builtAt)}</span>;
+    return <span className="am-meta am-meta--idle">never built</span>;
+  }
+
+  function badge(a: Automation) {
+    const state = processes[a.id] ? "running" : a.builtAt ? "built" : "idle";
+    return (
+      <span className={`am-badge am-badge--${state}`}>
+        {dot(a)}
+        {meta(a)}
+      </span>
+    );
+  }
+
+  const deleteTarget = automations.find(a => a.id === deleteId);
+
+  return (
+    <div className="am-root">
+      <div className="am-header">
+        <div className="am-header-left">
+          <h1 className="am-header-title">Automations</h1>
+          {!loading && automations.length > 0 && (
+            <span className="am-header-count">{automations.length}</span>
+          )}
+        </div>
+        <div className="am-header-right">
+          {projects.length > 1 && (
+            <div className="am-picker" ref={pickerRef}>
+              <button
+                className={`am-picker-btn${pickerOpen ? " am-picker-btn--open" : ""}`}
+                onClick={() => setPickerOpen(v => !v)}
+              >
+                <span className="am-picker-dot" />
+                <span className="am-picker-label">{project.name}</span>
+                <ChevronDown size={12} className="am-picker-chevron" />
+              </button>
+              {pickerOpen && (
+                <div className="am-picker-menu">
+                  {projects.map(p => (
+                    <button
+                      key={p.id}
+                      className={`am-picker-item${p.id === project.id ? " am-picker-item--active" : ""}`}
+                      onClick={() => { onSelectProject(p.id); setPickerOpen(false); }}
+                    >
+                      <span className="am-picker-item-check">
+                        {p.id === project.id && <Check size={11} />}
+                      </span>
+                      <span className="am-picker-item-name">{p.name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          <button className="am-new-btn" onClick={() => setCreating(true)}>
+            <Plus size={14} />
+            New Automation
+          </button>
+        </div>
+      </div>
+
+      <div className="am-list">
+        {loading ? (
+          <div className="am-loading">
+            <Loader size={16} className="am-spin" />
+          </div>
+        ) : automations.length === 0 ? (
+          <div className="am-empty">
+            <div className="am-empty-art">
+              <Workflow size={30} className="am-empty-icon" />
+            </div>
+            <p className="am-empty-text">No automations yet</p>
+            <p className="am-empty-sub">Build and schedule AI agents that run on autopilot.</p>
+            <button className="am-empty-cta" onClick={() => setCreating(true)}>
+              <Plus size={14} />
+              Create your first automation
+            </button>
+          </div>
+        ) : (
+          <div className="am-grid">
+            {automations.map((a, i) => (
+              <div
+                key={a.id}
+                className={`am-card${processes[a.id] ? " am-card--running" : ""}`}
+                style={{ animationDelay: `${Math.min(i, 12) * 35}ms` }}
+              >
+                <div className="am-card-top">
+                  <span className="am-card-glyph">
+                    <Workflow size={14} />
+                  </span>
+                  {badge(a)}
+                </div>
+
+                <div className="am-card-body">
+                  <span className="am-card-name" title={a.name}>{a.name}</span>
+                  <span className="am-card-slug">{a.slug}</span>
+                </div>
+
+                <div className="am-card-actions">
+                  <button className="am-act am-act--primary" onClick={() => onOpen(a.id, a.name)}>
+                    <ExternalLink size={12} />
+                    Open
+                  </button>
+                  {processes[a.id] && (
+                    <button className="am-act" onClick={() => handleStop(a.id)}>Stop</button>
+                  )}
+                  <span className="am-card-actions-spacer" />
+                  <Tooltip content="Delete" placement="top">
+                    <button className="am-act am-act--icon am-act--danger" onClick={() => setDeleteId(a.id)}>
+                      <Trash2 size={13} />
+                    </button>
+                  </Tooltip>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {creating && createPortal(
+        <div className="naming-modal-overlay" onClick={() => !saving && (setCreating(false), setNewName(""))}>
+          <div className="naming-modal" onClick={e => e.stopPropagation()}>
+            <div className="naming-modal-header">
+              <Workflow size={14} />
+              <span>New automation</span>
+            </div>
+            <input
+              ref={nameInputRef}
+              className="naming-modal-input"
+              placeholder="e.g. Daily Standup Bot"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === "Enter") handleCreate();
+                if (e.key === "Escape") { setCreating(false); setNewName(""); }
+              }}
+              disabled={saving}
+            />
+            <div className="naming-modal-actions">
+              <button
+                className="naming-modal-btn naming-modal-btn--cancel"
+                onClick={() => { setCreating(false); setNewName(""); }}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+              <button
+                className="naming-modal-btn naming-modal-btn--create"
+                onClick={handleCreate}
+                disabled={saving || !newName.trim()}
+              >
+                {saving ? <Loader size={13} className="am-spin" /> : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {deleteId && createPortal(
+        <div className="naming-modal-overlay" onClick={() => !deleting && setDeleteId(null)}>
+          <div className="naming-modal" onClick={e => e.stopPropagation()}>
+            <div className="naming-modal-header">
+              <Trash2 size={14} />
+              <span>Delete automation?</span>
+            </div>
+            <p className="naming-modal-desc">
+              <strong>{deleteTarget?.name}</strong> will be permanently removed.
+            </p>
+            <div className="naming-modal-actions">
+              <button
+                className="naming-modal-btn naming-modal-btn--cancel"
+                onClick={() => setDeleteId(null)}
+                disabled={deleting}
+              >
+                Cancel
+              </button>
+              <button
+                className="naming-modal-btn naming-modal-btn--delete"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? <Loader size={13} className="am-spin" /> : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/src/components/Automations/AutomationsList.tsx
+++ b/src/components/Automations/AutomationsList.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from "../Tooltip";
 
 interface Automation {
   id: string;
-  workspaceId: string;
+  workspaceId: string | null;
   name: string;
   slug: string;
   path: string;
@@ -54,10 +54,8 @@ export function AutomationsList({ projects, scope, onSelectScope, onOpen }: Prop
   async function load(projectId: string | null) {
     setLoading(true);
     try {
-      // ponytail: Global scope returns empty until backend supports unbound automations
-      const list = projectId
-        ? await invoke<Automation[]>("list_automations", { workspaceId: projectId })
-        : [];
+      // workspaceId: null → global (unbound) automations.
+      const list = await invoke<Automation[]>("list_automations", { workspaceId: projectId });
       setAutomations(list);
       const pairs = await Promise.all(
         list.map(a =>
@@ -83,9 +81,9 @@ export function AutomationsList({ projects, scope, onSelectScope, onOpen }: Prop
   async function handleCreate() {
     const name = newName.trim();
     if (!name) return;
-    if (!scope) return;
     setSaving(true);
     try {
+      // scope: null = Global (unbound).
       const a = await invoke<Automation>("create_automation", { workspaceId: scope, name });
       setAutomations(prev => [...prev, a]);
       setCreating(false);
@@ -143,9 +141,8 @@ export function AutomationsList({ projects, scope, onSelectScope, onOpen }: Prop
         <div className="am-header-right">
           <button
             className="am-new-btn"
-            onClick={() => scope && setCreating(true)}
-            disabled={!scope}
-            title={scope ? "Create a new automation" : "Select a project first"}
+            onClick={() => setCreating(true)}
+            title="Create a new automation"
           >
             <Plus size={14} />
             New Automation
@@ -187,14 +184,9 @@ export function AutomationsList({ projects, scope, onSelectScope, onOpen }: Prop
             <Workflow size={22} className="am-empty-icon" />
             <p className="am-empty-text">No automations yet</p>
             <p className="am-empty-sub">Build and schedule AI agents that run on autopilot.</p>
-            <button
-              className="am-empty-cta"
-              onClick={() => scope && setCreating(true)}
-              disabled={!scope}
-              title={scope ? "Create automation" : "Select a project first"}
-            >
+            <button className="am-empty-cta" onClick={() => setCreating(true)}>
               <Plus size={14} />
-              {scope ? "Create automation" : "Select a project"}
+              Create automation
             </button>
           </div>
         ) : (

--- a/src/components/Automations/AutomationsList.tsx
+++ b/src/components/Automations/AutomationsList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
-import { ChevronDown, Check, ExternalLink, Loader, Plus, Trash2, Workflow } from "lucide-react";
+import { ExternalLink, Globe, Loader, Plus, Trash2, Workflow } from "lucide-react";
 import type { StoredProject } from "../../store/openProjects";
 import { Tooltip } from "../Tooltip";
 
@@ -26,8 +26,8 @@ interface ProcessInfo {
 
 interface Props {
   projects: StoredProject[];
-  project: StoredProject;
-  onSelectProject: (id: string) => void;
+  scope: string | null;
+  onSelectScope: (id: string | null) => void;
   onOpen: (id: string, name: string) => void;
 }
 
@@ -39,23 +39,25 @@ function timeAgo(iso: string): string {
   return `${Math.floor(s / 86400)}d ago`;
 }
 
-export function AutomationsList({ projects, project, onSelectProject, onOpen }: Props) {
+export function AutomationsList({ projects, scope, onSelectScope, onOpen }: Props) {
   const [automations, setAutomations] = useState<Automation[]>([]);
   const [processes, setProcesses] = useState<Record<string, ProcessInfo>>({});
   const [loading, setLoading] = useState(true);
-  const [pickerOpen, setPickerOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
   const [saving, setSaving] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
-  const pickerRef = useRef<HTMLDivElement>(null);
+  const tabsRef = useRef<HTMLDivElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
-  async function load(projectId: string) {
+  async function load(projectId: string | null) {
     setLoading(true);
     try {
-      const list = await invoke<Automation[]>("list_automations", { workspaceId: projectId });
+      // ponytail: Global scope returns empty until backend supports unbound automations
+      const list = projectId
+        ? await invoke<Automation[]>("list_automations", { workspaceId: projectId })
+        : [];
       setAutomations(list);
       const pairs = await Promise.all(
         list.map(a =>
@@ -72,16 +74,7 @@ export function AutomationsList({ projects, project, onSelectProject, onOpen }: 
     }
   }
 
-  useEffect(() => { load(project.id); }, [project.id]);
-
-  useEffect(() => {
-    if (!pickerOpen) return;
-    function onOut(e: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) setPickerOpen(false);
-    }
-    document.addEventListener("mousedown", onOut);
-    return () => document.removeEventListener("mousedown", onOut);
-  }, [pickerOpen]);
+  useEffect(() => { load(scope); }, [scope]);
 
   useEffect(() => {
     if (creating) setTimeout(() => nameInputRef.current?.focus(), 0);
@@ -90,9 +83,10 @@ export function AutomationsList({ projects, project, onSelectProject, onOpen }: 
   async function handleCreate() {
     const name = newName.trim();
     if (!name) return;
+    if (!scope) return;
     setSaving(true);
     try {
-      const a = await invoke<Automation>("create_automation", { workspaceId: project.id, name });
+      const a = await invoke<Automation>("create_automation", { workspaceId: scope, name });
       setAutomations(prev => [...prev, a]);
       setCreating(false);
       setNewName("");
@@ -127,19 +121,9 @@ export function AutomationsList({ projects, project, onSelectProject, onOpen }: 
 
   function meta(a: Automation) {
     const p = processes[a.id];
-    if (p) return <span className="am-meta am-meta--running">running :{p.port}</span>;
-    if (a.builtAt) return <span className="am-meta am-meta--built">built · {timeAgo(a.builtAt)}</span>;
-    return <span className="am-meta am-meta--idle">never built</span>;
-  }
-
-  function badge(a: Automation) {
-    const state = processes[a.id] ? "running" : a.builtAt ? "built" : "idle";
-    return (
-      <span className={`am-badge am-badge--${state}`}>
-        {dot(a)}
-        {meta(a)}
-      </span>
-    );
+    if (p) return <span className="am-row-meta am-row-meta--running">running · :{p.port}</span>;
+    if (a.builtAt) return <span className="am-row-meta">Built {timeAgo(a.builtAt)}</span>;
+    return <span className="am-row-meta">Never built</span>;
   }
 
   const deleteTarget = automations.find(a => a.id === deleteId);
@@ -148,45 +132,49 @@ export function AutomationsList({ projects, project, onSelectProject, onOpen }: 
     <div className="am-root">
       <div className="am-header">
         <div className="am-header-left">
-          <h1 className="am-header-title">Automations</h1>
-          {!loading && automations.length > 0 && (
-            <span className="am-header-count">{automations.length}</span>
-          )}
+          <div className="am-header-titlerow">
+            <h1 className="am-header-title">Automations</h1>
+            {!loading && automations.length > 0 && (
+              <span className="am-header-count">{automations.length}</span>
+            )}
+          </div>
+          <p className="am-header-sub">Build and schedule AI agents that run on autopilot.</p>
         </div>
         <div className="am-header-right">
-          {projects.length > 1 && (
-            <div className="am-picker" ref={pickerRef}>
-              <button
-                className={`am-picker-btn${pickerOpen ? " am-picker-btn--open" : ""}`}
-                onClick={() => setPickerOpen(v => !v)}
-              >
-                <span className="am-picker-dot" />
-                <span className="am-picker-label">{project.name}</span>
-                <ChevronDown size={12} className="am-picker-chevron" />
-              </button>
-              {pickerOpen && (
-                <div className="am-picker-menu">
-                  {projects.map(p => (
-                    <button
-                      key={p.id}
-                      className={`am-picker-item${p.id === project.id ? " am-picker-item--active" : ""}`}
-                      onClick={() => { onSelectProject(p.id); setPickerOpen(false); }}
-                    >
-                      <span className="am-picker-item-check">
-                        {p.id === project.id && <Check size={11} />}
-                      </span>
-                      <span className="am-picker-item-name">{p.name}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-          <button className="am-new-btn" onClick={() => setCreating(true)}>
+          <button
+            className="am-new-btn"
+            onClick={() => scope && setCreating(true)}
+            disabled={!scope}
+            title={scope ? "Create a new automation" : "Select a project first"}
+          >
             <Plus size={14} />
             New Automation
           </button>
         </div>
+      </div>
+
+      <div className="am-tabs" ref={tabsRef} role="tablist">
+        <button
+          className={`am-tab${scope === null ? " am-tab--active" : ""}`}
+          onClick={() => onSelectScope(null)}
+          role="tab"
+          aria-selected={scope === null}
+        >
+          <Globe size={13} className="am-tab-icon" />
+          Global
+        </button>
+        {projects.map(p => (
+          <button
+            key={p.id}
+            className={`am-tab${scope === p.id ? " am-tab--active" : ""}`}
+            onClick={() => onSelectScope(p.id)}
+            role="tab"
+            aria-selected={scope === p.id}
+            title={p.name}
+          >
+            <span className="am-tab-label">{p.name}</span>
+          </button>
+        ))}
       </div>
 
       <div className="am-list">
@@ -196,45 +184,48 @@ export function AutomationsList({ projects, project, onSelectProject, onOpen }: 
           </div>
         ) : automations.length === 0 ? (
           <div className="am-empty">
-            <div className="am-empty-art">
-              <Workflow size={30} className="am-empty-icon" />
-            </div>
+            <Workflow size={22} className="am-empty-icon" />
             <p className="am-empty-text">No automations yet</p>
             <p className="am-empty-sub">Build and schedule AI agents that run on autopilot.</p>
-            <button className="am-empty-cta" onClick={() => setCreating(true)}>
+            <button
+              className="am-empty-cta"
+              onClick={() => scope && setCreating(true)}
+              disabled={!scope}
+              title={scope ? "Create automation" : "Select a project first"}
+            >
               <Plus size={14} />
-              Create your first automation
+              {scope ? "Create automation" : "Select a project"}
             </button>
           </div>
         ) : (
-          <div className="am-grid">
+          <div className="am-rows">
             {automations.map((a, i) => (
               <div
                 key={a.id}
-                className={`am-card${processes[a.id] ? " am-card--running" : ""}`}
-                style={{ animationDelay: `${Math.min(i, 12) * 35}ms` }}
+                className="am-row"
+                style={{ animationDelay: `${Math.min(i, 12) * 20}ms` }}
+                onClick={() => onOpen(a.id, a.name)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={e => { if (e.key === "Enter") onOpen(a.id, a.name); }}
               >
-                <div className="am-card-top">
-                  <span className="am-card-glyph">
-                    <Workflow size={14} />
-                  </span>
-                  {badge(a)}
+                <span className="am-row-status">{dot(a)}</span>
+
+                <div className="am-row-main">
+                  <span className="am-row-name" title={a.name}>{a.name}</span>
+                  <span className="am-row-slug">{a.slug}</span>
                 </div>
 
-                <div className="am-card-body">
-                  <span className="am-card-name" title={a.name}>{a.name}</span>
-                  <span className="am-card-slug">{a.slug}</span>
-                </div>
+                {meta(a)}
 
-                <div className="am-card-actions">
-                  <button className="am-act am-act--primary" onClick={() => onOpen(a.id, a.name)}>
-                    <ExternalLink size={12} />
-                    Open
-                  </button>
+                <div className="am-row-actions" onClick={e => e.stopPropagation()}>
                   {processes[a.id] && (
                     <button className="am-act" onClick={() => handleStop(a.id)}>Stop</button>
                   )}
-                  <span className="am-card-actions-spacer" />
+                  <button className="am-act" onClick={() => onOpen(a.id, a.name)}>
+                    <ExternalLink size={12} />
+                    Open
+                  </button>
                   <Tooltip content="Delete" placement="top">
                     <button className="am-act am-act--icon am-act--danger" onClick={() => setDeleteId(a.id)}>
                       <Trash2 size={13} />

--- a/src/components/Automations/AutomationsPage.css
+++ b/src/components/Automations/AutomationsPage.css
@@ -573,73 +573,149 @@
 /* ── Node palette ───────────────────────────────────────────────────────────── */
 
 .am-palette {
-  width: 200px;
+  width: 260px;
   flex-shrink: 0;
   border-right: 1px solid var(--tempest-border-default);
-  padding: 12px 8px;
+  padding: 14px 10px;
   overflow-y: auto;
   background: var(--tempest-bg-panel, var(--tempest-bg-editor));
 }
 
-.am-palette-group + .am-palette-group { margin-top: 14px; }
+.am-palette-intro {
+  font-size: 11.5px;
+  color: var(--tempest-fg-subtle);
+  line-height: 1.5;
+  padding: 0 6px 12px;
+}
+
+.am-palette-group + .am-palette-group { margin-top: 16px; }
 
 .am-palette-label {
   font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--tempest-fg-subtle);
-  padding: 0 6px 6px;
+  padding: 0 6px 8px;
+  font-weight: 600;
 }
 
 .am-palette-item {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: 5px;
-  font-size: 12.5px;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
   color: var(--tempest-fg-default);
   cursor: grab;
   user-select: none;
-  transition: background 0.1s;
+  transition: background 0.1s, transform 0.1s;
+  border: 1px solid transparent;
 }
-.am-palette-item:hover { background: var(--tempest-bg-hover); }
-.am-palette-item:active { cursor: grabbing; }
+.am-palette-item + .am-palette-item { margin-top: 4px; }
+.am-palette-item:hover { background: var(--tempest-bg-hover); border-color: var(--tempest-border-subtle); }
+.am-palette-item:active { cursor: grabbing; transform: scale(0.98); }
 .am-palette-item--disabled { opacity: 0.4; cursor: not-allowed; }
-.am-palette-icon { color: var(--tempest-fg-muted); display: inline-flex; }
+.am-palette-item--disabled:hover { background: transparent; border-color: transparent; }
+
+.am-palette-icon {
+  width: 26px; height: 26px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 1px;
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-muted);
+}
+.am-palette-item--trigger-manual .am-palette-icon,
+.am-palette-item--trigger-schedule .am-palette-icon { background: rgba(148, 163, 184, 0.15); color: #94a3b8; }
+.am-palette-item--agent .am-palette-icon      { background: rgba(59, 130, 246, 0.15);  color: #3b82f6; }
+.am-palette-item--tool .am-palette-icon       { background: rgba(34, 197, 94, 0.15);   color: #22c55e; }
+.am-palette-item--skill .am-palette-icon      { background: rgba(245, 158, 11, 0.15);  color: #f59e0b; }
+.am-palette-item--connection .am-palette-icon { background: rgba(6, 182, 212, 0.15);   color: #06b6d4; }
+.am-palette-item--subagent .am-palette-icon   { background: rgba(236, 72, 153, 0.15);  color: #ec4899; }
+
+.am-palette-text { display: flex; flex-direction: column; min-width: 0; gap: 2px; }
+.am-palette-name { font-size: 12.5px; font-weight: 600; line-height: 1.25; }
+.am-palette-desc { font-size: 11px; color: var(--tempest-fg-subtle); line-height: 1.35; }
 
 /* ── Node cards ─────────────────────────────────────────────────────────────── */
 
 .amn {
-  min-width: 160px;
-  border-radius: 8px;
+  position: relative;
+  width: 240px;
+  border-radius: 10px;
   border: 1px solid var(--tempest-border-default);
   background: var(--tempest-bg-editor);
-  padding: 10px 12px;
+  padding: 12px 14px;
   font-family: "Geist", sans-serif;
   color: var(--tempest-fg-default);
-  transition: box-shadow 0.15s, border-color 0.15s;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
-.amn--selected { border-color: var(--tempest-accent, #3b82f6); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15); }
+.amn:hover { border-color: var(--tempest-fg-subtle); }
+.amn--selected {
+  border-color: var(--tempest-accent, #3b82f6);
+  box-shadow: 0 0 0 1px var(--tempest-accent, #3b82f6);
+}
 
-.amn-body { display: flex; align-items: center; gap: 10px; }
+.amn-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
 .amn-icon {
-  width: 26px; height: 26px;
+  width: 22px; height: 22px;
   display: inline-flex; align-items: center; justify-content: center;
-  border-radius: 6px;
+  border-radius: 5px;
   background: var(--tempest-bg-hover);
   color: var(--tempest-fg-muted);
   flex-shrink: 0;
 }
-.amn-text { display: flex; flex-direction: column; min-width: 0; }
-.amn-title { font-size: 13px; font-weight: 600; line-height: 1.2; }
-.amn-sub {
-  font-size: 11px;
+.amn-kind {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   color: var(--tempest-fg-muted);
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 180px;
+}
+.amn-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 10px;
+  background: rgba(245, 158, 11, 0.15);
+  color: #d97706;
+  flex-shrink: 0;
+}
+
+.amn-primary {
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--tempest-fg-default);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.amn-secondary {
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--tempest-fg-muted);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Tone accents on the icon backdrop */
@@ -649,10 +725,135 @@
 .amn--skill .amn-icon      { background: rgba(245, 158, 11, 0.15);  color: #f59e0b; }
 .amn--connection .amn-icon { background: rgba(6, 182, 212, 0.15);   color: #06b6d4; }
 .amn--subagent .amn-icon   { background: rgba(236, 72, 153, 0.15);  color: #ec4899; }
+.amn--flow .amn-icon       { background: rgba(168, 85, 247, 0.15);  color: #a855f7; }
 
-/* React Flow handle sizing (default is too small) */
-.react-flow__handle { width: 8px; height: 8px; background: var(--tempest-fg-muted); border: 2px solid var(--tempest-bg-editor); }
-.react-flow__handle:hover { background: var(--tempest-accent, #3b82f6); }
+/* ── P6/P7 flow-step editor ─────────────────────────────────────── */
+.am-steplist { display: flex; flex-direction: column; gap: 8px; }
+.am-step {
+  border: 1px solid var(--tempest-border, rgba(148, 163, 184, 0.2));
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.04);
+  overflow: hidden;
+}
+.am-step-head {
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 8px;
+  background: rgba(148, 163, 184, 0.08);
+  font-size: 12px;
+  font-weight: 600;
+}
+.am-step-kind { flex: 1; }
+.am-step-drag, .am-step-del {
+  background: transparent; border: none; color: inherit;
+  cursor: pointer; padding: 2px; border-radius: 4px;
+  display: inline-flex; align-items: center;
+}
+.am-step-drag:hover, .am-step-del:hover { background: rgba(148, 163, 184, 0.15); }
+.am-step-body { padding: 8px; display: flex; flex-direction: column; gap: 8px; }
+.am-step-add {
+  display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
+  padding-top: 4px;
+}
+.am-step-add-btn {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid var(--tempest-border, rgba(148, 163, 184, 0.2));
+  border-radius: 6px;
+  cursor: pointer;
+  color: inherit;
+}
+.am-step-add-btn:hover { background: rgba(148, 163, 184, 0.2); }
+.am-branch {
+  border-left: 2px solid rgba(168, 85, 247, 0.4);
+  padding: 6px 8px;
+  margin-top: 4px;
+  border-radius: 0 6px 6px 0;
+  background: rgba(168, 85, 247, 0.04);
+}
+.am-branch-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--tempest-text-muted, #94a3b8);
+  margin-bottom: 6px;
+  display: flex; align-items: center; gap: 6px;
+}
+.am-cond { display: flex; flex-direction: column; gap: 6px; }
+.am-cond-row { display: flex; }
+
+/* Threads-style connector: React Flow Handle rendered inline in a node header
+   as a small hexagon icon. Neutralize the library's absolute positioning/dot
+   styling so it sits as a header icon; it still starts a connection drag /
+   click-to-connect. Mirrors .tnode-connector in threads/nodes/TextNode.css. */
+.react-flow__handle.am-connector {
+  position: relative;
+  inset: auto;
+  transform: none;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--tempest-fg-muted, #888);
+  cursor: crosshair;
+  transition: color 0.12s ease;
+  flex-shrink: 0;
+}
+/* SVG must not eat pointer events — click-to-connect reads handle attrs off
+   event.target, so a click hitting the inner <path> would be ignored. */
+.react-flow__handle.am-connector svg { pointer-events: none; }
+.react-flow__handle.am-connector:hover { color: var(--tempest-accent-yellow, #f5c518); }
+.react-flow__handle.am-connector.connected { color: var(--tempest-fg-default, #e6e6e6); }
+.react-flow__handle.am-connector.connecting,
+.react-flow__handle.am-connector.clickconnecting {
+  color: var(--tempest-accent-yellow, #f5c518);
+}
+.react-flow__handle.am-connector.clickconnecting svg { fill: var(--tempest-accent-yellow, #f5c518); }
+
+/* Vertical divider fencing the left (incoming) connector off from the title. */
+.am-connector-sep {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 16px;
+  background: var(--tempest-border-subtle, #2a2a2a);
+}
+
+/* Midpoint × on each connection edge (AutomationEdge). EdgeLabelRenderer
+   children are pointer-events:none by default, so re-enable it here. */
+.am-edge-del {
+  position: absolute;
+  pointer-events: all;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--tempest-bg-base, #0a0a0a);
+  background: var(--tempest-fg-default, #e6e6e6);
+  color: var(--tempest-bg-base, #0a0a0a);
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+  transition: background 0.12s ease, color 0.12s ease;
+  opacity: 0;
+}
+.react-flow__edge:hover .am-edge-del,
+.react-flow__edge.selected .am-edge-del {
+  opacity: 1;
+}
+.am-edge-del:hover {
+  background: var(--tempest-accent-red, #ff5f56);
+  color: #fff;
+  opacity: 1;
+}
 
 /* ── Save chip ──────────────────────────────────────────────────────────────── */
 
@@ -843,6 +1044,377 @@
 }
 .am-tabs2-btn:hover { background: var(--tempest-bg-hover); }
 .am-tabs2-btn--active { background: var(--tempest-bg-hover); color: var(--tempest-fg-default); }
+
+/* Modal title with subtitle */
+.am-modal-title-text { display: flex; flex-direction: column; gap: 2px; }
+.am-modal-title-sub {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--tempest-fg-subtle);
+}
+
+/* Inline hint below a field */
+.am-hint-block {
+  font-size: 11px;
+  color: var(--tempest-fg-subtle);
+  line-height: 1.4;
+  margin-top: 2px;
+}
+
+/* Segmented toggle (Call API / Custom code, MCP / OpenAPI) */
+.am-segmented {
+  display: inline-flex;
+  padding: 3px;
+  gap: 2px;
+  border-radius: 6px;
+  background: var(--tempest-bg-hover);
+  border: 1px solid var(--tempest-border-subtle);
+  align-self: flex-start;
+}
+.am-segmented-btn {
+  padding: 5px 12px;
+  border: none;
+  background: transparent;
+  color: var(--tempest-fg-muted);
+  font: 500 12px "Geist", sans-serif;
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.am-segmented-btn:hover { color: var(--tempest-fg-default); }
+.am-segmented-btn--active {
+  background: var(--tempest-bg-editor);
+  color: var(--tempest-fg-default);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+.am-segmented-tag {
+  font-size: 9.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.18);
+  color: #d97706;
+}
+
+/* Callout box (advanced-mode warning etc.) */
+.am-callout {
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--tempest-fg-default);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+/* Row of fields (method + URL, schedule controls) */
+.am-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+}
+.am-row--tight { gap: 8px; align-items: center; }
+.am-field--fixed { width: 110px; flex-shrink: 0; }
+.am-field--grow { flex: 1; min-width: 0; }
+.am-inline {
+  font-size: 12.5px;
+  color: var(--tempest-fg-muted);
+  white-space: nowrap;
+}
+.am-input--num { width: 90px; padding: 6px 8px; }
+.am-input--fit { width: auto; }
+
+/* Schedule readback pill */
+.am-readback {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 5px 10px;
+  border-radius: 20px;
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--tempest-fg-default);
+  font-size: 11.5px;
+  align-self: flex-start;
+}
+.am-readback-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--tempest-accent, #3b82f6);
+}
+
+/* ── Tool builder: shared bits ──────────────────────────────────────────────── */
+
+.am-req { display: flex; flex-direction: column; gap: 16px; }
+.am-req-section { display: flex; flex-direction: column; gap: 8px; }
+.am-req-section-head {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--tempest-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--tempest-border-default);
+  padding-bottom: 4px;
+}
+
+.am-callout--err {
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--tempest-fg-default);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Chip-value input (value + insert-input menu) ───────────────────────────── */
+
+.am-chipin { position: relative; display: flex; align-items: stretch; gap: 4px; }
+.am-chipin > .am-input,
+.am-chipin > .am-textarea { flex: 1; min-width: 0; }
+.am-chipin-btn {
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-muted);
+  border-radius: 6px;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 4px;
+  flex-shrink: 0;
+}
+.am-chipin-btn:hover:not(:disabled) { color: var(--tempest-fg-default); background: var(--tempest-bg-active, var(--tempest-bg-hover)); }
+.am-chipin-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.am-chipin-scrim { position: fixed; inset: 0; z-index: 40; }
+.am-chipin-menu {
+  position: absolute;
+  right: 0; top: calc(100% + 4px);
+  z-index: 41;
+  min-width: 200px;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--tempest-bg-elevated, var(--tempest-bg-editor));
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  padding: 4px;
+}
+.am-chipin-menu-head {
+  padding: 6px 8px 4px;
+  font-size: 10.5px;
+  color: var(--tempest-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.am-chipin-menu-item {
+  display: flex; justify-content: space-between; align-items: center;
+  width: 100%;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  color: var(--tempest-fg-default);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+.am-chipin-menu-item:hover { background: var(--tempest-bg-hover); }
+.am-chipin-menu-name { font-family: "Geist Mono", monospace; }
+.am-chipin-menu-type { font-size: 10.5px; color: var(--tempest-fg-muted); }
+
+/* ── KV rows ────────────────────────────────────────────────────────────────── */
+
+.am-kv { display: flex; flex-direction: column; gap: 6px; }
+.am-kv-empty {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--tempest-fg-subtle);
+  font-style: italic;
+}
+.am-kv-row { display: flex; align-items: stretch; gap: 6px; }
+.am-kv-row--off { opacity: 0.45; }
+.am-kv-check { margin: 8px 2px 0 2px; }
+.am-kv-key { width: 32%; min-width: 120px; flex-shrink: 0; }
+.am-kv-val { flex: 1; min-width: 0; }
+.am-kv-del {
+  height: 32px; width: 32px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--tempest-fg-muted);
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.am-kv-del:hover { background: rgba(239, 68, 68, 0.1); color: rgb(239, 68, 68); }
+.am-kv-add {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px;
+  background: transparent;
+  border: 1px dashed var(--tempest-border-default);
+  border-radius: 6px;
+  color: var(--tempest-fg-muted);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+.am-kv-add:hover { color: var(--tempest-fg-default); border-color: var(--tempest-fg-muted); }
+
+/* ── Input schema (fields editor) ───────────────────────────────────────────── */
+
+.am-fields { display: flex; flex-direction: column; gap: 10px; }
+.am-fields-hint {
+  font-size: 12px;
+  color: var(--tempest-fg-muted);
+  line-height: 1.5;
+}
+.am-fldrow {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 8px;
+  background: var(--tempest-bg-hover);
+}
+.am-fldrow-head { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.am-fldrow-name { flex: 1; min-width: 140px; }
+.am-fldrow-type { width: 100px; flex-shrink: 0; }
+.am-fldrow-req {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 11.5px;
+  color: var(--tempest-fg-muted);
+  white-space: nowrap;
+}
+.am-fldrow-icon {
+  height: 30px; width: 30px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--tempest-fg-muted);
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.am-fldrow-icon:hover:not(:disabled) { background: var(--tempest-bg-active, var(--tempest-bg-hover)); color: var(--tempest-fg-default); }
+.am-fldrow-icon:disabled { opacity: 0.3; cursor: not-allowed; }
+.am-fldrow-del:hover { background: rgba(239, 68, 68, 0.1); color: rgb(239, 68, 68); }
+.am-fldrow-enum, .am-fldrow-desc { width: 100%; }
+
+/* ── Response mapper + Try it ───────────────────────────────────────────────── */
+
+.am-resp { display: flex; flex-direction: column; gap: 14px; }
+.am-resp-try {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 8px;
+  background: var(--tempest-bg-hover);
+}
+.am-resp-sample { display: flex; flex-direction: column; gap: 8px; }
+.am-resp-run { align-self: flex-start; display: inline-flex; align-items: center; gap: 6px; }
+.am-spin { animation: am-spin 0.9s linear infinite; }
+@keyframes am-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+
+.am-resp-result {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 8px;
+  background: var(--tempest-bg-editor);
+  max-height: 360px;
+  overflow-y: auto;
+}
+.am-resp-status { display: inline-flex; align-items: center; gap: 8px; }
+.am-resp-status-code {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px;
+  border-radius: 20px;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  font-weight: 600;
+}
+.am-resp-status-code--ok       { background: rgba( 34, 197,  94, 0.15); color: rgb( 34, 197,  94); }
+.am-resp-status-code--redirect { background: rgba(245, 158,  11, 0.15); color: rgb(245, 158,  11); }
+.am-resp-status-code--err      { background: rgba(239,  68,  68, 0.15); color: rgb(239,  68,  68); }
+.am-resp-status-code--unk      { background: rgba(107, 114, 128, 0.15); color: rgb(107, 114, 128); }
+
+/* ── JSON tree ──────────────────────────────────────────────────────────────── */
+
+.am-json-obj { display: flex; flex-direction: column; }
+.am-json-toggle {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--tempest-fg-muted);
+  font-family: "Geist Mono", monospace;
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.am-json-body { padding-left: 14px; border-left: 1px dashed var(--tempest-border-default); margin-left: 3px; }
+.am-json-row { display: flex; align-items: flex-start; gap: 6px; font-family: "Geist Mono", monospace; font-size: 12px; padding: 1px 0; }
+.am-json-key { color: var(--tempest-fg-default); }
+.am-json-key--idx { color: var(--tempest-fg-muted); }
+.am-json-key--pick { cursor: pointer; padding: 0 3px; border-radius: 3px; }
+.am-json-key--pick:hover { background: rgba(59, 130, 246, 0.15); }
+.am-json-key--on { background: rgba(59, 130, 246, 0.25); color: var(--tempest-fg-default); }
+.am-json-colon { color: var(--tempest-fg-muted); }
+.am-json-leaf { color: var(--tempest-fg-muted); }
+.am-json-leaf--str    { color: rgb(120, 200, 120); }
+.am-json-leaf--number { color: rgb( 90, 170, 255); }
+.am-json-leaf--boolean{ color: rgb(210, 130, 210); }
+.am-json-leaf--null   { color: var(--tempest-fg-subtle); font-style: italic; }
+.am-json-leaf--pick { cursor: pointer; padding: 0 3px; border-radius: 3px; }
+.am-json-leaf--pick:hover { background: rgba(59, 130, 246, 0.15); }
+.am-json-leaf--on { background: rgba(59, 130, 246, 0.25); }
+.am-json-empty { color: var(--tempest-fg-subtle); font-family: "Geist Mono", monospace; font-size: 12px; }
+
+/* ── Schedule: day picker + hour grid ───────────────────────────────────────── */
+
+.am-daypicker { display: flex; gap: 4px; flex-wrap: wrap; }
+.am-daypicker-btn {
+  padding: 6px 12px;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--tempest-fg-muted);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  min-width: 44px;
+}
+.am-daypicker-btn:hover { color: var(--tempest-fg-default); }
+.am-daypicker-btn--on {
+  background: rgba(59, 130, 246, 0.15);
+  border-color: rgba(59, 130, 246, 0.5);
+  color: var(--tempest-fg-default);
+}
+
+.am-hourgrid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 3px;
+}
+.am-hourgrid-btn {
+  padding: 6px 0;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--tempest-fg-muted);
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  cursor: pointer;
+  text-align: center;
+}
+.am-hourgrid-btn:hover { color: var(--tempest-fg-default); }
+.am-hourgrid-btn--on {
+  background: rgba(59, 130, 246, 0.15);
+  border-color: rgba(59, 130, 246, 0.5);
+  color: var(--tempest-fg-default);
+}
 
 /* ── Chat panel ─────────────────────────────────────────────────────────────── */
 

--- a/src/components/Automations/AutomationsPage.css
+++ b/src/components/Automations/AutomationsPage.css
@@ -15,416 +15,290 @@
 .am-header {
   flex-shrink: 0;
   display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 22px 32px 18px;
-  border-bottom: 1px solid var(--tempest-border-default);
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 32px 40px 20px;
 }
 
 .am-header-left {
   display: flex;
-  align-items: center;
-  gap: 9px;
+  flex-direction: column;
+  gap: 4px;
   min-width: 0;
+}
+
+.am-header-titlerow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .am-header-title {
   margin: 0;
-  font-size: 18px;
+  font-size: 22px;
   font-weight: 600;
   color: var(--tempest-fg-default);
-  letter-spacing: -0.022em;
-  line-height: 1.2;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
 }
 
 .am-header-count {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 20px;
   height: 20px;
-  padding: 0 6px;
-  border-radius: 999px;
+  padding: 0 7px;
+  border-radius: 6px;
   background: var(--tempest-bg-hover);
-  border: 1px solid var(--tempest-border-default);
-  color: var(--tempest-fg-subtle);
+  color: var(--tempest-fg-muted);
   font-family: "Geist Mono", monospace;
   font-size: 11px;
   line-height: 1;
 }
 
+.am-header-sub {
+  margin: 0;
+  font-size: 13px;
+  color: var(--tempest-fg-subtle);
+  letter-spacing: -0.005em;
+}
+
 .am-header-right {
-  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-/* ── Project picker ─────────────────────────────────────────────────────────── */
+/* ── Scope tabs ─────────────────────────────────────────────────────────────── */
 
-.am-picker {
+.am-tabs {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 40px;
+  border-bottom: 1px solid var(--tempest-border-default);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.am-tabs::-webkit-scrollbar { display: none; }
+
+.am-tab {
   position: relative;
-}
-
-.am-picker-btn {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  height: 30px;
-  padding: 0 9px 0 10px;
-  background: var(--tempest-bg-panel);
-  border: 1px solid var(--tempest-border-default);
-  border-radius: 999px;
-  color: var(--tempest-fg-muted);
-  font-size: 12px;
-  font-family: inherit;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-
-.am-picker-btn:hover,
-.am-picker-btn--open {
-  background: var(--tempest-bg-hover);
-  border-color: var(--tempest-border-subtle);
-  color: var(--tempest-fg-default);
-}
-
-.am-picker-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  background: var(--tempest-fg-subtle);
-  opacity: 0.55;
-}
-
-.am-picker-btn:hover .am-picker-dot,
-.am-picker-btn--open .am-picker-dot {
-  background: var(--tempest-accent-green);
-  opacity: 1;
-}
-
-.am-picker-label {
-  max-width: 150px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.am-picker-chevron {
-  opacity: 0.6;
-  transition: transform 0.15s ease;
-}
-
-.am-picker-btn--open .am-picker-chevron {
-  transform: rotate(180deg);
-  opacity: 1;
-}
-
-.am-picker-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  min-width: 190px;
-  padding: 4px;
-  background: var(--tempest-bg-panel);
-  border: 1px solid var(--tempest-border-default);
-  border-radius: 10px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28), 0 2px 6px rgba(0, 0, 0, 0.16);
-  overflow: hidden;
-  z-index: 50;
-  animation: am-pop 0.13s ease both;
-  transform-origin: top right;
-}
-
-@keyframes am-pop {
-  from { opacity: 0; transform: scale(0.97) translateY(-3px); }
-  to   { opacity: 1; transform: scale(1) translateY(0); }
-}
-
-.am-picker-item {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  width: 100%;
-  padding: 7px 9px;
-  background: transparent;
-  border: none;
-  border-radius: 6px;
-  color: var(--tempest-fg-muted);
-  font-size: 12px;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-  transition: background 0.09s ease, color 0.09s ease;
-}
-
-.am-picker-item:hover {
-  background: var(--tempest-bg-hover);
-  color: var(--tempest-fg-default);
-}
-
-.am-picker-item--active {
-  color: var(--tempest-fg-default);
-  font-weight: 500;
-}
-
-.am-picker-item-check {
-  width: 11px;
-  flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  color: var(--tempest-accent-green);
+  gap: 6px;
+  height: 38px;
+  padding: 0 12px;
+  background: transparent;
+  border: none;
+  color: var(--tempest-fg-subtle);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.1s ease;
 }
 
-.am-picker-item-name {
-  flex: 1;
-  white-space: nowrap;
+.am-tab::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: -1px;
+  height: 2px;
+  background: var(--tempest-fg-default);
+  border-radius: 2px 2px 0 0;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.am-tab:hover {
+  color: var(--tempest-fg-muted);
+}
+
+.am-tab--active {
+  color: var(--tempest-fg-default);
+}
+
+.am-tab--active::after {
+  opacity: 1;
+}
+
+.am-tab-icon {
+  color: currentColor;
+  opacity: 0.7;
+}
+
+.am-tab-label {
+  max-width: 180px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-/* ── New button ─────────────────────────────────────────────────────────────── */
+/* ── Primary button (New) ───────────────────────────────────────────────────── */
 
 .am-new-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 30px;
-  padding: 0 13px 0 11px;
-  background: var(--tempest-bg-panel);
-  border: 1px solid var(--tempest-border-subtle);
-  border-radius: 8px;
-  color: var(--tempest-fg-default);
-  font-size: 12px;
+  height: 32px;
+  padding: 0 12px 0 10px;
+  background: var(--tempest-fg-default);
+  border: 1px solid var(--tempest-fg-default);
+  border-radius: 6px;
+  color: var(--tempest-bg-editor);
+  font-size: 12.5px;
   font-family: inherit;
   font-weight: 500;
   letter-spacing: -0.005em;
   cursor: pointer;
   white-space: nowrap;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
-  transition: background 0.12s ease, border-color 0.12s ease, transform 0.12s ease,
-    box-shadow 0.12s ease;
+  transition: opacity 0.12s ease;
 }
 
 .am-new-btn:hover {
-  background: var(--tempest-bg-active);
-  border-color: var(--tempest-border-subtle);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  opacity: 0.88;
 }
 
 .am-new-btn:active {
-  transform: translateY(0);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  opacity: 0.78;
 }
 
-/* ── Scroll container + grid ────────────────────────────────────────────────── */
+.am-new-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ── Scroll container + list ────────────────────────────────────────────────── */
 
 .am-list {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
+  padding: 4px 40px 48px;
 }
 
-.am-grid {
+.am-rows {
+  border-top: 1px solid var(--tempest-border-default);
+  border-bottom: 1px solid var(--tempest-border-default);
+}
+
+/* ── Row ────────────────────────────────────────────────────────────────────── */
+
+.am-row {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 14px;
-  max-width: 1040px;
-  padding: 24px 32px 40px;
-  align-content: start;
-}
-
-/* ── Card ───────────────────────────────────────────────────────────────────── */
-
-.am-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  min-width: 0;
-  padding: 16px;
-  background: var(--tempest-bg-panel);
-  border: 1px solid var(--tempest-border-default);
-  border-radius: 12px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  animation: am-card-in 0.32s cubic-bezier(0.22, 1, 0.36, 1) both;
-  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease,
-    background 0.16s ease;
-}
-
-@keyframes am-card-in {
-  from { opacity: 0; transform: translateY(8px) scale(0.985); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-.am-card:hover {
-  background: var(--tempest-bg-hover);
-  border-color: var(--tempest-border-subtle);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2), 0 2px 6px rgba(0, 0, 0, 0.12);
-}
-
-.am-card--running {
-  border-color: color-mix(in srgb, var(--tempest-accent-green) 30%, var(--tempest-border-default));
-}
-
-.am-card--running::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 2px;
-  border-radius: 12px 0 0 12px;
-  background: var(--tempest-accent-green);
-  opacity: 0.65;
-}
-
-.am-card-top {
-  display: flex;
+  grid-template-columns: 20px 1fr auto auto;
   align-items: center;
-  gap: 10px;
-  min-width: 0;
+  gap: 16px;
+  padding: 14px 4px;
+  border-bottom: 1px solid var(--tempest-border-default);
+  cursor: pointer;
+  transition: background 0.1s ease;
+  animation: am-row-in 0.24s ease both;
 }
 
-.am-card-glyph {
-  display: inline-flex;
+.am-row:last-child {
+  border-bottom: none;
+}
+
+.am-row:hover {
+  background: var(--tempest-bg-hover);
+}
+
+@keyframes am-row-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.am-row-status {
+  display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-  border-radius: 8px;
-  background: var(--tempest-bg-hover);
-  border: 1px solid var(--tempest-border-default);
-  color: var(--tempest-fg-muted);
-  transition: color 0.16s ease, border-color 0.16s ease;
 }
 
-.am-card:hover .am-card-glyph {
-  color: var(--tempest-fg-default);
-  border-color: var(--tempest-border-subtle);
-}
-
-.am-card-body {
+.am-row-main {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   min-width: 0;
 }
 
-.am-card-name {
-  font-size: 14px;
-  font-weight: 550;
-  letter-spacing: -0.012em;
+.am-row-name {
+  font-size: 13.5px;
+  font-weight: 500;
   color: var(--tempest-fg-default);
+  letter-spacing: -0.01em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.am-card-slug {
+.am-row-slug {
   font-family: "Geist Mono", monospace;
-  font-size: 11px;
+  font-size: 11.5px;
   color: var(--tempest-fg-subtle);
-  opacity: 0.75;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-/* ── Status badges ──────────────────────────────────────────────────────────── */
+.am-row-meta {
+  font-size: 12px;
+  color: var(--tempest-fg-subtle);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
 
-.am-badge {
-  margin-left: auto;
-  flex-shrink: 0;
-  display: inline-flex;
+.am-row-meta--running {
+  color: var(--tempest-accent-green);
+  font-family: "Geist Mono", monospace;
+  font-size: 11.5px;
+}
+
+.am-row-actions {
+  display: flex;
   align-items: center;
-  gap: 6px;
-  height: 22px;
-  padding: 0 9px 0 8px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  transition: background 0.16s ease, border-color 0.16s ease;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
 }
 
-.am-badge--idle {
-  background: var(--tempest-bg-hover);
-  border-color: var(--tempest-border-default);
+.am-row:hover .am-row-actions,
+.am-row:focus-within .am-row-actions {
+  opacity: 1;
 }
 
-.am-badge--built {
-  background: color-mix(in srgb, var(--tempest-accent-green) 7%, transparent);
-  border-color: color-mix(in srgb, var(--tempest-accent-green) 20%, transparent);
-}
-
-.am-badge--running {
-  background: color-mix(in srgb, var(--tempest-accent-green) 14%, transparent);
-  border-color: color-mix(in srgb, var(--tempest-accent-green) 34%, transparent);
-}
-
-/* ── Status dots ────────────────────────────────────────────────────────────── */
+/* ── Status dot ─────────────────────────────────────────────────────────────── */
 
 .am-dot {
   display: block;
-  width: 6px;
-  height: 6px;
+  width: 7px;
+  height: 7px;
   flex-shrink: 0;
   border-radius: 50%;
 }
 
 .am-dot--idle {
   background: var(--tempest-fg-subtle);
-  opacity: 0.4;
+  opacity: 0.35;
 }
 
 .am-dot--built {
   background: var(--tempest-accent-green);
-  opacity: 0.7;
+  opacity: 0.55;
 }
 
 .am-dot--running {
   background: var(--tempest-accent-green);
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--tempest-accent-green) 60%, transparent);
-  animation: am-pulse 1.9s ease-out infinite;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--tempest-accent-green) 18%, transparent);
 }
 
-@keyframes am-pulse {
-  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--tempest-accent-green) 55%, transparent); }
-  70%  { box-shadow: 0 0 0 5px color-mix(in srgb, var(--tempest-accent-green) 0%, transparent); }
-  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--tempest-accent-green) 0%, transparent); }
-}
-
-/* ── Status meta text ───────────────────────────────────────────────────────── */
-
-.am-meta {
-  font-size: 10.5px;
-  font-family: "Geist Mono", monospace;
-  letter-spacing: -0.01em;
-  flex-shrink: 0;
-  white-space: nowrap;
-  line-height: 1;
-}
-
-.am-meta--idle    { color: var(--tempest-fg-subtle); opacity: 0.7; }
-.am-meta--built   { color: color-mix(in srgb, var(--tempest-accent-green) 75%, var(--tempest-fg-muted)); }
-.am-meta--running { color: var(--tempest-accent-green); }
-
-/* ── Card actions ───────────────────────────────────────────────────────────── */
-
-.am-card-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding-top: 12px;
-  border-top: 1px solid var(--tempest-border-default);
-}
-
-.am-card-actions-spacer {
-  flex: 1;
-}
+/* ── Row action buttons ─────────────────────────────────────────────────────── */
 
 .am-act {
   display: inline-flex;
@@ -432,17 +306,17 @@
   justify-content: center;
   gap: 5px;
   height: 28px;
-  padding: 0 11px;
+  padding: 0 10px;
   background: transparent;
   border: 1px solid var(--tempest-border-default);
-  border-radius: 7px;
+  border-radius: 6px;
   color: var(--tempest-fg-muted);
-  font-size: 11.5px;
+  font-size: 12px;
   font-family: inherit;
   font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  transition: background 0.1s ease, color 0.1s ease, border-color 0.1s ease;
 }
 
 .am-act:hover {
@@ -451,34 +325,16 @@
   color: var(--tempest-fg-default);
 }
 
-.am-act--primary {
-  background: var(--tempest-bg-hover);
-  border-color: var(--tempest-border-subtle);
-  color: var(--tempest-fg-default);
-}
-
-.am-act--primary:hover {
-  background: var(--tempest-bg-active);
-}
-
 .am-act--icon {
   width: 28px;
   padding: 0;
-  border-color: transparent;
-  opacity: 0;
-  transition: opacity 0.14s ease, background 0.12s ease, color 0.12s ease,
-    border-color 0.12s ease;
-}
-
-.am-card:hover .am-act--icon,
-.am-act--icon:focus-visible {
-  opacity: 1;
+  color: var(--tempest-fg-subtle);
 }
 
 .am-act--danger:hover {
-  background: color-mix(in srgb, var(--tempest-git-deleted) 12%, transparent);
   color: var(--tempest-git-deleted);
-  border-color: color-mix(in srgb, var(--tempest-git-deleted) 35%, transparent);
+  border-color: color-mix(in srgb, var(--tempest-git-deleted) 40%, var(--tempest-border-default));
+  background: color-mix(in srgb, var(--tempest-git-deleted) 8%, transparent);
 }
 
 /* ── Loading ────────────────────────────────────────────────────────────────── */
@@ -487,7 +343,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 64px;
+  padding: 80px;
   color: var(--tempest-fg-subtle);
 }
 
@@ -507,72 +363,54 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 88px 24px;
-  animation: am-card-in 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
-}
-
-.am-empty-art {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 64px;
-  height: 64px;
-  margin-bottom: 20px;
-  border-radius: 18px;
-  background: var(--tempest-bg-panel);
-  border: 1px solid var(--tempest-border-default);
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.14);
+  padding: 72px 24px;
+  border: 1px dashed var(--tempest-border-default);
+  border-radius: 10px;
+  margin-top: 8px;
 }
 
 .am-empty-icon {
-  color: var(--tempest-fg-muted);
-  opacity: 0.7;
+  color: var(--tempest-fg-subtle);
+  opacity: 0.6;
+  margin-bottom: 16px;
 }
 
 .am-empty-text {
   margin: 0;
-  font-size: 15px;
-  font-weight: 550;
-  letter-spacing: -0.015em;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   color: var(--tempest-fg-default);
 }
 
 .am-empty-sub {
   margin: 6px 0 20px;
-  max-width: 320px;
+  max-width: 340px;
   text-align: center;
   font-size: 12.5px;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--tempest-fg-subtle);
 }
 
 .am-empty-cta {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  height: 34px;
-  padding: 0 16px 0 13px;
-  background: var(--tempest-bg-panel);
-  border: 1px solid var(--tempest-border-subtle);
-  border-radius: 9px;
-  color: var(--tempest-fg-default);
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px 0 10px;
+  background: var(--tempest-fg-default);
+  border: 1px solid var(--tempest-fg-default);
+  border-radius: 6px;
+  color: var(--tempest-bg-editor);
   font-size: 12.5px;
   font-family: inherit;
   font-weight: 500;
   cursor: pointer;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
-  transition: background 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
+  transition: opacity 0.12s ease;
 }
 
 .am-empty-cta:hover {
-  background: var(--tempest-bg-active);
-  transform: translateY(-1px);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
-}
-
-.am-empty-cta:active {
-  transform: translateY(0);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  opacity: 0.88;
 }
 
 /* ── No open projects ───────────────────────────────────────────────────────── */
@@ -588,7 +426,7 @@
 
 .am-no-projects-icon {
   color: var(--tempest-fg-subtle);
-  opacity: 0.25;
+  opacity: 0.3;
 }
 
 .am-no-projects-text {
@@ -603,7 +441,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 16px;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--tempest-border-default);
 }
 
@@ -611,15 +449,15 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 7px;
+  padding: 4px 8px;
   background: transparent;
   border: none;
   border-radius: 5px;
   color: var(--tempest-fg-muted);
-  font-size: 12px;
+  font-size: 12.5px;
   font-family: inherit;
   cursor: pointer;
-  transition: background 0.08s, color 0.08s;
+  transition: background 0.1s ease, color 0.1s ease;
 }
 
 .am-back-btn:hover {
@@ -640,20 +478,484 @@
   color: var(--tempest-fg-default);
 }
 
+/* ── Builder shell ──────────────────────────────────────────────────────────── */
+
+.am-builder {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.am-builder-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.am-canvas {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+}
+
+/* ── Build bar ──────────────────────────────────────────────────────────────── */
+
+.am-buildbar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-panel, var(--tempest-bg-editor));
+}
+
+.am-buildbar-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--tempest-fg-muted);
+}
+
+.am-buildbar-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--tempest-fg-subtle);
+  display: inline-block;
+}
+.am-buildbar-dot--building,
+.am-buildbar-dot--starting { background: #f59e0b; animation: am-pulse 1.4s ease-in-out infinite; }
+.am-buildbar-dot--built    { background: #3b82f6; }
+.am-buildbar-dot--running  { background: #22c55e; }
+.am-buildbar-dot--error    { background: #ef4444; }
+
+@keyframes am-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.am-buildbar-state { font-weight: 500; color: var(--tempest-fg-default); }
+
+.am-buildbar-right { display: flex; gap: 8px; }
+
+.am-buildbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-editor);
+  color: var(--tempest-fg-default);
+  font: 500 12.5px/1 "Geist", sans-serif;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+.am-buildbar-btn:hover:not(:disabled) { background: var(--tempest-bg-hover); }
+.am-buildbar-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.am-buildbar-btn--primary {
+  background: var(--tempest-accent, #3b82f6);
+  border-color: transparent;
+  color: white;
+}
+.am-buildbar-btn--primary:hover:not(:disabled) { filter: brightness(1.05); }
+.am-buildbar-btn--stop {
+  background: transparent;
+  color: #ef4444;
+  border-color: #ef4444;
+}
+
+/* ── Node palette ───────────────────────────────────────────────────────────── */
+
+.am-palette {
+  width: 200px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--tempest-border-default);
+  padding: 12px 8px;
+  overflow-y: auto;
+  background: var(--tempest-bg-panel, var(--tempest-bg-editor));
+}
+
+.am-palette-group + .am-palette-group { margin-top: 14px; }
+
+.am-palette-label {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tempest-fg-subtle);
+  padding: 0 6px 6px;
+}
+
+.am-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 5px;
+  font-size: 12.5px;
+  color: var(--tempest-fg-default);
+  cursor: grab;
+  user-select: none;
+  transition: background 0.1s;
+}
+.am-palette-item:hover { background: var(--tempest-bg-hover); }
+.am-palette-item:active { cursor: grabbing; }
+.am-palette-item--disabled { opacity: 0.4; cursor: not-allowed; }
+.am-palette-icon { color: var(--tempest-fg-muted); display: inline-flex; }
+
+/* ── Node cards ─────────────────────────────────────────────────────────────── */
+
+.amn {
+  min-width: 160px;
+  border-radius: 8px;
+  border: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-editor);
+  padding: 10px 12px;
+  font-family: "Geist", sans-serif;
+  color: var(--tempest-fg-default);
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+.amn--selected { border-color: var(--tempest-accent, #3b82f6); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15); }
+
+.amn-body { display: flex; align-items: center; gap: 10px; }
+.amn-icon {
+  width: 26px; height: 26px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 6px;
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-muted);
+  flex-shrink: 0;
+}
+.amn-text { display: flex; flex-direction: column; min-width: 0; }
+.amn-title { font-size: 13px; font-weight: 600; line-height: 1.2; }
+.amn-sub {
+  font-size: 11px;
+  color: var(--tempest-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+
+/* Tone accents on the icon backdrop */
+.amn--trigger .amn-icon    { background: rgba(148, 163, 184, 0.15); color: #94a3b8; }
+.amn--agent .amn-icon      { background: rgba(59, 130, 246, 0.15);  color: #3b82f6; }
+.amn--tool .amn-icon       { background: rgba(34, 197, 94, 0.15);   color: #22c55e; }
+.amn--skill .amn-icon      { background: rgba(245, 158, 11, 0.15);  color: #f59e0b; }
+.amn--connection .amn-icon { background: rgba(6, 182, 212, 0.15);   color: #06b6d4; }
+.amn--subagent .amn-icon   { background: rgba(236, 72, 153, 0.15);  color: #ec4899; }
+
+/* React Flow handle sizing (default is too small) */
+.react-flow__handle { width: 8px; height: 8px; background: var(--tempest-fg-muted); border: 2px solid var(--tempest-bg-editor); }
+.react-flow__handle:hover { background: var(--tempest-accent, #3b82f6); }
+
+/* ── Save chip ──────────────────────────────────────────────────────────────── */
+
+.am-savechip {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  padding: 4px 8px;
+  font-size: 11px;
+  color: var(--tempest-fg-muted);
+  background: var(--tempest-bg-editor);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 5px;
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+  z-index: 5;
+}
+.am-savechip--saving { opacity: 1; }
+.am-savechip--saved  { opacity: 1; color: #22c55e; }
+
+/* ── Build output panel ─────────────────────────────────────────────────────── */
+
+.am-buildpanel {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  max-height: 40%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-radius: 6px;
+  border: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-editor);
+  z-index: 6;
+}
+.am-buildpanel--error { border-color: #ef4444; }
+.am-buildpanel-title {
+  padding: 6px 10px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--tempest-fg-muted);
+  border-bottom: 1px solid var(--tempest-border-default);
+}
+.am-buildpanel--error .am-buildpanel-title { color: #ef4444; }
+.am-buildpanel-pre {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--tempest-fg-default);
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Node modal ─────────────────────────────────────────────────────────────── */
+
+.am-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.am-modal {
+  width: 560px;
+  max-width: 92vw;
+  max-height: 82vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--tempest-bg-editor);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 10px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+.am-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--tempest-border-default);
+}
+.am-modal-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.am-modal-icon { color: var(--tempest-fg-muted); display: inline-flex; }
+.am-modal-close {
+  background: transparent;
+  border: none;
+  color: var(--tempest-fg-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+}
+.am-modal-close:hover { background: var(--tempest-bg-hover); color: var(--tempest-fg-default); }
+.am-modal-body {
+  padding: 14px 16px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.am-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-top: 1px solid var(--tempest-border-default);
+}
+.am-modal-primary {
+  padding: 6px 14px;
+  border-radius: 5px;
+  border: none;
+  background: var(--tempest-accent, #3b82f6);
+  color: white;
+  font: 500 12.5px "Geist", sans-serif;
+  cursor: pointer;
+}
+.am-modal-danger {
+  padding: 6px 10px;
+  border-radius: 5px;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: transparent;
+  color: #ef4444;
+  font: 500 12px "Geist", sans-serif;
+  cursor: pointer;
+}
+.am-modal-danger:hover { background: rgba(239, 68, 68, 0.1); }
+
+/* Modal fields */
+.am-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.am-field > span {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--tempest-fg-default);
+}
+.am-hint {
+  font-weight: 400;
+  color: var(--tempest-fg-subtle);
+  margin-left: 4px;
+}
+.am-input, .am-textarea {
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-panel, var(--tempest-bg-editor));
+  color: var(--tempest-fg-default);
+  font: 400 12.5px "Geist", sans-serif;
+  resize: vertical;
+  box-sizing: border-box;
+}
+.am-input:focus, .am-textarea:focus {
+  outline: none;
+  border-color: var(--tempest-accent, #3b82f6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+.am-mono { font-family: "Geist Mono", ui-monospace, monospace; font-size: 12px; }
+
+.am-tabs2 {
+  display: flex;
+  gap: 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--tempest-border-subtle);
+}
+.am-tabs2-btn {
+  padding: 5px 10px;
+  border-radius: 5px;
+  background: transparent;
+  border: none;
+  color: var(--tempest-fg-muted);
+  font: 500 12px "Geist", sans-serif;
+  cursor: pointer;
+}
+.am-tabs2-btn:hover { background: var(--tempest-bg-hover); }
+.am-tabs2-btn--active { background: var(--tempest-bg-hover); color: var(--tempest-fg-default); }
+
+/* ── Chat panel ─────────────────────────────────────────────────────────────── */
+
+.am-chat {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 380px;
+  background: var(--tempest-bg-editor);
+  border-left: 1px solid var(--tempest-border-default);
+  display: flex;
+  flex-direction: column;
+  z-index: 900;
+  box-shadow: -12px 0 40px rgba(0, 0, 0, 0.25);
+}
+.am-chat-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--tempest-border-default);
+}
+.am-chat-title { font-size: 12.5px; font-weight: 600; }
+.am-chat-close {
+  background: transparent;
+  border: none;
+  color: var(--tempest-fg-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+}
+.am-chat-close:hover { background: var(--tempest-bg-hover); color: var(--tempest-fg-default); }
+.am-chat-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.am-chat-empty {
+  color: var(--tempest-fg-subtle);
+  font-size: 12px;
+  text-align: center;
+  padding-top: 40px;
+}
+.am-chat-msg { display: flex; }
+.am-chat-msg--user { justify-content: flex-end; }
+.am-chat-msg-body {
+  max-width: 78%;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.am-chat-msg--user .am-chat-msg-body {
+  background: var(--tempest-accent, #3b82f6);
+  color: white;
+}
+.am-chat-msg--assistant .am-chat-msg-body {
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-default);
+}
+.am-chat-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--tempest-fg-muted);
+  font-size: 11.5px;
+}
+.am-chat-input-row {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--tempest-border-default);
+}
+.am-chat-input {
+  flex: 1;
+  padding: 7px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-panel, var(--tempest-bg-editor));
+  color: var(--tempest-fg-default);
+  font: 400 12.5px "Geist", sans-serif;
+  resize: none;
+}
+.am-chat-input:focus {
+  outline: none;
+  border-color: var(--tempest-accent, #3b82f6);
+}
+.am-chat-send {
+  padding: 0 12px;
+  border-radius: 5px;
+  border: none;
+  background: var(--tempest-accent, #3b82f6);
+  color: white;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.am-chat-send:disabled { opacity: 0.4; cursor: not-allowed; }
+
 /* ── Motion preference ──────────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
-  .am-card,
-  .am-empty,
-  .am-picker-menu {
-    animation: none;
-  }
-  .am-card:hover,
-  .am-new-btn:hover,
-  .am-empty-cta:hover {
-    transform: none;
-  }
-  .am-dot--running {
+  .am-row,
+  .am-picker-menu,
+  .am-buildbar-dot--building,
+  .am-buildbar-dot--starting {
     animation: none;
   }
 }

--- a/src/components/Automations/AutomationsPage.css
+++ b/src/components/Automations/AutomationsPage.css
@@ -1,0 +1,659 @@
+/* ── Root ───────────────────────────────────────────────────────────────────── */
+
+.am-root {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--tempest-bg-editor);
+  overflow: hidden;
+  font-family: "Geist", sans-serif;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────────── */
+
+.am-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 22px 32px 18px;
+  border-bottom: 1px solid var(--tempest-border-default);
+}
+
+.am-header-left {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.am-header-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--tempest-fg-default);
+  letter-spacing: -0.022em;
+  line-height: 1.2;
+}
+
+.am-header-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--tempest-bg-hover);
+  border: 1px solid var(--tempest-border-default);
+  color: var(--tempest-fg-subtle);
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.am-header-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── Project picker ─────────────────────────────────────────────────────────── */
+
+.am-picker {
+  position: relative;
+}
+
+.am-picker-btn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 30px;
+  padding: 0 9px 0 10px;
+  background: var(--tempest-bg-panel);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 999px;
+  color: var(--tempest-fg-muted);
+  font-size: 12px;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.am-picker-btn:hover,
+.am-picker-btn--open {
+  background: var(--tempest-bg-hover);
+  border-color: var(--tempest-border-subtle);
+  color: var(--tempest-fg-default);
+}
+
+.am-picker-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--tempest-fg-subtle);
+  opacity: 0.55;
+}
+
+.am-picker-btn:hover .am-picker-dot,
+.am-picker-btn--open .am-picker-dot {
+  background: var(--tempest-accent-green);
+  opacity: 1;
+}
+
+.am-picker-label {
+  max-width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.am-picker-chevron {
+  opacity: 0.6;
+  transition: transform 0.15s ease;
+}
+
+.am-picker-btn--open .am-picker-chevron {
+  transform: rotate(180deg);
+  opacity: 1;
+}
+
+.am-picker-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 190px;
+  padding: 4px;
+  background: var(--tempest-bg-panel);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28), 0 2px 6px rgba(0, 0, 0, 0.16);
+  overflow: hidden;
+  z-index: 50;
+  animation: am-pop 0.13s ease both;
+  transform-origin: top right;
+}
+
+@keyframes am-pop {
+  from { opacity: 0; transform: scale(0.97) translateY(-3px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.am-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 7px 9px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--tempest-fg-muted);
+  font-size: 12px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.09s ease, color 0.09s ease;
+}
+
+.am-picker-item:hover {
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-default);
+}
+
+.am-picker-item--active {
+  color: var(--tempest-fg-default);
+  font-weight: 500;
+}
+
+.am-picker-item-check {
+  width: 11px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--tempest-accent-green);
+}
+
+.am-picker-item-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── New button ─────────────────────────────────────────────────────────────── */
+
+.am-new-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 13px 0 11px;
+  background: var(--tempest-bg-panel);
+  border: 1px solid var(--tempest-border-subtle);
+  border-radius: 8px;
+  color: var(--tempest-fg-default);
+  font-size: 12px;
+  font-family: inherit;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  transition: background 0.12s ease, border-color 0.12s ease, transform 0.12s ease,
+    box-shadow 0.12s ease;
+}
+
+.am-new-btn:hover {
+  background: var(--tempest-bg-active);
+  border-color: var(--tempest-border-subtle);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+.am-new-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+/* ── Scroll container + grid ────────────────────────────────────────────────── */
+
+.am-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.am-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 14px;
+  max-width: 1040px;
+  padding: 24px 32px 40px;
+  align-content: start;
+}
+
+/* ── Card ───────────────────────────────────────────────────────────────────── */
+
+.am-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+  padding: 16px;
+  background: var(--tempest-bg-panel);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 12px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  animation: am-card-in 0.32s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease,
+    background 0.16s ease;
+}
+
+@keyframes am-card-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.985); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.am-card:hover {
+  background: var(--tempest-bg-hover);
+  border-color: var(--tempest-border-subtle);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2), 0 2px 6px rgba(0, 0, 0, 0.12);
+}
+
+.am-card--running {
+  border-color: color-mix(in srgb, var(--tempest-accent-green) 30%, var(--tempest-border-default));
+}
+
+.am-card--running::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 2px;
+  border-radius: 12px 0 0 12px;
+  background: var(--tempest-accent-green);
+  opacity: 0.65;
+}
+
+.am-card-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.am-card-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  background: var(--tempest-bg-hover);
+  border: 1px solid var(--tempest-border-default);
+  color: var(--tempest-fg-muted);
+  transition: color 0.16s ease, border-color 0.16s ease;
+}
+
+.am-card:hover .am-card-glyph {
+  color: var(--tempest-fg-default);
+  border-color: var(--tempest-border-subtle);
+}
+
+.am-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.am-card-name {
+  font-size: 14px;
+  font-weight: 550;
+  letter-spacing: -0.012em;
+  color: var(--tempest-fg-default);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.am-card-slug {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--tempest-fg-subtle);
+  opacity: 0.75;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Status badges ──────────────────────────────────────────────────────────── */
+
+.am-badge {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 9px 0 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: background 0.16s ease, border-color 0.16s ease;
+}
+
+.am-badge--idle {
+  background: var(--tempest-bg-hover);
+  border-color: var(--tempest-border-default);
+}
+
+.am-badge--built {
+  background: color-mix(in srgb, var(--tempest-accent-green) 7%, transparent);
+  border-color: color-mix(in srgb, var(--tempest-accent-green) 20%, transparent);
+}
+
+.am-badge--running {
+  background: color-mix(in srgb, var(--tempest-accent-green) 14%, transparent);
+  border-color: color-mix(in srgb, var(--tempest-accent-green) 34%, transparent);
+}
+
+/* ── Status dots ────────────────────────────────────────────────────────────── */
+
+.am-dot {
+  display: block;
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+.am-dot--idle {
+  background: var(--tempest-fg-subtle);
+  opacity: 0.4;
+}
+
+.am-dot--built {
+  background: var(--tempest-accent-green);
+  opacity: 0.7;
+}
+
+.am-dot--running {
+  background: var(--tempest-accent-green);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--tempest-accent-green) 60%, transparent);
+  animation: am-pulse 1.9s ease-out infinite;
+}
+
+@keyframes am-pulse {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--tempest-accent-green) 55%, transparent); }
+  70%  { box-shadow: 0 0 0 5px color-mix(in srgb, var(--tempest-accent-green) 0%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--tempest-accent-green) 0%, transparent); }
+}
+
+/* ── Status meta text ───────────────────────────────────────────────────────── */
+
+.am-meta {
+  font-size: 10.5px;
+  font-family: "Geist Mono", monospace;
+  letter-spacing: -0.01em;
+  flex-shrink: 0;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.am-meta--idle    { color: var(--tempest-fg-subtle); opacity: 0.7; }
+.am-meta--built   { color: color-mix(in srgb, var(--tempest-accent-green) 75%, var(--tempest-fg-muted)); }
+.am-meta--running { color: var(--tempest-accent-green); }
+
+/* ── Card actions ───────────────────────────────────────────────────────────── */
+
+.am-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 12px;
+  border-top: 1px solid var(--tempest-border-default);
+}
+
+.am-card-actions-spacer {
+  flex: 1;
+}
+
+.am-act {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 11px;
+  background: transparent;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 7px;
+  color: var(--tempest-fg-muted);
+  font-size: 11.5px;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.am-act:hover {
+  background: var(--tempest-bg-active);
+  border-color: var(--tempest-border-subtle);
+  color: var(--tempest-fg-default);
+}
+
+.am-act--primary {
+  background: var(--tempest-bg-hover);
+  border-color: var(--tempest-border-subtle);
+  color: var(--tempest-fg-default);
+}
+
+.am-act--primary:hover {
+  background: var(--tempest-bg-active);
+}
+
+.am-act--icon {
+  width: 28px;
+  padding: 0;
+  border-color: transparent;
+  opacity: 0;
+  transition: opacity 0.14s ease, background 0.12s ease, color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.am-card:hover .am-act--icon,
+.am-act--icon:focus-visible {
+  opacity: 1;
+}
+
+.am-act--danger:hover {
+  background: color-mix(in srgb, var(--tempest-git-deleted) 12%, transparent);
+  color: var(--tempest-git-deleted);
+  border-color: color-mix(in srgb, var(--tempest-git-deleted) 35%, transparent);
+}
+
+/* ── Loading ────────────────────────────────────────────────────────────────── */
+
+.am-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 64px;
+  color: var(--tempest-fg-subtle);
+}
+
+@keyframes am-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+.am-spin {
+  animation: am-spin 1s linear infinite;
+}
+
+/* ── Empty state ────────────────────────────────────────────────────────────── */
+
+.am-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 88px 24px;
+  animation: am-card-in 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.am-empty-art {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  margin-bottom: 20px;
+  border-radius: 18px;
+  background: var(--tempest-bg-panel);
+  border: 1px solid var(--tempest-border-default);
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.14);
+}
+
+.am-empty-icon {
+  color: var(--tempest-fg-muted);
+  opacity: 0.7;
+}
+
+.am-empty-text {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 550;
+  letter-spacing: -0.015em;
+  color: var(--tempest-fg-default);
+}
+
+.am-empty-sub {
+  margin: 6px 0 20px;
+  max-width: 320px;
+  text-align: center;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--tempest-fg-subtle);
+}
+
+.am-empty-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 34px;
+  padding: 0 16px 0 13px;
+  background: var(--tempest-bg-panel);
+  border: 1px solid var(--tempest-border-subtle);
+  border-radius: 9px;
+  color: var(--tempest-fg-default);
+  font-size: 12.5px;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  transition: background 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.am-empty-cta:hover {
+  background: var(--tempest-bg-active);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+}
+
+.am-empty-cta:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+/* ── No open projects ───────────────────────────────────────────────────────── */
+
+.am-no-projects {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.am-no-projects-icon {
+  color: var(--tempest-fg-subtle);
+  opacity: 0.25;
+}
+
+.am-no-projects-text {
+  font-size: 13px;
+  color: var(--tempest-fg-subtle);
+}
+
+/* ── Builder topbar ─────────────────────────────────────────────────────────── */
+
+.am-builder-topbar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--tempest-border-default);
+}
+
+.am-back-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 7px;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  color: var(--tempest-fg-muted);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.08s, color 0.08s;
+}
+
+.am-back-btn:hover {
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-default);
+}
+
+.am-builder-sep {
+  font-size: 13px;
+  color: var(--tempest-fg-subtle);
+  user-select: none;
+  opacity: 0.4;
+}
+
+.am-builder-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--tempest-fg-default);
+}
+
+/* ── Motion preference ──────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .am-card,
+  .am-empty,
+  .am-picker-menu {
+    animation: none;
+  }
+  .am-card:hover,
+  .am-new-btn:hover,
+  .am-empty-cta:hover {
+    transform: none;
+  }
+  .am-dot--running {
+    animation: none;
+  }
+}

--- a/src/components/Automations/AutomationsPage.tsx
+++ b/src/components/Automations/AutomationsPage.tsx
@@ -15,8 +15,8 @@ interface Automation {
 
 export function AutomationsPage() {
   const projects = getOpenProjects();
-  // Default to first project; Global is opt-in (backend doesn't scope to it yet).
-  const [scope, setScope] = useState<string | null>(() => projects[0]?.id ?? null);
+  // scope: null = Global (unbound automations), otherwise project id.
+  const [scope, setScope] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedName, setSelectedName] = useState("");
   const [selected, setSelected] = useState<Automation | null>(null);

--- a/src/components/Automations/AutomationsPage.tsx
+++ b/src/components/Automations/AutomationsPage.tsx
@@ -1,31 +1,32 @@
-import { useState } from "react";
-import { ReactFlow, Background, Controls, MiniMap } from "@xyflow/react";
-import "@xyflow/react/dist/style.css";
-import { ChevronLeft, Workflow } from "lucide-react";
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { ChevronLeft } from "lucide-react";
 import { getOpenProjects } from "../../store/openProjects";
-import { useTheme } from "../../themes/ThemeContext";
 import { AutomationsList } from "./AutomationsList";
+import { AutomationBuilder } from "./builder/AutomationBuilder";
 import "./AutomationsPage.css";
+
+interface Automation {
+  id: string;
+  name: string;
+  graph: string;
+  builtAt: string | null;
+}
 
 export function AutomationsPage() {
   const projects = getOpenProjects();
-  const [projectId, setProjectId] = useState<string | null>(projects[0]?.id ?? null);
+  // Default to first project; Global is opt-in (backend doesn't scope to it yet).
+  const [scope, setScope] = useState<string | null>(() => projects[0]?.id ?? null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedName, setSelectedName] = useState("");
-  const { theme } = useTheme();
+  const [selected, setSelected] = useState<Automation | null>(null);
 
-  const project = projects.find(p => p.id === projectId) ?? projects[0] ?? null;
-
-  if (!project) {
-    return (
-      <div className="am-root">
-        <div className="am-no-projects">
-          <Workflow size={28} className="am-no-projects-icon" />
-          <p className="am-no-projects-text">Open a project to use Automations.</p>
-        </div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (!selectedId) { setSelected(null); return; }
+    invoke<Automation>("get_automation", { id: selectedId })
+      .then(setSelected)
+      .catch(() => setSelected(null));
+  }, [selectedId]);
 
   if (selectedId) {
     return (
@@ -38,13 +39,14 @@ export function AutomationsPage() {
           <span className="am-builder-sep">/</span>
           <span className="am-builder-name">{selectedName}</span>
         </div>
-        <div style={{ flex: 1, minHeight: 0 }}>
-          <ReactFlow nodes={[]} edges={[]} proOptions={{ hideAttribution: true }} colorMode={theme.type}>
-            <Background id="am-bg" bgColor="var(--tempest-bg-editor)" color="var(--tempest-border-subtle)" gap={28} size={2.5} />
-            <Controls />
-            <MiniMap pannable zoomable />
-          </ReactFlow>
-        </div>
+        {selected && (
+          <AutomationBuilder
+            automationId={selected.id}
+            initialGraph={selected.graph}
+            builtAt={selected.builtAt}
+            onBuiltAtChange={v => setSelected(prev => prev ? { ...prev, builtAt: v } : prev)}
+          />
+        )}
       </div>
     );
   }
@@ -52,8 +54,8 @@ export function AutomationsPage() {
   return (
     <AutomationsList
       projects={projects}
-      project={project}
-      onSelectProject={setProjectId}
+      scope={scope}
+      onSelectScope={setScope}
       onOpen={(id, name) => { setSelectedId(id); setSelectedName(name); }}
     />
   );

--- a/src/components/Automations/AutomationsPage.tsx
+++ b/src/components/Automations/AutomationsPage.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { ReactFlow, Background, Controls, MiniMap } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { ChevronLeft, Workflow } from "lucide-react";
+import { getOpenProjects } from "../../store/openProjects";
+import { useTheme } from "../../themes/ThemeContext";
+import { AutomationsList } from "./AutomationsList";
+import "./AutomationsPage.css";
+
+export function AutomationsPage() {
+  const projects = getOpenProjects();
+  const [projectId, setProjectId] = useState<string | null>(projects[0]?.id ?? null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedName, setSelectedName] = useState("");
+  const { theme } = useTheme();
+
+  const project = projects.find(p => p.id === projectId) ?? projects[0] ?? null;
+
+  if (!project) {
+    return (
+      <div className="am-root">
+        <div className="am-no-projects">
+          <Workflow size={28} className="am-no-projects-icon" />
+          <p className="am-no-projects-text">Open a project to use Automations.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (selectedId) {
+    return (
+      <div className="am-root">
+        <div className="am-builder-topbar">
+          <button className="am-back-btn" onClick={() => setSelectedId(null)}>
+            <ChevronLeft size={14} />
+            Automations
+          </button>
+          <span className="am-builder-sep">/</span>
+          <span className="am-builder-name">{selectedName}</span>
+        </div>
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <ReactFlow nodes={[]} edges={[]} proOptions={{ hideAttribution: true }} colorMode={theme.type}>
+            <Background id="am-bg" bgColor="var(--tempest-bg-editor)" color="var(--tempest-border-subtle)" gap={28} size={2.5} />
+            <Controls />
+            <MiniMap pannable zoomable />
+          </ReactFlow>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <AutomationsList
+      projects={projects}
+      project={project}
+      onSelectProject={setProjectId}
+      onOpen={(id, name) => { setSelectedId(id); setSelectedName(name); }}
+    />
+  );
+}

--- a/src/components/Automations/builder/AutomationBuilder.tsx
+++ b/src/components/Automations/builder/AutomationBuilder.tsx
@@ -185,16 +185,7 @@ function Inner({ automationId, initialGraph, builtAt, onBuiltAtChange }: Props) 
     e.dataTransfer.dropEffect = "move";
   };
 
-  const onDropCanvas = (e: React.DragEvent) => {
-    e.preventDefault();
-    const kind = e.dataTransfer.getData("application/tempest-node") as NodeKind;
-    if (!kind) return;
-    if (!wrapperRef.current) return;
-    const rect = wrapperRef.current.getBoundingClientRect();
-    const position = rf.screenToFlowPosition({
-      x: e.clientX - rect.left,
-      y: e.clientY - rect.top,
-    });
+  const addNodeAt = useCallback((kind: NodeKind, position: { x: number; y: number }) => {
     const id = `${kind}-${Math.random().toString(36).slice(2, 9)}`;
     const data = structuredClone(NODE_DEFAULTS[kind]);
     setNodes(prev => {
@@ -202,12 +193,34 @@ function Inner({ automationId, initialGraph, builtAt, onBuiltAtChange }: Props) 
       scheduleSave({ nodes: next, edges });
       return next;
     });
+  }, [edges, scheduleSave]);
+
+  const onDropCanvas = (e: React.DragEvent) => {
+    e.preventDefault();
+    const kind = e.dataTransfer.getData("application/tempest-node") as NodeKind;
+    if (!kind) return;
+    // screenToFlowPosition takes viewport (client) coords; don't subtract offsets.
+    const position = rf.screenToFlowPosition({ x: e.clientX, y: e.clientY });
+    addNodeAt(kind, position);
   };
 
   const handleDragStartFromPalette = (kind: NodeKind, e: React.DragEvent) => {
     e.dataTransfer.setData("application/tempest-node", kind);
     e.dataTransfer.effectAllowed = "move";
   };
+
+  // Click a palette item → drop node near the viewport centre with a small
+  // scatter so successive clicks don't stack on the same pixel.
+  const handleClickFromPalette = useCallback((kind: NodeKind) => {
+    if (!wrapperRef.current) return;
+    const rect = wrapperRef.current.getBoundingClientRect();
+    const jitter = () => (Math.random() - 0.5) * 60;
+    const position = rf.screenToFlowPosition({
+      x: rect.left + rect.width / 2 + jitter(),
+      y: rect.top + rect.height / 2 + jitter(),
+    });
+    addNodeAt(kind, position);
+  }, [rf, addNodeAt]);
 
   const selectedNode = selectedId
     ? (() => {
@@ -302,7 +315,11 @@ function Inner({ automationId, initialGraph, builtAt, onBuiltAtChange }: Props) 
         onOpenChat={hasManualTrigger && port ? () => setChatOpen(true) : undefined}
       />
       <div className="am-builder-body">
-        <NodePalette hasAgent={hasAgent} onDragStart={handleDragStartFromPalette} />
+        <NodePalette
+          hasAgent={hasAgent}
+          onDragStart={handleDragStartFromPalette}
+          onClick={handleClickFromPalette}
+        />
         <div className="am-canvas" ref={wrapperRef} onDragOver={onDragOverCanvas} onDrop={onDropCanvas}>
           <ReactFlow
             nodes={nodes}

--- a/src/components/Automations/builder/AutomationBuilder.tsx
+++ b/src/components/Automations/builder/AutomationBuilder.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow, ReactFlowProvider, Background, Controls, MiniMap,
-  addEdge, applyEdgeChanges, applyNodeChanges, useReactFlow,
+  addEdge, applyEdgeChanges, applyNodeChanges, useReactFlow, ConnectionMode,
   type Node as RFNode, type Edge as RFEdge, type Connection,
-  type NodeChange, type EdgeChange,
+  type NodeChange, type EdgeChange, type EdgeTypes,
 } from "@xyflow/react";
+import { AutomationEdge } from "./AutomationEdge";
 import "@xyflow/react/dist/style.css";
 import { invoke } from "@tauri-apps/api/core";
 import { useTheme } from "../../../themes/ThemeContext";
@@ -27,12 +28,29 @@ interface Props {
 const NODE_DEFAULTS: Record<NodeKind, Node["data"]> = {
   "trigger-manual": { label: "" },
   "trigger-schedule": { cron: "0 9 * * 1-5", prompt: "" },
+  // P8: trigger channels — all share the TriggerChannelData shape.
+  "trigger-linear":   { fields: [], secrets: [], prompt: "" },
+  "trigger-discord":  { fields: [], secrets: [], prompt: "" },
+  "trigger-telegram": { fields: [], secrets: [], prompt: "" },
+  "trigger-teams":    { fields: [], secrets: [], prompt: "" },
+  "trigger-photon":   { fields: [], secrets: [], prompt: "" },
+  "trigger-poll":     { fields: [], secrets: [], prompt: "" },
   "agent": { model: "anthropic/claude-sonnet-5", instructions: "", sandbox: "auto" },
-  "tool": { name: "new_tool", description: "", preset: "http", httpMethod: "GET", httpUrl: "" },
+  "tool": {
+    name: "new_tool",
+    description: "",
+    request: { method: "GET", url: "", queryParams: [], headers: [], auth: { kind: "none" }, body: { kind: "none" } },
+    input: { fields: [] },
+    response: { kind: "raw" },
+  },
   "skill": { name: "new_skill", markdown: "" },
   "connection": { name: "new_connection", kind: "mcp", url: "" },
   "subagent": { name: "researcher", model: "anthropic/claude-sonnet-5", description: "", instructions: "" },
+  // P6/P7: a flow is a callable capability with a linear step-tree.
+  "flow": { name: "new_flow", description: "", input: { fields: [] }, steps: [] },
 };
+
+const edgeTypes: EdgeTypes = { auto: AutomationEdge };
 
 function toRF(g: Graph): { nodes: RFNode[]; edges: RFEdge[] } {
   return {
@@ -46,9 +64,9 @@ function toRF(g: Graph): { nodes: RFNode[]; edges: RFEdge[] } {
       id: e.id,
       source: e.source,
       target: e.target,
+      type: "auto",
       data: { kind: e.kind },
-      style: { stroke: edgeColor(e.kind), strokeWidth: 1.5 },
-      animated: false,
+      style: { stroke: edgeColor(e.kind), strokeWidth: 3 },
     })),
   };
 }
@@ -70,15 +88,8 @@ function fromRF(nodes: RFNode[], edges: RFEdge[]): Graph {
   };
 }
 
-function edgeColor(k: EdgeKind): string {
-  switch (k) {
-    case "fires": return "var(--tempest-fg-muted, #888)";
-    case "model": return "#8b5cf6";
-    case "tool": return "#22c55e";
-    case "skill": return "#f59e0b";
-    case "connection": return "#06b6d4";
-    case "subagent": return "#ec4899";
-  }
+function edgeColor(_k: EdgeKind): string {
+  return "var(--tempest-accent-yellow, #f5c518)";
 }
 
 function edgeKindFor(sourceKind: NodeKind, targetKind: NodeKind): EdgeKind | null {
@@ -86,6 +97,7 @@ function edgeKindFor(sourceKind: NodeKind, targetKind: NodeKind): EdgeKind | nul
   if (sourceKind === "agent") {
     switch (targetKind) {
       case "tool": return "tool";
+      case "flow": return "flow";
       case "skill": return "skill";
       case "connection": return "connection";
       case "subagent": return "subagent";
@@ -161,8 +173,9 @@ function Inner({ automationId, initialGraph, builtAt, onBuiltAtChange }: Props) 
     setEdges(prev => {
       const next = addEdge({
         ...c,
+        type: "auto",
         data: { kind },
-        style: { stroke: edgeColor(kind), strokeWidth: 1.5 },
+        style: { stroke: edgeColor(kind), strokeWidth: 3 },
       }, prev);
       scheduleSave({ nodes, edges: next });
       return next;
@@ -331,10 +344,14 @@ function Inner({ automationId, initialGraph, builtAt, onBuiltAtChange }: Props) 
             onNodeClick={onNodeClick}
             onPaneClick={onPaneClick}
             nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
             colorMode={theme.type}
             proOptions={{ hideAttribution: true }}
             fitView={nodes.length > 0}
             fitViewOptions={{ padding: 0.3, maxZoom: 1 }}
+            connectOnClick
+            connectionMode={ConnectionMode.Loose}
+            connectionLineStyle={{ stroke: "var(--tempest-accent-yellow, #f5c518)", strokeWidth: 3 }}
           >
             <Background
               id="am-bg"

--- a/src/components/Automations/builder/AutomationBuilder.tsx
+++ b/src/components/Automations/builder/AutomationBuilder.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactFlow, ReactFlowProvider, Background, Controls, MiniMap,
+  addEdge, applyEdgeChanges, applyNodeChanges, useReactFlow,
+  type Node as RFNode, type Edge as RFEdge, type Connection,
+  type NodeChange, type EdgeChange,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { invoke } from "@tauri-apps/api/core";
+import { useTheme } from "../../../themes/ThemeContext";
+import {
+  parseGraph, type Graph, type Node, type NodeKind, type EdgeKind,
+} from "./graph";
+import { nodeTypes } from "./nodes";
+import { NodePalette } from "./NodePalette";
+import { BuildBar, type BuildState } from "./BuildBar";
+import { NodeModal } from "./NodeModal";
+import { ChatPanel } from "./ChatPanel";
+
+interface Props {
+  automationId: string;
+  initialGraph: string;
+  builtAt: string | null;
+  onBuiltAtChange: (v: string | null) => void;
+}
+
+const NODE_DEFAULTS: Record<NodeKind, Node["data"]> = {
+  "trigger-manual": { label: "" },
+  "trigger-schedule": { cron: "0 9 * * 1-5", prompt: "" },
+  "agent": { model: "anthropic/claude-sonnet-5", instructions: "", sandbox: "auto" },
+  "tool": { name: "new_tool", description: "", preset: "http", httpMethod: "GET", httpUrl: "" },
+  "skill": { name: "new_skill", markdown: "" },
+  "connection": { name: "new_connection", kind: "mcp", url: "" },
+  "subagent": { name: "researcher", model: "anthropic/claude-sonnet-5", description: "", instructions: "" },
+};
+
+function toRF(g: Graph): { nodes: RFNode[]; edges: RFEdge[] } {
+  return {
+    nodes: g.nodes.map(n => ({
+      id: n.id,
+      type: n.kind,
+      position: n.position,
+      data: n.data as Record<string, unknown>,
+    })),
+    edges: g.edges.map(e => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      data: { kind: e.kind },
+      style: { stroke: edgeColor(e.kind), strokeWidth: 1.5 },
+      animated: false,
+    })),
+  };
+}
+
+function fromRF(nodes: RFNode[], edges: RFEdge[]): Graph {
+  return {
+    nodes: nodes.map(n => ({
+      id: n.id,
+      kind: (n.type as NodeKind) ?? "agent",
+      position: n.position,
+      data: n.data as never,
+    } as Node)),
+    edges: edges.map(e => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      kind: ((e.data as { kind?: EdgeKind } | undefined)?.kind ?? "tool") as EdgeKind,
+    })),
+  };
+}
+
+function edgeColor(k: EdgeKind): string {
+  switch (k) {
+    case "fires": return "var(--tempest-fg-muted, #888)";
+    case "model": return "#8b5cf6";
+    case "tool": return "#22c55e";
+    case "skill": return "#f59e0b";
+    case "connection": return "#06b6d4";
+    case "subagent": return "#ec4899";
+  }
+}
+
+function edgeKindFor(sourceKind: NodeKind, targetKind: NodeKind): EdgeKind | null {
+  if (sourceKind.startsWith("trigger-") && targetKind === "agent") return "fires";
+  if (sourceKind === "agent") {
+    switch (targetKind) {
+      case "tool": return "tool";
+      case "skill": return "skill";
+      case "connection": return "connection";
+      case "subagent": return "subagent";
+      default: return null;
+    }
+  }
+  return null;
+}
+
+function Inner({ automationId, initialGraph, builtAt, onBuiltAtChange }: Props) {
+  const { theme } = useTheme();
+  const rf = useReactFlow();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const initial = useMemo(() => toRF(parseGraph(initialGraph)), [initialGraph]);
+  const [nodes, setNodes] = useState<RFNode[]>(initial.nodes);
+  const [edges, setEdges] = useState<RFEdge[]>(initial.edges);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [buildState, setBuildState] = useState<BuildState>("idle");
+  const [buildOutput, setBuildOutput] = useState<string>("");
+  const [port, setPort] = useState<number | undefined>(undefined);
+  const [chatOpen, setChatOpen] = useState(false);
+  const [savingLabel, setSavingLabel] = useState<"idle" | "saving" | "saved">("idle");
+  const saveTimer = useRef<number | null>(null);
+
+  // Detect existing process (page reopen with a still-running agent).
+  useEffect(() => {
+    invoke<{ port: number; pid: number } | null>("get_automation_process", { id: automationId })
+      .then(p => {
+        if (p) { setPort(p.port); setBuildState("running"); }
+      })
+      .catch(() => {});
+  }, [automationId]);
+
+  const scheduleSave = useCallback((next: { nodes: RFNode[]; edges: RFEdge[] }) => {
+    setSavingLabel("saving");
+    if (saveTimer.current) window.clearTimeout(saveTimer.current);
+    saveTimer.current = window.setTimeout(() => {
+      const g = fromRF(next.nodes, next.edges);
+      invoke("update_automation", { id: automationId, req: { graph: JSON.stringify(g) } })
+        .then(() => {
+          setSavingLabel("saved");
+          window.setTimeout(() => setSavingLabel("idle"), 900);
+          // Graph changed → treat as needing rebuild if it was previously built.
+          if (buildState === "built") setBuildState("idle");
+        })
+        .catch(() => setSavingLabel("idle"));
+    }, 500);
+  }, [automationId, buildState]);
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes(prev => {
+      const next = applyNodeChanges(changes, prev);
+      const meaningful = changes.some(c => c.type === "position" ? !c.dragging : true);
+      if (meaningful) scheduleSave({ nodes: next, edges });
+      return next;
+    });
+  }, [edges, scheduleSave]);
+
+  const onEdgesChange = useCallback((changes: EdgeChange[]) => {
+    setEdges(prev => {
+      const next = applyEdgeChanges(changes, prev);
+      scheduleSave({ nodes, edges: next });
+      return next;
+    });
+  }, [nodes, scheduleSave]);
+
+  const onConnect = useCallback((c: Connection) => {
+    const src = nodes.find(n => n.id === c.source);
+    const tgt = nodes.find(n => n.id === c.target);
+    if (!src || !tgt) return;
+    const kind = edgeKindFor(src.type as NodeKind, tgt.type as NodeKind);
+    if (!kind) return;
+    setEdges(prev => {
+      const next = addEdge({
+        ...c,
+        data: { kind },
+        style: { stroke: edgeColor(kind), strokeWidth: 1.5 },
+      }, prev);
+      scheduleSave({ nodes, edges: next });
+      return next;
+    });
+  }, [nodes, scheduleSave]);
+
+  const isValidConnection = useCallback((c: Connection | RFEdge) => {
+    const src = nodes.find(n => n.id === c.source);
+    const tgt = nodes.find(n => n.id === c.target);
+    if (!src || !tgt) return false;
+    return edgeKindFor(src.type as NodeKind, tgt.type as NodeKind) !== null;
+  }, [nodes]);
+
+  const onNodeClick = useCallback((_: React.MouseEvent, n: RFNode) => setSelectedId(n.id), []);
+
+  const onPaneClick = useCallback(() => setSelectedId(null), []);
+
+  const onDragOverCanvas = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  };
+
+  const onDropCanvas = (e: React.DragEvent) => {
+    e.preventDefault();
+    const kind = e.dataTransfer.getData("application/tempest-node") as NodeKind;
+    if (!kind) return;
+    if (!wrapperRef.current) return;
+    const rect = wrapperRef.current.getBoundingClientRect();
+    const position = rf.screenToFlowPosition({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    });
+    const id = `${kind}-${Math.random().toString(36).slice(2, 9)}`;
+    const data = structuredClone(NODE_DEFAULTS[kind]);
+    setNodes(prev => {
+      const next = [...prev, { id, type: kind, position, data: data as Record<string, unknown> }];
+      scheduleSave({ nodes: next, edges });
+      return next;
+    });
+  };
+
+  const handleDragStartFromPalette = (kind: NodeKind, e: React.DragEvent) => {
+    e.dataTransfer.setData("application/tempest-node", kind);
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  const selectedNode = selectedId
+    ? (() => {
+        const rfn = nodes.find(n => n.id === selectedId);
+        if (!rfn) return null;
+        return {
+          id: rfn.id,
+          kind: rfn.type as NodeKind,
+          position: rfn.position,
+          data: rfn.data,
+        } as Node;
+      })()
+    : null;
+
+  const updateSelected = (data: Node["data"]) => {
+    if (!selectedId) return;
+    setNodes(prev => {
+      const next = prev.map(n => n.id === selectedId ? { ...n, data: data as Record<string, unknown> } : n);
+      scheduleSave({ nodes: next, edges });
+      return next;
+    });
+  };
+
+  const deleteSelected = () => {
+    if (!selectedId) return;
+    setNodes(prev => {
+      const next = prev.filter(n => n.id !== selectedId);
+      const nextEdges = edges.filter(e => e.source !== selectedId && e.target !== selectedId);
+      setEdges(nextEdges);
+      scheduleSave({ nodes: next, edges: nextEdges });
+      return next;
+    });
+    setSelectedId(null);
+  };
+
+  const hasAgent = useMemo(() => nodes.some(n => n.type === "agent"), [nodes]);
+  const hasManualTrigger = useMemo(
+    () => nodes.some(n => n.type === "trigger-manual") &&
+          edges.some(e => (e.data as { kind?: EdgeKind } | undefined)?.kind === "fires"),
+    [nodes, edges]
+  );
+
+  const handleBuild = async () => {
+    setBuildState("building");
+    setBuildOutput("");
+    try {
+      const res = await invoke<{ success: boolean; output: string; durationMs: number }>(
+        "build_automation", { id: automationId }
+      );
+      if (res.success) {
+        setBuildState("built");
+        setBuildOutput(res.output || "Build succeeded.");
+        onBuiltAtChange(new Date().toISOString());
+      } else {
+        setBuildState("error");
+        setBuildOutput(res.output || "Build failed.");
+      }
+    } catch (e) {
+      setBuildState("error");
+      setBuildOutput(String(e));
+    }
+  };
+
+  const handleStart = async () => {
+    setBuildState("starting");
+    try {
+      const p = await invoke<{ port: number; pid: number }>("start_automation", { id: automationId });
+      setPort(p.port);
+      setBuildState("running");
+    } catch (e) {
+      setBuildState("error");
+      setBuildOutput(String(e));
+    }
+  };
+
+  const handleStop = async () => {
+    try { await invoke("stop_automation", { id: automationId }); } catch {}
+    setPort(undefined);
+    setBuildState(builtAt ? "built" : "idle");
+    setChatOpen(false);
+  };
+
+  return (
+    <div className="am-builder">
+      <BuildBar
+        state={buildState}
+        port={port}
+        builtAt={builtAt}
+        onBuild={handleBuild}
+        onStart={handleStart}
+        onStop={handleStop}
+        onOpenChat={hasManualTrigger && port ? () => setChatOpen(true) : undefined}
+      />
+      <div className="am-builder-body">
+        <NodePalette hasAgent={hasAgent} onDragStart={handleDragStartFromPalette} />
+        <div className="am-canvas" ref={wrapperRef} onDragOver={onDragOverCanvas} onDrop={onDropCanvas}>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            isValidConnection={isValidConnection}
+            onNodeClick={onNodeClick}
+            onPaneClick={onPaneClick}
+            nodeTypes={nodeTypes}
+            colorMode={theme.type}
+            proOptions={{ hideAttribution: true }}
+            fitView={nodes.length > 0}
+            fitViewOptions={{ padding: 0.3, maxZoom: 1 }}
+          >
+            <Background
+              id="am-bg"
+              bgColor="var(--tempest-bg-editor)"
+              color="var(--tempest-border-subtle)"
+              gap={28}
+              size={2.5}
+            />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable />
+          </ReactFlow>
+          <div className={`am-savechip am-savechip--${savingLabel}`}>
+            {savingLabel === "saving" ? "Saving…" : savingLabel === "saved" ? "Saved" : ""}
+          </div>
+          {buildOutput && (buildState === "error" || buildState === "built") && (
+            <div className={`am-buildpanel am-buildpanel--${buildState}`}>
+              <div className="am-buildpanel-title">
+                {buildState === "error" ? "Build output (error)" : "Build output"}
+              </div>
+              <pre className="am-buildpanel-pre">{buildOutput}</pre>
+            </div>
+          )}
+        </div>
+      </div>
+      {selectedNode && (
+        <NodeModal
+          node={selectedNode}
+          onChange={updateSelected}
+          onClose={() => setSelectedId(null)}
+          onDelete={deleteSelected}
+        />
+      )}
+      {chatOpen && port && (
+        <ChatPanel port={port} onClose={() => setChatOpen(false)} />
+      )}
+    </div>
+  );
+}
+
+export function AutomationBuilder(props: Props) {
+  return (
+    <ReactFlowProvider>
+      <Inner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/Automations/builder/AutomationEdge.tsx
+++ b/src/components/Automations/builder/AutomationEdge.tsx
@@ -1,0 +1,29 @@
+import { BaseEdge, EdgeLabelRenderer, getBezierPath, useReactFlow, type EdgeProps } from "@xyflow/react";
+import { X } from "lucide-react";
+
+// Removable connection edge. Mirrors threads/ThreadEdge — React Flow has no
+// built-in disconnect gesture, so each edge carries a midpoint × button.
+export function AutomationEdge({
+  id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, style, markerEnd,
+}: EdgeProps) {
+  const { deleteElements } = useReactFlow();
+  const [path, labelX, labelY] = getBezierPath({
+    sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />
+      <EdgeLabelRenderer>
+        <button
+          className="am-edge-del nodrag nopan"
+          style={{ transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)` }}
+          onClick={(e) => { e.stopPropagation(); void deleteElements({ edges: [{ id }] }); }}
+          title="Remove connection"
+        >
+          <X size={11} strokeWidth={2.5} />
+        </button>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/src/components/Automations/builder/BuildBar.tsx
+++ b/src/components/Automations/builder/BuildBar.tsx
@@ -1,0 +1,72 @@
+import { Hammer, Loader, Play, RefreshCw, Square } from "lucide-react";
+
+export type BuildState = "idle" | "building" | "built" | "starting" | "running" | "error";
+
+interface Props {
+  state: BuildState;
+  port?: number;
+  builtAt: string | null;
+  onBuild: () => void;
+  onStart: () => void;
+  onStop: () => void;
+  onOpenChat?: () => void;
+}
+
+export function BuildBar({ state, port, builtAt, onBuild, onStart, onStop, onOpenChat }: Props) {
+  const isBuilding = state === "building";
+  const isRunning = state === "running";
+  const isStarting = state === "starting";
+  const canBuild = !isBuilding && !isRunning && !isStarting;
+  const canStart = state === "built" || (builtAt !== null && state === "idle") || state === "error";
+
+  return (
+    <div className="am-buildbar">
+      <div className="am-buildbar-left">
+        <span className={`am-buildbar-dot am-buildbar-dot--${state}`} />
+        <span className="am-buildbar-state">
+          {state === "idle" && (builtAt ? "Built" : "Not built")}
+          {state === "building" && "Building…"}
+          {state === "built" && "Built"}
+          {state === "starting" && "Starting…"}
+          {state === "running" && `Running · :${port}`}
+          {state === "error" && "Build failed"}
+        </span>
+      </div>
+      <div className="am-buildbar-right">
+        <button
+          className="am-buildbar-btn"
+          onClick={onBuild}
+          disabled={!canBuild}
+          title="Regenerate Eve project and run `eve build`"
+        >
+          {isBuilding ? <Loader size={13} className="am-spin" /> : <Hammer size={13} />}
+          {builtAt ? "Rebuild" : "Build"}
+        </button>
+        {isRunning ? (
+          <>
+            {onOpenChat && (
+              <button className="am-buildbar-btn am-buildbar-btn--primary" onClick={onOpenChat}>
+                <Play size={13} />
+                Chat
+              </button>
+            )}
+            <button className="am-buildbar-btn am-buildbar-btn--stop" onClick={onStop}>
+              <Square size={13} />
+              Stop
+            </button>
+          </>
+        ) : (
+          <button
+            className="am-buildbar-btn am-buildbar-btn--primary"
+            onClick={onStart}
+            disabled={!canStart || isStarting}
+            title={canStart ? "Start the agent" : "Build first"}
+          >
+            {isStarting ? <Loader size={13} className="am-spin" /> : <RefreshCw size={13} />}
+            Start
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Automations/builder/ChatPanel.tsx
+++ b/src/components/Automations/builder/ChatPanel.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+import { Loader, Send, X } from "lucide-react";
+
+interface Props {
+  port: number;
+  onClose: () => void;
+}
+
+interface Msg {
+  role: "user" | "assistant";
+  text: string;
+  pending?: boolean;
+}
+
+// Streams NDJSON events from Eve's HTTP channel.
+// Consumes `message.appended.data.messageDelta` chunks into the current
+// assistant message; ends on `message.completed` or `session.waiting`.
+async function streamInto(port: number, sessionId: string, onDelta: (s: string) => void, onDone: () => void) {
+  const res = await fetch(`http://localhost:${port}/eve/v1/session/${sessionId}/stream`, {
+    method: "GET",
+  });
+  if (!res.body) { onDone(); return; }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx: number;
+    while ((idx = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, idx).trim();
+      buffer = buffer.slice(idx + 1);
+      if (!line) continue;
+      try {
+        const ev = JSON.parse(line);
+        if (ev.type === "message.appended" && ev.data?.messageDelta) {
+          onDelta(ev.data.messageDelta);
+        }
+        if (ev.type === "message.completed" || ev.type === "session.waiting") {
+          onDone();
+          return;
+        }
+      } catch { /* skip malformed */ }
+    }
+  }
+  onDone();
+}
+
+export function ChatPanel({ port, onClose }: Props) {
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setInput("");
+    setMessages(prev => [...prev, { role: "user", text }, { role: "assistant", text: "", pending: true }]);
+    try {
+      const url = sessionId
+        ? `http://localhost:${port}/eve/v1/session/${sessionId}`
+        : `http://localhost:${port}/eve/v1/session`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text }),
+      });
+      const body = await res.json();
+      const sid: string = body.sessionId || sessionId!;
+      if (!sessionId) setSessionId(sid);
+      await streamInto(
+        port,
+        sid,
+        delta => setMessages(prev => {
+          const next = [...prev];
+          const last = next[next.length - 1];
+          if (last && last.role === "assistant") {
+            next[next.length - 1] = { ...last, text: last.text + delta, pending: true };
+          }
+          return next;
+        }),
+        () => setMessages(prev => {
+          const next = [...prev];
+          const last = next[next.length - 1];
+          if (last && last.role === "assistant") next[next.length - 1] = { ...last, pending: false };
+          return next;
+        }),
+      );
+    } catch (e) {
+      setMessages(prev => {
+        const next = [...prev];
+        next[next.length - 1] = { role: "assistant", text: `Error: ${e}`, pending: false };
+        return next;
+      });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="am-chat">
+      <div className="am-chat-head">
+        <span className="am-chat-title">Agent · :{port}</span>
+        <button className="am-chat-close" onClick={onClose} aria-label="Close"><X size={14} /></button>
+      </div>
+      <div className="am-chat-list" ref={listRef}>
+        {messages.length === 0 && (
+          <div className="am-chat-empty">Send a message to start.</div>
+        )}
+        {messages.map((m, i) => (
+          <div key={i} className={`am-chat-msg am-chat-msg--${m.role}`}>
+            <div className="am-chat-msg-body">
+              {m.text || (m.pending && <span className="am-chat-thinking"><Loader size={12} className="am-spin" /> thinking…</span>)}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="am-chat-input-row">
+        <textarea
+          className="am-chat-input"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); } }}
+          placeholder="Message the agent…"
+          rows={2}
+          disabled={sending}
+        />
+        <button className="am-chat-send" onClick={send} disabled={sending || !input.trim()}>
+          {sending ? <Loader size={13} className="am-spin" /> : <Send size={13} />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Automations/builder/ModelPicker.tsx
+++ b/src/components/Automations/builder/ModelPicker.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ChevronDown, Search } from "lucide-react";
+import { CDN, CHAT_PROVIDERS, type ChatModel } from "../../../lib/chatModels";
+import { useModelManifest } from "../../../lib/remoteConfig";
+
+interface Props {
+  value: string;                       // gateway id, e.g. "anthropic/claude-sonnet-5"
+  onChange: (id: string) => void;
+  placeholder?: string;
+}
+
+// Same visual design as ChatNode's picker (sidebar of provider icons + right
+// panel with search + model list), scoped to a single gateway-id output.
+export function ModelPicker({ value, onChange, placeholder = "anthropic/claude-sonnet-5" }: Props) {
+  const manifest = useModelManifest();
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+  const [search, setSearch] = useState("");
+
+  // Parse "provider/model" back to (provider, model). Fall back to Anthropic.
+  const { activeProvider, activeModelId } = useMemo(() => {
+    const slash = value.indexOf("/");
+    if (slash > 0) {
+      return { activeProvider: value.slice(0, slash), activeModelId: value.slice(slash + 1) };
+    }
+    return { activeProvider: "anthropic", activeModelId: value };
+  }, [value]);
+
+  const [pickerProvider, setPickerProvider] = useState(activeProvider);
+  useEffect(() => { setPickerProvider(activeProvider); }, [activeProvider]);
+
+  const providerMeta = CHAT_PROVIDERS.find(p => p.id === pickerProvider) ?? CHAT_PROVIDERS[0];
+  const activeProviderMeta = CHAT_PROVIDERS.find(p => p.id === activeProvider) ?? CHAT_PROVIDERS[0];
+  const activeModel = (manifest.providers[activeProvider] ?? []).find(m => m.id === activeModelId);
+
+  const rawModels = manifest.providers[pickerProvider] ?? [];
+  const filtered = search.trim()
+    ? rawModels.filter(m => m.label.toLowerCase().includes(search.toLowerCase()) || m.id.toLowerCase().includes(search.toLowerCase()))
+    : rawModels;
+
+  function openPicker() {
+    if (!btnRef.current) return;
+    const r = btnRef.current.getBoundingClientRect();
+    // Prefer below; flip above if it would clip the viewport bottom.
+    const height = 300;
+    const gap = 6;
+    const below = r.bottom + gap;
+    const top = below + height > window.innerHeight ? Math.max(8, r.top - height - gap) : below;
+    setPos({ top, left: r.left });
+    setOpen(true);
+    setSearch("");
+    setTimeout(() => searchRef.current?.focus(), 0);
+  }
+
+  function select(m: ChatModel) {
+    onChange(`${pickerProvider}/${m.id}`);
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        className="chat-bar-mode"
+        onClick={(e) => { e.stopPropagation(); openPicker(); }}
+      >
+        <img
+          src={CDN + activeProviderMeta.icon}
+          alt={activeProviderMeta.label}
+          width={14}
+          height={14}
+          className={activeProviderMeta.invert ? "chat-logo-invert" : ""}
+          style={{ objectFit: "contain", flexShrink: 0 }}
+          onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+        />
+        {activeModel?.label ?? (value || placeholder)}
+        <ChevronDown size={11} style={{ transform: open ? "rotate(180deg)" : "none", transition: "transform 0.15s" }} />
+      </button>
+
+      {open && createPortal(
+        <>
+          <div className="chat-drop-overlay" onClick={() => setOpen(false)} />
+          <div className="chat-picker" style={{ top: pos.top, left: pos.left }}>
+            <div className="chat-picker-sidebar">
+              {CHAT_PROVIDERS.map((p) => (
+                <button
+                  key={p.id}
+                  className={`chat-picker-prov${pickerProvider === p.id ? " chat-picker-prov--active" : ""}`}
+                  onClick={() => { setPickerProvider(p.id); setSearch(""); searchRef.current?.focus(); }}
+                  title={p.label}
+                >
+                  <img
+                    src={CDN + p.icon}
+                    alt={p.label}
+                    width={16}
+                    height={16}
+                    className={p.invert ? "chat-logo-invert" : ""}
+                    style={{ objectFit: "contain" }}
+                    onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+                  />
+                </button>
+              ))}
+            </div>
+            <div className="chat-picker-panel">
+              <div className="chat-picker-prov-name">{providerMeta.label}</div>
+              <div className="chat-picker-search-wrap">
+                <div className="chat-picker-search-box">
+                  <Search size={11} className="chat-picker-search-ico" />
+                  <input
+                    ref={searchRef}
+                    className="chat-picker-search-inp"
+                    placeholder="Search models…"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="chat-picker-list">
+                {filtered.length === 0 ? (
+                  <div className="chat-picker-empty">No models found</div>
+                ) : filtered.map((m) => {
+                  const isActive = activeProvider === pickerProvider && activeModelId === m.id;
+                  return (
+                    <button
+                      key={m.id}
+                      className={`chat-picker-item${isActive ? " chat-picker-item--active" : ""}`}
+                      onClick={() => select(m)}
+                    >
+                      <div className="chat-picker-item-logo">
+                        <img
+                          src={CDN + providerMeta.icon}
+                          alt={providerMeta.label}
+                          width={18}
+                          height={18}
+                          className={providerMeta.invert ? "chat-logo-invert" : ""}
+                          style={{ objectFit: "contain" }}
+                          onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+                        />
+                      </div>
+                      <div className="chat-picker-item-text">
+                        <span className="chat-picker-item-name">{m.label}</span>
+                        <span className="chat-picker-item-desc">{pickerProvider}/{m.id}</span>
+                      </div>
+                      {isActive && <div className="chat-picker-item-dot" />}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/src/components/Automations/builder/NodeConnector.tsx
+++ b/src/components/Automations/builder/NodeConnector.tsx
@@ -1,0 +1,39 @@
+import { Handle, Position, useConnection, useNodeConnections } from "@xyflow/react";
+import { Hexagon } from "lucide-react";
+
+// Threads-style connector: a Hexagon icon rendered inline in a node header
+// (not a floating border dot). React Flow's absolute-positioned handle styling
+// is neutralized in CSS so this sits as a header icon that still starts a
+// connection drag / click-to-connect.
+export function NodeConnector({ nodeId, side }: { nodeId: string; side: "left" | "right" }) {
+  const connecting = useConnection((c) => c.inProgress && c.fromNode?.id === nodeId);
+  const connected = useNodeConnections({
+    id: nodeId,
+    handleType: side === "left" ? "target" : "source",
+  }).length > 0;
+
+  const fill = connecting
+    ? "var(--tempest-accent-yellow, #f5c518)"
+    : connected
+    ? "currentColor"
+    : "none";
+
+  const handle = (
+    <Handle
+      type={side === "left" ? "target" : "source"}
+      position={side === "left" ? Position.Left : Position.Right}
+      id={side === "left" ? "in" : "out"}
+      className={`am-connector nodrag${connecting ? " connecting" : ""}${connected ? " connected" : ""}`}
+      title={side === "left" ? "Connect into this node" : "Click or drag to connect"}
+    >
+      <Hexagon size={13} fill={fill} />
+    </Handle>
+  );
+  if (side === "right") return handle;
+  return (
+    <>
+      {handle}
+      <span className="am-connector-sep" />
+    </>
+  );
+}

--- a/src/components/Automations/builder/NodeModal.tsx
+++ b/src/components/Automations/builder/NodeModal.tsx
@@ -1,8 +1,25 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
-import type { Node } from "./graph";
-import { nodeIcon, nodeLabel } from "./nodes";
+import type { Node, ToolData, FlowData, TriggerChannelData } from "./graph";
+import { emptyRequest, emptyToolData } from "./graph";
+import { nodeIcon, nodeLabel, nodeDescription } from "./nodes";
+import { ModelPicker } from "./ModelPicker";
+import {
+  parseCron, buildCron, describeCron, WEEKDAY_NAMES, WEEKDAY_NAMES_SHORT,
+  type SchedulePreset,
+} from "./humanCron";
+import { RequestBuilder } from "./tool/RequestBuilder";
+import { InputSchemaBuilder } from "./tool/InputSchemaBuilder";
+import { ResponseMapper } from "./tool/ResponseMapper";
+import { StepList, scopedFields } from "./flow/StepEditor";
+import { TriggerChannelModal } from "./triggers/TriggerChannelModal";
+
+const CHANNEL_TRIGGER_KINDS = [
+  "trigger-linear", "trigger-discord", "trigger-telegram",
+  "trigger-teams", "trigger-photon", "trigger-poll",
+] as const;
+type ChannelTriggerKind = typeof CHANNEL_TRIGGER_KINDS[number];
 
 interface Props {
   node: Node;
@@ -27,7 +44,10 @@ export function NodeModal({ node, onChange, onClose, onDelete }: Props) {
         <div className="am-modal-header">
           <span className="am-modal-title">
             <span className="am-modal-icon">{nodeIcon[node.kind]}</span>
-            {nodeLabel[node.kind]}
+            <span className="am-modal-title-text">
+              <span>{nodeLabel[node.kind]}</span>
+              <span className="am-modal-title-sub">{nodeDescription[node.kind]}</span>
+            </span>
           </span>
           <button className="am-modal-close" onClick={onClose} aria-label="Close">
             <X size={14} />
@@ -55,14 +75,15 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
     const d = node.data;
     return (
       <label className="am-field">
-        <span>Label</span>
+        <span>What should the Start button say?</span>
         <input
           ref={firstRef}
           className="am-input"
           value={d.label || ""}
           onChange={e => set("label" as never, e.target.value as never)}
-          placeholder="Start button"
+          placeholder="e.g. Send morning report"
         />
+        <span className="am-hint-block">You'll see this button in the chat panel — click it to run the automation.</span>
       </label>
     );
   }
@@ -71,25 +92,20 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
     const d = node.data;
     return (
       <>
+        <SchedulePicker
+          cron={d.cron || ""}
+          onChange={c => set("cron" as never, c as never)}
+        />
         <label className="am-field">
-          <span>Cron expression <span className="am-hint">(minute hour day month weekday · UTC)</span></span>
-          <input
-            ref={firstRef}
-            className="am-input am-mono"
-            value={d.cron || ""}
-            onChange={e => set("cron" as never, e.target.value as never)}
-            placeholder="0 9 * * 1-5"
-          />
-        </label>
-        <label className="am-field">
-          <span>Prompt <span className="am-hint">(what the agent runs each time)</span></span>
+          <span>What should the agent do each time?</span>
           <textarea
             className="am-textarea"
             value={d.prompt || ""}
             onChange={e => set("prompt" as never, e.target.value as never)}
             rows={4}
-            placeholder="Pull open Linear issues and post a summary…"
+            placeholder="Pull open Linear issues and post a summary to #standup"
           />
+          <span className="am-hint-block">Write it like you're asking a coworker — the agent reads this every time it runs.</span>
         </label>
       </>
     );
@@ -100,87 +116,20 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
   }
 
   if (node.kind === "tool") {
-    const d = node.data;
+    return <ToolTabs data={node.data} onChange={onChange as (d: ToolData) => void} firstRef={firstRef} />;
+  }
+
+  if (node.kind === "flow") {
+    return <FlowTabs data={node.data as FlowData} onChange={onChange as (d: FlowData) => void} firstRef={firstRef} />;
+  }
+
+  if ((CHANNEL_TRIGGER_KINDS as readonly string[]).includes(node.kind)) {
     return (
-      <>
-        <label className="am-field">
-          <span>Name <span className="am-hint">(filename slug the model sees)</span></span>
-          <input
-            ref={firstRef}
-            className="am-input am-mono"
-            value={d.name || ""}
-            onChange={e => set("name" as never, e.target.value as never)}
-            placeholder="get_weather"
-          />
-        </label>
-        <label className="am-field">
-          <span>Description <span className="am-hint">(written for the model)</span></span>
-          <textarea
-            className="am-textarea"
-            value={d.description || ""}
-            onChange={e => set("description" as never, e.target.value as never)}
-            rows={2}
-            placeholder="Get the current weather for a city."
-          />
-        </label>
-        <label className="am-field">
-          <span>Preset</span>
-          <select
-            className="am-input"
-            value={d.preset || "custom"}
-            onChange={e => set("preset" as never, e.target.value as never)}
-          >
-            <option value="http">HTTP request</option>
-            <option value="custom">Custom (TypeScript)</option>
-          </select>
-        </label>
-        {d.preset === "http" ? (
-          <>
-            <label className="am-field">
-              <span>Method</span>
-              <select
-                className="am-input"
-                value={d.httpMethod || "GET"}
-                onChange={e => set("httpMethod" as never, e.target.value as never)}
-              >
-                {["GET", "POST", "PUT", "PATCH", "DELETE"].map(m => <option key={m}>{m}</option>)}
-              </select>
-            </label>
-            <label className="am-field">
-              <span>URL</span>
-              <input
-                className="am-input am-mono"
-                value={d.httpUrl || ""}
-                onChange={e => set("httpUrl" as never, e.target.value as never)}
-                placeholder="https://api.example.com/v1/thing"
-              />
-            </label>
-          </>
-        ) : (
-          <>
-            <label className="am-field">
-              <span>Input schema <span className="am-hint">(Zod)</span></span>
-              <textarea
-                className="am-textarea am-mono"
-                value={d.customInputSchema || ""}
-                onChange={e => set("customInputSchema" as never, e.target.value as never)}
-                rows={3}
-                placeholder="z.object({ query: z.string() })"
-              />
-            </label>
-            <label className="am-field">
-              <span>Execute body <span className="am-hint">(async execute(input, ctx))</span></span>
-              <textarea
-                className="am-textarea am-mono"
-                value={d.customExecute || ""}
-                onChange={e => set("customExecute" as never, e.target.value as never)}
-                rows={8}
-                placeholder="const res = await fetch(...);&#10;return { ok: true };"
-              />
-            </label>
-          </>
-        )}
-      </>
+      <TriggerChannelModal
+        kind={node.kind as ChannelTriggerKind}
+        data={node.data as TriggerChannelData}
+        onChange={onChange as (d: TriggerChannelData) => void}
+      />
     );
   }
 
@@ -189,24 +138,26 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
     return (
       <>
         <label className="am-field">
-          <span>Name <span className="am-hint">(filename slug)</span></span>
+          <span>Name for this skill</span>
           <input
             ref={firstRef}
-            className="am-input am-mono"
+            className="am-input"
             value={d.name || ""}
             onChange={e => set("name" as never, e.target.value as never)}
             placeholder="summarize"
           />
+          <span className="am-hint-block">Short, no spaces. The agent loads this on demand when it's relevant.</span>
         </label>
         <label className="am-field">
-          <span>Markdown <span className="am-hint">(loaded on-demand)</span></span>
+          <span>What should the agent do?</span>
           <textarea
-            className="am-textarea am-mono"
+            className="am-textarea"
             value={d.markdown || ""}
             onChange={e => set("markdown" as never, e.target.value as never)}
             rows={12}
-            placeholder={"# Skill: summarize\n\n1. …\n2. …"}
+            placeholder={"# Skill: summarize\n\n1. Read the input\n2. Return 3 bullet points"}
           />
+          <span className="am-hint-block">Written in Markdown. Numbered steps work well.</span>
         </label>
       </>
     );
@@ -214,36 +165,38 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
 
   if (node.kind === "connection") {
     const d = node.data;
+    const isMcp = (d.kind || "mcp") === "mcp";
     return (
       <>
         <label className="am-field">
-          <span>Name <span className="am-hint">(filename slug)</span></span>
+          <span>Name for this connection</span>
           <input
             ref={firstRef}
-            className="am-input am-mono"
+            className="am-input"
             value={d.name || ""}
             onChange={e => set("name" as never, e.target.value as never)}
             placeholder="linear"
           />
         </label>
+        <div className="am-segmented">
+          <button
+            type="button"
+            className={`am-segmented-btn${isMcp ? " am-segmented-btn--active" : ""}`}
+            onClick={() => set("kind" as never, "mcp" as never)}
+          >MCP server</button>
+          <button
+            type="button"
+            className={`am-segmented-btn${!isMcp ? " am-segmented-btn--active" : ""}`}
+            onClick={() => set("kind" as never, "openapi" as never)}
+          >OpenAPI spec</button>
+        </div>
         <label className="am-field">
-          <span>Type</span>
-          <select
-            className="am-input"
-            value={d.kind || "mcp"}
-            onChange={e => set("kind" as never, e.target.value as never)}
-          >
-            <option value="mcp">MCP server</option>
-            <option value="openapi">OpenAPI spec</option>
-          </select>
-        </label>
-        <label className="am-field">
-          <span>URL</span>
+          <span>{isMcp ? "Server URL" : "OpenAPI spec URL"}</span>
           <input
             className="am-input am-mono"
             value={d.url || ""}
             onChange={e => set("url" as never, e.target.value as never)}
-            placeholder="https://mcp.example.com"
+            placeholder={isMcp ? "https://mcp.example.com" : "https://api.example.com/openapi.json"}
           />
         </label>
       </>
@@ -255,10 +208,10 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
     return (
       <>
         <label className="am-field">
-          <span>Name <span className="am-hint">(directory slug)</span></span>
+          <span>Name for this helper</span>
           <input
             ref={firstRef}
-            className="am-input am-mono"
+            className="am-input"
             value={d.name || ""}
             onChange={e => set("name" as never, e.target.value as never)}
             placeholder="researcher"
@@ -266,31 +219,30 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
         </label>
         <label className="am-field">
           <span>Model</span>
-          <input
-            className="am-input am-mono"
+          <ModelPicker
             value={d.model || ""}
-            onChange={e => set("model" as never, e.target.value as never)}
-            placeholder="anthropic/claude-sonnet-5"
+            onChange={v => set("model" as never, v as never)}
           />
         </label>
         <label className="am-field">
-          <span>Description <span className="am-hint">(required — parent uses this to decide when to delegate)</span></span>
+          <span>When should the main agent call this helper?</span>
           <textarea
             className="am-textarea"
             value={d.description || ""}
             onChange={e => set("description" as never, e.target.value as never)}
             rows={2}
-            placeholder="Researches and returns a summary of open issues."
+            placeholder="Use to research and summarize open issues from Linear."
           />
+          <span className="am-hint-block">Required — the main agent uses this to decide when to delegate.</span>
         </label>
         <label className="am-field">
-          <span>Instructions</span>
+          <span>Instructions for the helper</span>
           <textarea
             className="am-textarea"
             value={d.instructions || ""}
             onChange={e => set("instructions" as never, e.target.value as never)}
             rows={8}
-            placeholder="You are a research specialist. …"
+            placeholder="You are a research specialist. Read what's given, summarize in 3 bullet points."
           />
         </label>
       </>
@@ -299,6 +251,353 @@ function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.Muta
 
   return null;
 }
+
+// ── Schedule picker ─────────────────────────────────────────────────────────
+
+const PRESETS: { id: SchedulePreset; label: string }[] = [
+  { id: "every-minutes",  label: "Every few minutes" },
+  { id: "every-hours",    label: "Every few hours" },
+  { id: "daily",          label: "Every day" },
+  { id: "weekdays",       label: "Every weekday (Mon–Fri)" },
+  { id: "on-days",        label: "On specific days" },
+  { id: "times-per-day",  label: "Several times a day" },
+  { id: "weekly",         label: "Once a week" },
+  { id: "monthly",        label: "Once a month" },
+];
+
+function SchedulePicker({ cron, onChange }: { cron: string; onChange: (c: string) => void }) {
+  const [state, setState] = useState(() => parseCron(cron));
+
+  const update = (patch: Partial<typeof state>) => {
+    // Coming out of an unrecognized cron ("custom") snaps to a real preset.
+    const preset = patch.preset ?? (state.preset === "custom" ? "daily" : state.preset);
+    const next = { ...state, ...patch, preset };
+    setState(next);
+    onChange(buildCron(next));
+  };
+
+  const timeValue = `${pad(state.hour)}:${pad(state.minute)}`;
+  const setTime = (v: string) => {
+    const [h, m] = v.split(":").map(x => parseInt(x, 10) || 0);
+    update({ hour: h, minute: m });
+  };
+
+  const toggleWeekday = (i: number) => {
+    const has = state.weekdays.includes(i);
+    const next = has ? state.weekdays.filter(x => x !== i) : [...state.weekdays, i].sort((a, b) => a - b);
+    update({ weekdays: next.length ? next : [i] });   // never empty
+  };
+  const toggleHour = (h: number) => {
+    const has = state.hours.includes(h);
+    const next = has ? state.hours.filter(x => x !== h) : [...state.hours, h].sort((a, b) => a - b);
+    update({ hours: next.length ? next : [h] });
+  };
+
+  const isCustom = state.preset === "custom";
+  const shownPreset: SchedulePreset = isCustom ? "daily" : state.preset;
+
+  return (
+    <div className="am-field">
+      <span>When should this run?</span>
+      {isCustom && (
+        <div className="am-callout">
+          Existing cron doesn't match a preset: <code>{cron}</code>. Pick a preset below to replace it.
+        </div>
+      )}
+      <select
+        className="am-input"
+        value={shownPreset}
+        onChange={e => update({ preset: e.target.value as SchedulePreset })}
+      >
+        {PRESETS.map(p => <option key={p.id} value={p.id}>{p.label}</option>)}
+      </select>
+
+      {state.preset === "every-minutes" && (
+        <div className="am-row am-row--tight">
+          <span className="am-inline">every</span>
+          <input
+            type="number" min={1} max={59}
+            className="am-input am-input--num"
+            value={state.n}
+            onChange={e => update({ n: Math.max(1, Math.min(59, +e.target.value || 1)) })}
+          />
+          <span className="am-inline">minutes</span>
+        </div>
+      )}
+      {state.preset === "every-hours" && (
+        <div className="am-row am-row--tight">
+          <span className="am-inline">every</span>
+          <input
+            type="number" min={1} max={23}
+            className="am-input am-input--num"
+            value={state.n}
+            onChange={e => update({ n: Math.max(1, Math.min(23, +e.target.value || 1)) })}
+          />
+          <span className="am-inline">hours</span>
+        </div>
+      )}
+      {(state.preset === "daily" || state.preset === "weekdays") && (
+        <div className="am-row am-row--tight">
+          <span className="am-inline">at</span>
+          <input type="time" className="am-input am-input--num" value={timeValue} onChange={e => setTime(e.target.value)} />
+        </div>
+      )}
+      {state.preset === "on-days" && (
+        <>
+          <div className="am-daypicker">
+            {WEEKDAY_NAMES_SHORT.map((n, i) => (
+              <button
+                key={i}
+                type="button"
+                className={`am-daypicker-btn${state.weekdays.includes(i) ? " am-daypicker-btn--on" : ""}`}
+                onClick={() => toggleWeekday(i)}
+              >{n}</button>
+            ))}
+          </div>
+          <div className="am-row am-row--tight">
+            <span className="am-inline">at</span>
+            <input type="time" className="am-input am-input--num" value={timeValue} onChange={e => setTime(e.target.value)} />
+          </div>
+        </>
+      )}
+      {state.preset === "times-per-day" && (
+        <>
+          <div className="am-hourgrid">
+            {Array.from({ length: 24 }, (_, h) => (
+              <button
+                key={h}
+                type="button"
+                className={`am-hourgrid-btn${state.hours.includes(h) ? " am-hourgrid-btn--on" : ""}`}
+                onClick={() => toggleHour(h)}
+              >{pad(h)}</button>
+            ))}
+          </div>
+          <div className="am-row am-row--tight">
+            <span className="am-inline">at :</span>
+            <input
+              type="number" min={0} max={59}
+              className="am-input am-input--num"
+              value={state.minute}
+              onChange={e => update({ minute: Math.max(0, Math.min(59, +e.target.value || 0)) })}
+            />
+            <span className="am-inline">minutes past each hour</span>
+          </div>
+        </>
+      )}
+      {state.preset === "weekly" && (
+        <div className="am-row am-row--tight">
+          <span className="am-inline">every</span>
+          <select
+            className="am-input am-input--fit"
+            value={state.weekday}
+            onChange={e => update({ weekday: +e.target.value })}
+          >
+            {WEEKDAY_NAMES.map((n, i) => <option key={i} value={i}>{n}</option>)}
+          </select>
+          <span className="am-inline">at</span>
+          <input type="time" className="am-input am-input--num" value={timeValue} onChange={e => setTime(e.target.value)} />
+        </div>
+      )}
+      {state.preset === "monthly" && (
+        <div className="am-row am-row--tight">
+          <span className="am-inline">on day</span>
+          <input
+            type="number" min={1} max={28}
+            className="am-input am-input--num"
+            value={state.day}
+            onChange={e => update({ day: Math.max(1, Math.min(28, +e.target.value || 1)) })}
+          />
+          <span className="am-inline">at</span>
+          <input type="time" className="am-input am-input--num" value={timeValue} onChange={e => setTime(e.target.value)} />
+        </div>
+      )}
+
+      <div className="am-readback">
+        <span className="am-readback-dot" /> {describeCron(buildCron(state))}
+      </div>
+    </div>
+  );
+}
+
+function pad(n: number) { return String(n).padStart(2, "0"); }
+
+// ── Tool tabs ───────────────────────────────────────────────────────────────
+
+type ToolTab = "basics" | "inputs" | "request" | "response";
+
+function ToolTabs({ data, onChange, firstRef }: {
+  data: ToolData;
+  onChange: (d: ToolData) => void;
+  firstRef: React.MutableRefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+}) {
+  const [tab, setTab] = useState<ToolTab>("basics");
+  // Migrate legacy shape (preset/httpUrl/customExecute) on first render so the
+  // rest of the modal only sees the new fields. Per [[feedback_clean_over_compat]]:
+  // if the graph came from before P1–P3, take the URL if we can and drop the code.
+  const d: ToolData = {
+    name: data.name || "",
+    description: data.description || "",
+    request: data.request || {
+      ...emptyRequest(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      method: ((data as any).httpMethod as HttpReqMethod) || "GET",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      url: (data as any).httpUrl || "",
+    },
+    input: data.input || { fields: [] },
+    response: data.response || { kind: "raw" },
+  };
+  // If migration happened, persist it on any subsequent edit so we never write
+  // the legacy fields back.
+  const set = <K extends keyof ToolData>(k: K, v: ToolData[K]) =>
+    onChange({ ...emptyToolData(), ...d, [k]: v });
+
+  const tabs: { id: ToolTab; label: string }[] = [
+    { id: "basics",   label: "Basics" },
+    { id: "inputs",   label: "Inputs" },
+    { id: "request",  label: "Request" },
+    { id: "response", label: "Response" },
+  ];
+
+  return (
+    <>
+      <div className="am-tabs2">
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            type="button"
+            className={`am-tabs2-btn${tab === t.id ? " am-tabs2-btn--active" : ""}`}
+            onClick={() => setTab(t.id)}
+          >{t.label}</button>
+        ))}
+      </div>
+      {tab === "basics" && (
+        <>
+          <label className="am-field">
+            <span>Name for this tool</span>
+            <input
+              ref={firstRef as React.RefObject<HTMLInputElement>}
+              className="am-input am-mono"
+              value={d.name}
+              onChange={e => set("name", e.target.value)}
+              placeholder="get_weather"
+            />
+            <span className="am-hint-block">Short, no spaces — the agent uses this to call the tool.</span>
+          </label>
+          <label className="am-field">
+            <span>What does this tool do?</span>
+            <textarea
+              className="am-textarea"
+              value={d.description}
+              onChange={e => set("description", e.target.value)}
+              rows={3}
+              placeholder="Look up the current weather for a city."
+            />
+            <span className="am-hint-block">The agent reads this to decide when to use the tool. Be specific.</span>
+          </label>
+        </>
+      )}
+      {tab === "inputs" && (
+        <InputSchemaBuilder
+          schema={d.input}
+          onChange={s => set("input", s)}
+        />
+      )}
+      {tab === "request" && (
+        <RequestBuilder
+          request={d.request}
+          onChange={r => set("request", r)}
+          fields={d.input.fields}
+        />
+      )}
+      {tab === "response" && (
+        <ResponseMapper
+          response={d.response}
+          onChange={r => set("response", r)}
+          request={d.request}
+          fields={d.input.fields}
+        />
+      )}
+    </>
+  );
+}
+
+type HttpReqMethod = ToolData["request"]["method"];
+
+// ── Flow tabs ───────────────────────────────────────────────────────────────
+
+type FlowTab = "basics" | "inputs" | "steps";
+
+function FlowTabs({ data, onChange, firstRef }: {
+  data: FlowData;
+  onChange: (d: FlowData) => void;
+  firstRef: React.MutableRefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+}) {
+  const [tab, setTab] = useState<FlowTab>("basics");
+  const set = <K extends keyof FlowData>(k: K, v: FlowData[K]) => onChange({ ...data, [k]: v });
+  const tabs: { id: FlowTab; label: string }[] = [
+    { id: "basics", label: "Basics" },
+    { id: "inputs", label: "Inputs" },
+    { id: "steps",  label: "Steps" },
+  ];
+  const rootFields = data.input?.fields ?? [];
+  const chipFields = scopedFields(rootFields, data.steps);
+  return (
+    <>
+      <div className="am-tabs2">
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            type="button"
+            className={`am-tabs2-btn${tab === t.id ? " am-tabs2-btn--active" : ""}`}
+            onClick={() => setTab(t.id)}
+          >{t.label}</button>
+        ))}
+      </div>
+      {tab === "basics" && (
+        <>
+          <label className="am-field">
+            <span>Name for this flow</span>
+            <input
+              ref={firstRef as React.RefObject<HTMLInputElement>}
+              className="am-input am-mono"
+              value={data.name}
+              onChange={e => set("name", e.target.value)}
+              placeholder="get_weather_and_summarize"
+            />
+            <span className="am-hint-block">Short, no spaces — the agent calls this as a tool.</span>
+          </label>
+          <label className="am-field">
+            <span>What does this flow do?</span>
+            <textarea
+              className="am-textarea"
+              value={data.description}
+              onChange={e => set("description", e.target.value)}
+              rows={3}
+              placeholder="Look up the weather for a city and summarize it in one line."
+            />
+          </label>
+        </>
+      )}
+      {tab === "inputs" && (
+        <InputSchemaBuilder
+          schema={data.input}
+          onChange={s => set("input", s)}
+        />
+      )}
+      {tab === "steps" && (
+        <StepList
+          steps={data.steps}
+          onChange={s => set("steps", s)}
+          fields={chipFields}
+          rootFields={rootFields}
+        />
+      )}
+    </>
+  );
+}
+
+// ── Agent tabs ──────────────────────────────────────────────────────────────
 
 type Tab = "instructions" | "model" | "sandbox" | "limits";
 
@@ -324,30 +623,29 @@ function AgentTabs({ data, set, firstRef }: { data: any; set: (k: string, v: any
       </div>
       {tab === "instructions" && (
         <label className="am-field">
-          <span>System prompt <span className="am-hint">(markdown)</span></span>
+          <span>How should the agent behave?</span>
           <textarea
             ref={firstRef}
             className="am-textarea"
             value={data.instructions || ""}
             onChange={e => set("instructions", e.target.value)}
             rows={14}
-            placeholder="You are a helpful assistant that…"
+            placeholder="You are a helpful assistant that reads incoming emails and drafts short replies. Always ask before sending."
           />
+          <span className="am-hint-block">Written like a job description — the agent reads this every run.</span>
         </label>
       )}
       {tab === "model" && (
         <>
           <label className="am-field">
-            <span>Model <span className="am-hint">(gateway id or provider slug)</span></span>
-            <input
-              className="am-input am-mono"
+            <span>Which model should the agent use?</span>
+            <ModelPicker
               value={data.model || ""}
-              onChange={e => set("model", e.target.value)}
-              placeholder="anthropic/claude-sonnet-5"
+              onChange={v => set("model", v)}
             />
           </label>
           <label className="am-field">
-            <span>Reasoning</span>
+            <span>Reasoning effort</span>
             <select
               className="am-input"
               value={data.reasoning || "provider-default"}
@@ -357,21 +655,23 @@ function AgentTabs({ data, set, firstRef }: { data: any; set: (k: string, v: any
                 <option key={r}>{r}</option>
               ))}
             </select>
+            <span className="am-hint-block">Higher = slower but thinks harder. Leave on default if unsure.</span>
           </label>
         </>
       )}
       {tab === "sandbox" && (
         <label className="am-field">
-          <span>Sandbox backend</span>
+          <span>Where should the agent run code?</span>
           <select
             className="am-input"
             value={data.sandbox || "auto"}
             onChange={e => set("sandbox", e.target.value)}
           >
             <option value="auto">Auto (recommended)</option>
-            <option value="docker">Docker (requires Docker Desktop)</option>
-            <option value="none">None (justbash)</option>
+            <option value="docker">Docker (needs Docker Desktop)</option>
+            <option value="none">None — run on this machine directly</option>
           </select>
+          <span className="am-hint-block">Sandboxes isolate the agent so it can't touch your files by accident.</span>
         </label>
       )}
       {tab === "limits" && (
@@ -385,6 +685,7 @@ function AgentTabs({ data, set, firstRef }: { data: any; set: (k: string, v: any
               onChange={e => set("maxInputTokens", e.target.value ? Number(e.target.value) : undefined)}
               placeholder="200000"
             />
+            <span className="am-hint-block">Caps how much text the agent can read in one run. Leave blank for provider default.</span>
           </label>
           <label className="am-field">
             <span>Max output tokens per session</span>
@@ -395,6 +696,7 @@ function AgentTabs({ data, set, firstRef }: { data: any; set: (k: string, v: any
               onChange={e => set("maxOutputTokens", e.target.value ? Number(e.target.value) : undefined)}
               placeholder="20000"
             />
+            <span className="am-hint-block">Caps how much the agent can write in one run.</span>
           </label>
         </>
       )}

--- a/src/components/Automations/builder/NodeModal.tsx
+++ b/src/components/Automations/builder/NodeModal.tsx
@@ -1,0 +1,403 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import type { Node } from "./graph";
+import { nodeIcon, nodeLabel } from "./nodes";
+
+interface Props {
+  node: Node;
+  onChange: (data: Node["data"]) => void;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+export function NodeModal({ node, onChange, onClose, onDelete }: Props) {
+  const firstInputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    setTimeout(() => firstInputRef.current?.focus(), 0);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return createPortal(
+    <div className="am-modal-overlay" onClick={onClose}>
+      <div className="am-modal" onClick={e => e.stopPropagation()}>
+        <div className="am-modal-header">
+          <span className="am-modal-title">
+            <span className="am-modal-icon">{nodeIcon[node.kind]}</span>
+            {nodeLabel[node.kind]}
+          </span>
+          <button className="am-modal-close" onClick={onClose} aria-label="Close">
+            <X size={14} />
+          </button>
+        </div>
+        <div className="am-modal-body">
+          {renderBody(node, onChange, firstInputRef)}
+        </div>
+        <div className="am-modal-footer">
+          <button className="am-modal-danger" onClick={onDelete}>Delete node</button>
+          <button className="am-modal-primary" onClick={onClose}>Done</button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function renderBody(node: Node, onChange: (d: any) => void, firstRef: React.MutableRefObject<any>) {
+  const set = <K extends keyof typeof node.data>(k: K, v: (typeof node.data)[K]) =>
+    onChange({ ...node.data, [k]: v });
+
+  if (node.kind === "trigger-manual") {
+    const d = node.data;
+    return (
+      <label className="am-field">
+        <span>Label</span>
+        <input
+          ref={firstRef}
+          className="am-input"
+          value={d.label || ""}
+          onChange={e => set("label" as never, e.target.value as never)}
+          placeholder="Start button"
+        />
+      </label>
+    );
+  }
+
+  if (node.kind === "trigger-schedule") {
+    const d = node.data;
+    return (
+      <>
+        <label className="am-field">
+          <span>Cron expression <span className="am-hint">(minute hour day month weekday · UTC)</span></span>
+          <input
+            ref={firstRef}
+            className="am-input am-mono"
+            value={d.cron || ""}
+            onChange={e => set("cron" as never, e.target.value as never)}
+            placeholder="0 9 * * 1-5"
+          />
+        </label>
+        <label className="am-field">
+          <span>Prompt <span className="am-hint">(what the agent runs each time)</span></span>
+          <textarea
+            className="am-textarea"
+            value={d.prompt || ""}
+            onChange={e => set("prompt" as never, e.target.value as never)}
+            rows={4}
+            placeholder="Pull open Linear issues and post a summary…"
+          />
+        </label>
+      </>
+    );
+  }
+
+  if (node.kind === "agent") {
+    return <AgentTabs data={node.data} set={set as never} firstRef={firstRef} />;
+  }
+
+  if (node.kind === "tool") {
+    const d = node.data;
+    return (
+      <>
+        <label className="am-field">
+          <span>Name <span className="am-hint">(filename slug the model sees)</span></span>
+          <input
+            ref={firstRef}
+            className="am-input am-mono"
+            value={d.name || ""}
+            onChange={e => set("name" as never, e.target.value as never)}
+            placeholder="get_weather"
+          />
+        </label>
+        <label className="am-field">
+          <span>Description <span className="am-hint">(written for the model)</span></span>
+          <textarea
+            className="am-textarea"
+            value={d.description || ""}
+            onChange={e => set("description" as never, e.target.value as never)}
+            rows={2}
+            placeholder="Get the current weather for a city."
+          />
+        </label>
+        <label className="am-field">
+          <span>Preset</span>
+          <select
+            className="am-input"
+            value={d.preset || "custom"}
+            onChange={e => set("preset" as never, e.target.value as never)}
+          >
+            <option value="http">HTTP request</option>
+            <option value="custom">Custom (TypeScript)</option>
+          </select>
+        </label>
+        {d.preset === "http" ? (
+          <>
+            <label className="am-field">
+              <span>Method</span>
+              <select
+                className="am-input"
+                value={d.httpMethod || "GET"}
+                onChange={e => set("httpMethod" as never, e.target.value as never)}
+              >
+                {["GET", "POST", "PUT", "PATCH", "DELETE"].map(m => <option key={m}>{m}</option>)}
+              </select>
+            </label>
+            <label className="am-field">
+              <span>URL</span>
+              <input
+                className="am-input am-mono"
+                value={d.httpUrl || ""}
+                onChange={e => set("httpUrl" as never, e.target.value as never)}
+                placeholder="https://api.example.com/v1/thing"
+              />
+            </label>
+          </>
+        ) : (
+          <>
+            <label className="am-field">
+              <span>Input schema <span className="am-hint">(Zod)</span></span>
+              <textarea
+                className="am-textarea am-mono"
+                value={d.customInputSchema || ""}
+                onChange={e => set("customInputSchema" as never, e.target.value as never)}
+                rows={3}
+                placeholder="z.object({ query: z.string() })"
+              />
+            </label>
+            <label className="am-field">
+              <span>Execute body <span className="am-hint">(async execute(input, ctx))</span></span>
+              <textarea
+                className="am-textarea am-mono"
+                value={d.customExecute || ""}
+                onChange={e => set("customExecute" as never, e.target.value as never)}
+                rows={8}
+                placeholder="const res = await fetch(...);&#10;return { ok: true };"
+              />
+            </label>
+          </>
+        )}
+      </>
+    );
+  }
+
+  if (node.kind === "skill") {
+    const d = node.data;
+    return (
+      <>
+        <label className="am-field">
+          <span>Name <span className="am-hint">(filename slug)</span></span>
+          <input
+            ref={firstRef}
+            className="am-input am-mono"
+            value={d.name || ""}
+            onChange={e => set("name" as never, e.target.value as never)}
+            placeholder="summarize"
+          />
+        </label>
+        <label className="am-field">
+          <span>Markdown <span className="am-hint">(loaded on-demand)</span></span>
+          <textarea
+            className="am-textarea am-mono"
+            value={d.markdown || ""}
+            onChange={e => set("markdown" as never, e.target.value as never)}
+            rows={12}
+            placeholder={"# Skill: summarize\n\n1. …\n2. …"}
+          />
+        </label>
+      </>
+    );
+  }
+
+  if (node.kind === "connection") {
+    const d = node.data;
+    return (
+      <>
+        <label className="am-field">
+          <span>Name <span className="am-hint">(filename slug)</span></span>
+          <input
+            ref={firstRef}
+            className="am-input am-mono"
+            value={d.name || ""}
+            onChange={e => set("name" as never, e.target.value as never)}
+            placeholder="linear"
+          />
+        </label>
+        <label className="am-field">
+          <span>Type</span>
+          <select
+            className="am-input"
+            value={d.kind || "mcp"}
+            onChange={e => set("kind" as never, e.target.value as never)}
+          >
+            <option value="mcp">MCP server</option>
+            <option value="openapi">OpenAPI spec</option>
+          </select>
+        </label>
+        <label className="am-field">
+          <span>URL</span>
+          <input
+            className="am-input am-mono"
+            value={d.url || ""}
+            onChange={e => set("url" as never, e.target.value as never)}
+            placeholder="https://mcp.example.com"
+          />
+        </label>
+      </>
+    );
+  }
+
+  if (node.kind === "subagent") {
+    const d = node.data;
+    return (
+      <>
+        <label className="am-field">
+          <span>Name <span className="am-hint">(directory slug)</span></span>
+          <input
+            ref={firstRef}
+            className="am-input am-mono"
+            value={d.name || ""}
+            onChange={e => set("name" as never, e.target.value as never)}
+            placeholder="researcher"
+          />
+        </label>
+        <label className="am-field">
+          <span>Model</span>
+          <input
+            className="am-input am-mono"
+            value={d.model || ""}
+            onChange={e => set("model" as never, e.target.value as never)}
+            placeholder="anthropic/claude-sonnet-5"
+          />
+        </label>
+        <label className="am-field">
+          <span>Description <span className="am-hint">(required — parent uses this to decide when to delegate)</span></span>
+          <textarea
+            className="am-textarea"
+            value={d.description || ""}
+            onChange={e => set("description" as never, e.target.value as never)}
+            rows={2}
+            placeholder="Researches and returns a summary of open issues."
+          />
+        </label>
+        <label className="am-field">
+          <span>Instructions</span>
+          <textarea
+            className="am-textarea"
+            value={d.instructions || ""}
+            onChange={e => set("instructions" as never, e.target.value as never)}
+            rows={8}
+            placeholder="You are a research specialist. …"
+          />
+        </label>
+      </>
+    );
+  }
+
+  return null;
+}
+
+type Tab = "instructions" | "model" | "sandbox" | "limits";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function AgentTabs({ data, set, firstRef }: { data: any; set: (k: string, v: any) => void; firstRef: React.MutableRefObject<any> }) {
+  const [tab, setTab] = useState<Tab>("instructions");
+  const tabs: { id: Tab; label: string }[] = [
+    { id: "instructions", label: "Instructions" },
+    { id: "model", label: "Model" },
+    { id: "sandbox", label: "Sandbox" },
+    { id: "limits", label: "Limits" },
+  ];
+  return (
+    <>
+      <div className="am-tabs2">
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            className={`am-tabs2-btn${tab === t.id ? " am-tabs2-btn--active" : ""}`}
+            onClick={() => setTab(t.id)}
+          >{t.label}</button>
+        ))}
+      </div>
+      {tab === "instructions" && (
+        <label className="am-field">
+          <span>System prompt <span className="am-hint">(markdown)</span></span>
+          <textarea
+            ref={firstRef}
+            className="am-textarea"
+            value={data.instructions || ""}
+            onChange={e => set("instructions", e.target.value)}
+            rows={14}
+            placeholder="You are a helpful assistant that…"
+          />
+        </label>
+      )}
+      {tab === "model" && (
+        <>
+          <label className="am-field">
+            <span>Model <span className="am-hint">(gateway id or provider slug)</span></span>
+            <input
+              className="am-input am-mono"
+              value={data.model || ""}
+              onChange={e => set("model", e.target.value)}
+              placeholder="anthropic/claude-sonnet-5"
+            />
+          </label>
+          <label className="am-field">
+            <span>Reasoning</span>
+            <select
+              className="am-input"
+              value={data.reasoning || "provider-default"}
+              onChange={e => set("reasoning", e.target.value === "provider-default" ? "" : e.target.value)}
+            >
+              {["provider-default", "none", "minimal", "low", "medium", "high", "xhigh"].map(r => (
+                <option key={r}>{r}</option>
+              ))}
+            </select>
+          </label>
+        </>
+      )}
+      {tab === "sandbox" && (
+        <label className="am-field">
+          <span>Sandbox backend</span>
+          <select
+            className="am-input"
+            value={data.sandbox || "auto"}
+            onChange={e => set("sandbox", e.target.value)}
+          >
+            <option value="auto">Auto (recommended)</option>
+            <option value="docker">Docker (requires Docker Desktop)</option>
+            <option value="none">None (justbash)</option>
+          </select>
+        </label>
+      )}
+      {tab === "limits" && (
+        <>
+          <label className="am-field">
+            <span>Max input tokens per session</span>
+            <input
+              className="am-input am-mono"
+              type="number"
+              value={data.maxInputTokens ?? ""}
+              onChange={e => set("maxInputTokens", e.target.value ? Number(e.target.value) : undefined)}
+              placeholder="200000"
+            />
+          </label>
+          <label className="am-field">
+            <span>Max output tokens per session</span>
+            <input
+              className="am-input am-mono"
+              type="number"
+              value={data.maxOutputTokens ?? ""}
+              onChange={e => set("maxOutputTokens", e.target.value ? Number(e.target.value) : undefined)}
+              placeholder="20000"
+            />
+          </label>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/Automations/builder/NodePalette.tsx
+++ b/src/components/Automations/builder/NodePalette.tsx
@@ -1,11 +1,20 @@
-import { nodeIcon, nodeLabel } from "./nodes";
+import { nodeIcon, nodeLabel, nodeDescription } from "./nodes";
 import type { NodeKind } from "./graph";
 
 interface Group { label: string; kinds: NodeKind[] }
 const GROUPS: Group[] = [
-  { label: "Triggers", kinds: ["trigger-manual", "trigger-schedule"] },
-  { label: "Core", kinds: ["agent"] },
-  { label: "Capabilities", kinds: ["tool", "skill", "connection", "subagent"] },
+  { label: "1. Pick a trigger", kinds: ["trigger-manual", "trigger-schedule"] },
+  {
+    // P8: channel triggers. Webhook / Slack / GitHub (P5) will land in a
+    // separate group once they ship; for now these six cover the rest.
+    label: "More triggers",
+    kinds: [
+      "trigger-linear", "trigger-discord", "trigger-telegram",
+      "trigger-teams", "trigger-photon", "trigger-poll",
+    ],
+  },
+  { label: "2. Add the agent", kinds: ["agent"] },
+  { label: "3. Give it capabilities", kinds: ["tool", "flow", "skill", "connection", "subagent"] },
 ];
 
 interface Props {
@@ -17,6 +26,9 @@ interface Props {
 export function NodePalette({ hasAgent, onDragStart, onClick }: Props) {
   return (
     <div className="am-palette">
+      <div className="am-palette-intro">
+        Drag blocks onto the canvas, or click to drop one in the middle.
+      </div>
       {GROUPS.map(g => (
         <div key={g.label} className="am-palette-group">
           <div className="am-palette-label">{g.label}</div>
@@ -25,14 +37,17 @@ export function NodePalette({ hasAgent, onDragStart, onClick }: Props) {
             return (
               <div
                 key={k}
-                className={`am-palette-item${disabled ? " am-palette-item--disabled" : ""}`}
+                className={`am-palette-item am-palette-item--${k}${disabled ? " am-palette-item--disabled" : ""}`}
                 draggable={!disabled}
                 onDragStart={e => !disabled && onDragStart(k, e)}
                 onClick={() => !disabled && onClick(k)}
-                title={disabled ? "Only one Agent per automation" : `Click or drag ${nodeLabel[k]}`}
+                title={disabled ? "Only one Agent per automation" : `Click or drag to add`}
               >
                 <span className="am-palette-icon">{nodeIcon[k]}</span>
-                <span>{nodeLabel[k]}</span>
+                <div className="am-palette-text">
+                  <span className="am-palette-name">{nodeLabel[k]}</span>
+                  <span className="am-palette-desc">{nodeDescription[k]}</span>
+                </div>
               </div>
             );
           })}

--- a/src/components/Automations/builder/NodePalette.tsx
+++ b/src/components/Automations/builder/NodePalette.tsx
@@ -1,0 +1,41 @@
+import { nodeIcon, nodeLabel } from "./nodes";
+import type { NodeKind } from "./graph";
+
+interface Group { label: string; kinds: NodeKind[] }
+const GROUPS: Group[] = [
+  { label: "Triggers", kinds: ["trigger-manual", "trigger-schedule"] },
+  { label: "Core", kinds: ["agent"] },
+  { label: "Capabilities", kinds: ["tool", "skill", "connection", "subagent"] },
+];
+
+interface Props {
+  hasAgent: boolean;
+  onDragStart: (kind: NodeKind, e: React.DragEvent) => void;
+}
+
+export function NodePalette({ hasAgent, onDragStart }: Props) {
+  return (
+    <div className="am-palette">
+      {GROUPS.map(g => (
+        <div key={g.label} className="am-palette-group">
+          <div className="am-palette-label">{g.label}</div>
+          {g.kinds.map(k => {
+            const disabled = k === "agent" && hasAgent;
+            return (
+              <div
+                key={k}
+                className={`am-palette-item${disabled ? " am-palette-item--disabled" : ""}`}
+                draggable={!disabled}
+                onDragStart={e => !disabled && onDragStart(k, e)}
+                title={disabled ? "Only one Agent per automation" : `Drag ${nodeLabel[k]}`}
+              >
+                <span className="am-palette-icon">{nodeIcon[k]}</span>
+                <span>{nodeLabel[k]}</span>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Automations/builder/NodePalette.tsx
+++ b/src/components/Automations/builder/NodePalette.tsx
@@ -11,9 +11,10 @@ const GROUPS: Group[] = [
 interface Props {
   hasAgent: boolean;
   onDragStart: (kind: NodeKind, e: React.DragEvent) => void;
+  onClick: (kind: NodeKind) => void;
 }
 
-export function NodePalette({ hasAgent, onDragStart }: Props) {
+export function NodePalette({ hasAgent, onDragStart, onClick }: Props) {
   return (
     <div className="am-palette">
       {GROUPS.map(g => (
@@ -27,7 +28,8 @@ export function NodePalette({ hasAgent, onDragStart }: Props) {
                 className={`am-palette-item${disabled ? " am-palette-item--disabled" : ""}`}
                 draggable={!disabled}
                 onDragStart={e => !disabled && onDragStart(k, e)}
-                title={disabled ? "Only one Agent per automation" : `Drag ${nodeLabel[k]}`}
+                onClick={() => !disabled && onClick(k)}
+                title={disabled ? "Only one Agent per automation" : `Click or drag ${nodeLabel[k]}`}
               >
                 <span className="am-palette-icon">{nodeIcon[k]}</span>
                 <span>{nodeLabel[k]}</span>

--- a/src/components/Automations/builder/flow/ConditionBuilder.tsx
+++ b/src/components/Automations/builder/flow/ConditionBuilder.tsx
@@ -1,0 +1,61 @@
+import type { Condition, ConditionOp, ToolInputField } from "../graph";
+import { ValueChipsInput } from "../tool/ValueChipsInput";
+
+// P6: shared field+op+value primitive used by `if`, `switch`, and `loop while`.
+
+const OPS: { id: ConditionOp; label: string; unary?: boolean }[] = [
+  { id: "equals",         label: "equals" },
+  { id: "not-equals",     label: "does not equal" },
+  { id: "contains",       label: "contains" },
+  { id: "not-contains",   label: "does not contain" },
+  { id: "gt",             label: "greater than (>)" },
+  { id: "gte",            label: "greater or equal (≥)" },
+  { id: "lt",             label: "less than (<)" },
+  { id: "lte",            label: "less or equal (≤)" },
+  { id: "is-empty",       label: "is empty",     unary: true },
+  { id: "is-not-empty",   label: "is not empty", unary: true },
+  { id: "matches",        label: "matches regex" },
+];
+
+interface Props {
+  condition: Condition;
+  onChange: (c: Condition) => void;
+  fields: ToolInputField[];
+}
+
+export function ConditionBuilder({ condition, onChange, fields }: Props) {
+  const op = OPS.find(o => o.id === condition.op) || OPS[0];
+  return (
+    <div className="am-cond">
+      <div className="am-cond-row">
+        <ValueChipsInput
+          value={condition.left}
+          onChange={v => onChange({ ...condition, left: v })}
+          fields={fields}
+          placeholder="{{input.something}}"
+          mono
+        />
+      </div>
+      <div className="am-cond-row">
+        <select
+          className="am-input"
+          value={condition.op}
+          onChange={e => onChange({ ...condition, op: e.target.value as ConditionOp })}
+        >
+          {OPS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+        </select>
+      </div>
+      {!op.unary && (
+        <div className="am-cond-row">
+          <ValueChipsInput
+            value={condition.right}
+            onChange={v => onChange({ ...condition, right: v })}
+            fields={fields}
+            placeholder="value or {{input.other}}"
+            mono
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Automations/builder/flow/StepEditor.tsx
+++ b/src/components/Automations/builder/flow/StepEditor.tsx
@@ -1,0 +1,385 @@
+import type { FlowStep, ToolInputField, SetVar, SwitchCase, HttpRequest } from "../graph";
+import { emptyCondition, emptyRequest } from "../graph";
+import { Plus, Trash2, GripVertical } from "lucide-react";
+import { ConditionBuilder } from "./ConditionBuilder";
+import { RequestBuilder } from "../tool/RequestBuilder";
+import { ValueChipsInput } from "../tool/ValueChipsInput";
+
+// P6/P7: renders a step list. Recursive — `if`/`switch`/`loop`/`parallel`
+// steps embed nested StepList editors. Kept dense — every collapsible would
+// double the code. If step-count in real flows explodes, add collapse then.
+// ponytail: flat rendering, add collapsing when a real user has >20 steps.
+
+const KIND_LABELS: Record<FlowStep["kind"], string> = {
+  call:     "HTTP call",
+  if:       "If / Else",
+  switch:   "Switch",
+  set:      "Set variable(s)",
+  return:   "Return",
+  loop:     "Loop",
+  parallel: "Parallel (merge)",
+};
+
+const KINDS = Object.keys(KIND_LABELS) as FlowStep["kind"][];
+
+function rid() { return Math.random().toString(36).slice(2, 10); }
+
+function emptyStep(kind: FlowStep["kind"]): FlowStep {
+  switch (kind) {
+    case "call":     return { id: rid(), kind, assignTo: "", request: emptyRequest() };
+    case "if":       return { id: rid(), kind, condition: emptyCondition(), then: [], else: [] };
+    case "switch":   return { id: rid(), kind, cases: [], default: [] };
+    case "set":      return { id: rid(), kind, vars: [{ name: "", value: "" }] };
+    case "return":   return { id: rid(), kind, value: "" };
+    case "loop":     return {
+      id: rid(), kind, shape: "for-each",
+      listChip: "", itemVar: "item",
+      condition: emptyCondition(), body: [],
+    };
+    case "parallel": return { id: rid(), kind, mode: "all", branches: [[], []] };
+  }
+}
+
+// Chip fields visible inside a flow: the flow inputs + variables introduced
+// by prior `set`/`call` steps + any loop iteration var currently in scope.
+// We only surface `set`/`call` names — chasing "prior in the tree" precisely
+// isn't worth the cycles; the chip menu is a hint, users can type anything.
+export function scopedFields(
+  base: ToolInputField[],
+  steps: FlowStep[],
+): ToolInputField[] {
+  const extras: ToolInputField[] = [];
+  const walk = (ss: FlowStep[]) => {
+    for (const s of ss) {
+      if (s.kind === "set") {
+        for (const v of s.vars) if (v.name) extras.push({ name: v.name, type: "string", required: false });
+      }
+      if (s.kind === "call" && s.assignTo) {
+        extras.push({ name: s.assignTo, type: "string", required: false });
+      }
+      if (s.kind === "if") { walk(s.then); walk(s.else); }
+      if (s.kind === "switch") { for (const c of s.cases) walk(c.steps); walk(s.default); }
+      if (s.kind === "loop") { extras.push({ name: s.itemVar || "item", type: "string", required: false }); walk(s.body); }
+      if (s.kind === "parallel") { for (const b of s.branches) walk(b); }
+    }
+  };
+  walk(steps);
+  // Dedupe by name — later wins.
+  const merged = new Map<string, ToolInputField>();
+  for (const f of base) merged.set(f.name, f);
+  for (const f of extras) if (f.name) merged.set(f.name, f);
+  return Array.from(merged.values());
+}
+
+interface Props {
+  steps: FlowStep[];
+  onChange: (s: FlowStep[]) => void;
+  fields: ToolInputField[];
+  /** Root flow-input fields (used for chip menus in nested editors too). */
+  rootFields: ToolInputField[];
+}
+
+export function StepList({ steps, onChange, fields, rootFields }: Props) {
+  const replaceAt = (i: number, s: FlowStep) => {
+    const next = [...steps]; next[i] = s; onChange(next);
+  };
+  const removeAt = (i: number) => onChange(steps.filter((_, j) => j !== i));
+  const moveUp = (i: number) => {
+    if (i === 0) return;
+    const next = [...steps];
+    [next[i - 1], next[i]] = [next[i], next[i - 1]];
+    onChange(next);
+  };
+  const add = (kind: FlowStep["kind"]) => onChange([...steps, emptyStep(kind)]);
+
+  return (
+    <div className="am-steplist">
+      {steps.map((s, i) => (
+        <div key={s.id} className="am-step">
+          <div className="am-step-head">
+            <button type="button" className="am-step-drag" onClick={() => moveUp(i)} title="Move up">
+              <GripVertical size={12} />
+            </button>
+            <span className="am-step-kind">{KIND_LABELS[s.kind]}</span>
+            <button type="button" className="am-step-del" onClick={() => removeAt(i)} title="Delete step">
+              <Trash2 size={12} />
+            </button>
+          </div>
+          <div className="am-step-body">
+            <StepBody step={s} onChange={next => replaceAt(i, next)} fields={fields} rootFields={rootFields} />
+          </div>
+        </div>
+      ))}
+      <div className="am-step-add">
+        <span className="am-hint">Add a step:</span>
+        {KINDS.map(k => (
+          <button key={k} type="button" className="am-step-add-btn" onClick={() => add(k)}>
+            <Plus size={11} /> {KIND_LABELS[k]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StepBody({ step, onChange, fields, rootFields }: {
+  step: FlowStep;
+  onChange: (s: FlowStep) => void;
+  fields: ToolInputField[];
+  rootFields: ToolInputField[];
+}) {
+  if (step.kind === "call") {
+    return (
+      <>
+        <label className="am-field">
+          <span>Save the response as</span>
+          <input
+            className="am-input am-mono"
+            value={step.assignTo}
+            onChange={e => onChange({ ...step, assignTo: e.target.value })}
+            placeholder="weather"
+          />
+          <span className="am-hint-block">Later steps can read this back as <code>{`{{input.${step.assignTo || "name"}}}`}</code>.</span>
+        </label>
+        <RequestBuilder
+          request={step.request as HttpRequest}
+          onChange={r => onChange({ ...step, request: r })}
+          fields={fields}
+        />
+      </>
+    );
+  }
+  if (step.kind === "if") {
+    return (
+      <>
+        <div className="am-field"><span>Condition</span>
+          <ConditionBuilder
+            condition={step.condition}
+            onChange={c => onChange({ ...step, condition: c })}
+            fields={fields}
+          />
+        </div>
+        <div className="am-branch">
+          <div className="am-branch-label">Then</div>
+          <StepList
+            steps={step.then}
+            onChange={s => onChange({ ...step, then: s })}
+            fields={scopedFields(rootFields, step.then)}
+            rootFields={rootFields}
+          />
+        </div>
+        <div className="am-branch">
+          <div className="am-branch-label">Else</div>
+          <StepList
+            steps={step.else}
+            onChange={s => onChange({ ...step, else: s })}
+            fields={scopedFields(rootFields, step.else)}
+            rootFields={rootFields}
+          />
+        </div>
+      </>
+    );
+  }
+  if (step.kind === "switch") {
+    const addCase = () => onChange({
+      ...step,
+      cases: [...step.cases, { label: "case", condition: emptyCondition(), steps: [] }],
+    });
+    const setCase = (i: number, c: SwitchCase) => {
+      const next = [...step.cases]; next[i] = c; onChange({ ...step, cases: next });
+    };
+    const removeCase = (i: number) =>
+      onChange({ ...step, cases: step.cases.filter((_, j) => j !== i) });
+    return (
+      <>
+        {step.cases.map((c, i) => (
+          <div key={i} className="am-branch">
+            <div className="am-branch-label">
+              <input
+                className="am-input am-input--fit"
+                value={c.label}
+                onChange={e => setCase(i, { ...c, label: e.target.value })}
+                placeholder="Case name"
+              />
+              <button type="button" className="am-step-del" onClick={() => removeCase(i)}>
+                <Trash2 size={12} />
+              </button>
+            </div>
+            <ConditionBuilder
+              condition={c.condition}
+              onChange={cond => setCase(i, { ...c, condition: cond })}
+              fields={fields}
+            />
+            <StepList
+              steps={c.steps}
+              onChange={ss => setCase(i, { ...c, steps: ss })}
+              fields={scopedFields(rootFields, c.steps)}
+              rootFields={rootFields}
+            />
+          </div>
+        ))}
+        <button type="button" className="am-step-add-btn" onClick={addCase}>
+          <Plus size={11} /> Add case
+        </button>
+        <div className="am-branch">
+          <div className="am-branch-label">Default (none matched)</div>
+          <StepList
+            steps={step.default}
+            onChange={s => onChange({ ...step, default: s })}
+            fields={scopedFields(rootFields, step.default)}
+            rootFields={rootFields}
+          />
+        </div>
+      </>
+    );
+  }
+  if (step.kind === "set") {
+    const setVar = (i: number, v: SetVar) => {
+      const next = [...step.vars]; next[i] = v; onChange({ ...step, vars: next });
+    };
+    return (
+      <>
+        {step.vars.map((v, i) => (
+          <div key={i} className="am-row am-row--tight">
+            <input
+              className="am-input am-mono am-input--fit"
+              value={v.name}
+              onChange={e => setVar(i, { ...v, name: e.target.value })}
+              placeholder="name"
+            />
+            <div className="am-field am-field--grow">
+              <ValueChipsInput
+                value={v.value}
+                onChange={val => setVar(i, { ...v, value: val })}
+                fields={fields}
+                placeholder="value (chips allowed)"
+                mono
+              />
+            </div>
+            <button type="button" className="am-step-del"
+              onClick={() => onChange({ ...step, vars: step.vars.filter((_, j) => j !== i) })}>
+              <Trash2 size={12} />
+            </button>
+          </div>
+        ))}
+        <button type="button" className="am-step-add-btn"
+          onClick={() => onChange({ ...step, vars: [...step.vars, { name: "", value: "" }] })}>
+          <Plus size={11} /> Add variable
+        </button>
+      </>
+    );
+  }
+  if (step.kind === "return") {
+    return (
+      <label className="am-field">
+        <span>Return this value to the agent</span>
+        <ValueChipsInput
+          value={step.value}
+          onChange={v => onChange({ ...step, value: v })}
+          fields={fields}
+          placeholder="{{input.result}} or a literal"
+          multiline
+          rows={2}
+          mono
+        />
+      </label>
+    );
+  }
+  if (step.kind === "loop") {
+    return (
+      <>
+        <div className="am-segmented">
+          <button type="button"
+            className={`am-segmented-btn${step.shape === "for-each" ? " am-segmented-btn--active" : ""}`}
+            onClick={() => onChange({ ...step, shape: "for-each" })}
+          >For each item</button>
+          <button type="button"
+            className={`am-segmented-btn${step.shape === "while" ? " am-segmented-btn--active" : ""}`}
+            onClick={() => onChange({ ...step, shape: "while" })}
+          >While condition</button>
+        </div>
+        {step.shape === "for-each" ? (
+          <div className="am-row">
+            <label className="am-field am-field--grow">
+              <span>List to iterate</span>
+              <ValueChipsInput
+                value={step.listChip}
+                onChange={v => onChange({ ...step, listChip: v })}
+                fields={fields}
+                placeholder="{{input.items}}"
+                mono
+              />
+            </label>
+            <label className="am-field am-field--fixed">
+              <span>Each item as</span>
+              <input
+                className="am-input am-mono"
+                value={step.itemVar}
+                onChange={e => onChange({ ...step, itemVar: e.target.value })}
+                placeholder="item"
+              />
+            </label>
+          </div>
+        ) : (
+          <div className="am-field"><span>Condition (loops while true)</span>
+            <ConditionBuilder
+              condition={step.condition}
+              onChange={c => onChange({ ...step, condition: c })}
+              fields={fields}
+            />
+          </div>
+        )}
+        <div className="am-branch">
+          <div className="am-branch-label">Do these steps each time</div>
+          <StepList
+            steps={step.body}
+            onChange={s => onChange({ ...step, body: s })}
+            fields={scopedFields(rootFields, step.body)}
+            rootFields={rootFields}
+          />
+        </div>
+      </>
+    );
+  }
+  if (step.kind === "parallel") {
+    return (
+      <>
+        <div className="am-segmented">
+          <button type="button"
+            className={`am-segmented-btn${step.mode === "all" ? " am-segmented-btn--active" : ""}`}
+            onClick={() => onChange({ ...step, mode: "all" })}
+          >Wait for all branches</button>
+          <button type="button"
+            className={`am-segmented-btn${step.mode === "race" ? " am-segmented-btn--active" : ""}`}
+            onClick={() => onChange({ ...step, mode: "race" })}
+          >First finished wins</button>
+        </div>
+        {step.branches.map((b, i) => (
+          <div key={i} className="am-branch">
+            <div className="am-branch-label">
+              Branch {i + 1}
+              <button type="button" className="am-step-del"
+                onClick={() => onChange({ ...step, branches: step.branches.filter((_, j) => j !== i) })}>
+                <Trash2 size={12} />
+              </button>
+            </div>
+            <StepList
+              steps={b}
+              onChange={ss => {
+                const next = [...step.branches]; next[i] = ss;
+                onChange({ ...step, branches: next });
+              }}
+              fields={scopedFields(rootFields, b)}
+              rootFields={rootFields}
+            />
+          </div>
+        ))}
+        <button type="button" className="am-step-add-btn"
+          onClick={() => onChange({ ...step, branches: [...step.branches, []] })}>
+          <Plus size={11} /> Add branch
+        </button>
+      </>
+    );
+  }
+  return null;
+}

--- a/src/components/Automations/builder/graph.ts
+++ b/src/components/Automations/builder/graph.ts
@@ -1,0 +1,113 @@
+// Graph JSON schema — single source of truth for the builder.
+// Serialized into automations.graph (TEXT); consumed by both React Flow and the
+// Rust `generate_eve_project` writer. Keep field names snake_case-free so JSON
+// maps 1:1 to Rust structs via serde.
+
+export type NodeKind =
+  | "trigger-manual"
+  | "trigger-schedule"
+  | "agent"
+  | "tool"
+  | "skill"
+  | "connection"
+  | "subagent";
+
+export interface XY { x: number; y: number }
+
+interface BaseNode<K extends NodeKind, D> {
+  id: string;
+  kind: K;
+  position: XY;
+  data: D;
+}
+
+export interface TriggerManualData {
+  label?: string;
+}
+export interface TriggerScheduleData {
+  cron: string;              // "0 9 * * 1-5"
+  prompt: string;            // markdown fire-and-forget prompt
+}
+export interface AgentData {
+  model: string;             // e.g. "anthropic/claude-sonnet-5"
+  instructions: string;      // system prompt (markdown)
+  sandbox: "auto" | "docker" | "none";
+  reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+}
+export type ToolPreset = "http" | "custom";
+export interface ToolData {
+  name: string;              // filename slug
+  description: string;
+  preset: ToolPreset;
+  // preset === "http"
+  httpMethod?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  httpUrl?: string;
+  // preset === "custom" — raw TS body of `execute`
+  customInputSchema?: string;  // e.g. `z.object({ query: z.string() })`
+  customExecute?: string;      // body of async execute(input, ctx) { ... }
+}
+export interface SkillData {
+  name: string;              // filename slug
+  markdown: string;
+}
+export type ConnectionKind = "mcp" | "openapi";
+export interface ConnectionData {
+  name: string;              // filename slug
+  kind: ConnectionKind;
+  url: string;               // MCP server URL or OpenAPI spec URL
+}
+export interface SubagentData {
+  name: string;              // directory slug under subagents/
+  model: string;
+  description: string;       // required by Eve for delegation
+  instructions: string;
+}
+
+export type Node =
+  | BaseNode<"trigger-manual", TriggerManualData>
+  | BaseNode<"trigger-schedule", TriggerScheduleData>
+  | BaseNode<"agent", AgentData>
+  | BaseNode<"tool", ToolData>
+  | BaseNode<"skill", SkillData>
+  | BaseNode<"connection", ConnectionData>
+  | BaseNode<"subagent", SubagentData>;
+
+// Typed edges. `fires` connects a Trigger to the Agent (top port).
+// `model|tool|skill|connection|subagent` connect the Agent's bottom typed
+// handles to sub-node top handles.
+export type EdgeKind = "fires" | "model" | "tool" | "skill" | "connection" | "subagent";
+
+export interface Edge {
+  id: string;
+  source: string;   // node id
+  target: string;   // node id
+  kind: EdgeKind;
+}
+
+export interface Graph {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export const emptyGraph: Graph = { nodes: [], edges: [] };
+
+export function parseGraph(s: string | null | undefined): Graph {
+  if (!s) return emptyGraph;
+  try {
+    const g = JSON.parse(s) as Graph;
+    return { nodes: g.nodes ?? [], edges: g.edges ?? [] };
+  } catch {
+    return emptyGraph;
+  }
+}
+
+export function findAgent(g: Graph): Extract<Node, { kind: "agent" }> | undefined {
+  return g.nodes.find((n): n is Extract<Node, { kind: "agent" }> => n.kind === "agent");
+}
+
+// ponytail: slugify is one line, kept here so backend + frontend agree.
+export function slugify(s: string): string {
+  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "item";
+}

--- a/src/components/Automations/builder/graph.ts
+++ b/src/components/Automations/builder/graph.ts
@@ -6,11 +6,25 @@
 export type NodeKind =
   | "trigger-manual"
   | "trigger-schedule"
+  // P8: additional trigger channels (P5's webhook/slack/github deferred — TODO).
+  | "trigger-linear"
+  | "trigger-discord"
+  | "trigger-telegram"
+  | "trigger-teams"
+  | "trigger-photon"
+  | "trigger-poll"
   | "agent"
   | "tool"
   | "skill"
   | "connection"
-  | "subagent";
+  | "subagent"
+  // P6/P7: control-flow container. Its data.steps carries a linear tree of
+  // `FlowStep` values (if/switch/set/return/loop/parallel/call). The Rust
+  // writer compiles it to one `agent/tools/<flowName>.ts` file. We keep
+  // steps *inside* the flow node's data rather than as separate top-level
+  // nodes on the canvas — same semantics, a small fraction of the wiring
+  // work, and no need for a nested sub-canvas UI.
+  | "flow";
 
 export interface XY { x: number; y: number }
 
@@ -36,17 +50,80 @@ export interface AgentData {
   maxInputTokens?: number;
   maxOutputTokens?: number;
 }
-export type ToolPreset = "http" | "custom";
+// ── Tool: HTTP-request-first, code-free ─────────────────────────────────────
+// Everything is visual. Values in `url`, `queryParams[].value`, `headers[].value`,
+// `body.fields[].value`, and `body.text` may contain chip tokens like
+// `{{input.city}}` which the Rust writer resolves at runtime against `input`.
+// See automations-enhance.md Phase 1-3.
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface KV { key: string; value: string; enabled: boolean }
+
+export type HttpAuth =
+  | { kind: "none" }
+  | { kind: "bearer"; token: string }
+  | { kind: "basic"; user: string; pass: string }
+  | { kind: "apiKey"; in: "header" | "query"; name: string; value: string };
+
+export type HttpBody =
+  | { kind: "none" }
+  | { kind: "json"; fields: KV[] }
+  | { kind: "form"; fields: KV[] }
+  | { kind: "raw"; contentType: string; text: string };
+
+export interface HttpRequest {
+  method: HttpMethod;
+  url: string;
+  queryParams: KV[];
+  headers: KV[];
+  auth: HttpAuth;
+  body: HttpBody;
+}
+
+export type ToolInputType = "string" | "number" | "boolean" | "enum";
+export interface ToolInputField {
+  name: string;
+  type: ToolInputType;
+  required: boolean;
+  enumValues?: string[];
+  description?: string;
+}
+export interface ToolInputSchema {
+  fields: ToolInputField[];
+}
+
+export interface ResponseMap {
+  kind: "raw" | "pick";
+  pick?: string;   // JSONPath-ish: "data.items[0].name" — set by the visual picker
+}
+
 export interface ToolData {
-  name: string;              // filename slug
-  description: string;
-  preset: ToolPreset;
-  // preset === "http"
-  httpMethod?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-  httpUrl?: string;
-  // preset === "custom" — raw TS body of `execute`
-  customInputSchema?: string;  // e.g. `z.object({ query: z.string() })`
-  customExecute?: string;      // body of async execute(input, ctx) { ... }
+  name: string;              // filename slug the agent calls
+  description: string;       // shown to the agent
+  request: HttpRequest;
+  input: ToolInputSchema;
+  response: ResponseMap;
+}
+
+export function emptyRequest(): HttpRequest {
+  return {
+    method: "GET",
+    url: "",
+    queryParams: [],
+    headers: [],
+    auth: { kind: "none" },
+    body: { kind: "none" },
+  };
+}
+export function emptyToolData(): ToolData {
+  return {
+    name: "",
+    description: "",
+    request: emptyRequest(),
+    input: { fields: [] },
+    response: { kind: "raw" },
+  };
 }
 export interface SkillData {
   name: string;              // filename slug
@@ -65,19 +142,121 @@ export interface SubagentData {
   instructions: string;
 }
 
+// ── P6/P7: control-flow tree ─────────────────────────────────────────────────
+// A `flow` node is a callable capability (like a tool). Its data.steps is a
+// linear tree; the compiler walks it and emits one `agent/tools/<name>.ts`.
+//
+// Chip resolution: every {{input.<name>}} inside a flow resolves against a
+// merged runtime scope: flow inputs, `set`-vars, `call.assignTo` results,
+// and loop iteration variables. The chip helper is the same one tools use.
+
+export type ConditionOp =
+  | "equals" | "not-equals"
+  | "contains" | "not-contains"
+  | "gt" | "gte" | "lt" | "lte"
+  | "is-empty" | "is-not-empty"
+  | "matches";               // regex
+
+export interface Condition {
+  left: string;              // chip expression, e.g. "{{input.city}}"
+  op: ConditionOp;
+  right: string;             // chip expression or literal (unused for is-empty)
+}
+
+export interface SetVar { name: string; value: string }
+
+export interface SwitchCase {
+  label: string;
+  condition: Condition;
+  steps: FlowStep[];
+}
+
+export type FlowStep =
+  | { id: string; kind: "call"; assignTo: string; request: HttpRequest }
+  | { id: string; kind: "if"; condition: Condition; then: FlowStep[]; else: FlowStep[] }
+  | { id: string; kind: "switch"; cases: SwitchCase[]; default: FlowStep[] }
+  | { id: string; kind: "set"; vars: SetVar[] }
+  | { id: string; kind: "return"; value: string }
+  | {
+      id: string;
+      kind: "loop";
+      shape: "for-each" | "while";
+      listChip: string;      // for-each: chip resolving to an array (or JSON string)
+      itemVar: string;       // name introduced into scope inside the body
+      condition: Condition;  // while shape
+      body: FlowStep[];
+    }
+  | {
+      id: string;
+      kind: "parallel";
+      mode: "all" | "race";
+      branches: FlowStep[][];
+    };
+
+export interface FlowData {
+  name: string;              // filename slug — the agent calls this as a tool
+  description: string;       // shown to the agent (like ToolData.description)
+  input: ToolInputSchema;    // reuse tool input shape
+  steps: FlowStep[];
+}
+
+export function emptyCondition(): Condition {
+  return { left: "", op: "equals", right: "" };
+}
+export function emptyFlowData(): FlowData {
+  return {
+    name: "",
+    description: "",
+    input: { fields: [] },
+    steps: [],
+  };
+}
+
+// ── P8: trigger channel node data ────────────────────────────────────────────
+// Every trigger-channel kind shares the same shape: a set of KV fields plus a
+// per-automation secret bag (`.env` refs). We keep it uniform so one modal
+// serves all six kinds and the Rust writer branches once on `kind`.
+//
+// Field values may be chip refs like `{{secrets.<slug>}}` — those are stored
+// verbatim; the Rust writer emits a `.env` alongside the project and rewrites
+// the reference to `process.env.<slug>` at generate time.
+
+export interface ChannelSecret { slug: string; value: string }
+
+export interface TriggerChannelData {
+  // Fields keyed by channel kind — see writer for the schema per kind.
+  fields: KV[];
+  // Per-node secret bag. Persisted; user pastes once, chip form is
+  // `{{secrets.<slug>}}` and the `slug` here matches the chip.
+  secrets: ChannelSecret[];
+  // Free-text prompt fired when the trigger delivers input to the agent.
+  prompt: string;
+}
+
+export function emptyTriggerChannelData(): TriggerChannelData {
+  return { fields: [], secrets: [], prompt: "" };
+}
+
 export type Node =
   | BaseNode<"trigger-manual", TriggerManualData>
   | BaseNode<"trigger-schedule", TriggerScheduleData>
+  | BaseNode<"trigger-linear", TriggerChannelData>
+  | BaseNode<"trigger-discord", TriggerChannelData>
+  | BaseNode<"trigger-telegram", TriggerChannelData>
+  | BaseNode<"trigger-teams", TriggerChannelData>
+  | BaseNode<"trigger-photon", TriggerChannelData>
+  | BaseNode<"trigger-poll", TriggerChannelData>
   | BaseNode<"agent", AgentData>
   | BaseNode<"tool", ToolData>
   | BaseNode<"skill", SkillData>
   | BaseNode<"connection", ConnectionData>
-  | BaseNode<"subagent", SubagentData>;
+  | BaseNode<"subagent", SubagentData>
+  | BaseNode<"flow", FlowData>;
 
 // Typed edges. `fires` connects a Trigger to the Agent (top port).
-// `model|tool|skill|connection|subagent` connect the Agent's bottom typed
-// handles to sub-node top handles.
-export type EdgeKind = "fires" | "model" | "tool" | "skill" | "connection" | "subagent";
+// `model|tool|skill|connection|subagent|flow` connect the Agent's bottom
+// typed handles to sub-node top handles.
+export type EdgeKind = "fires" | "model" | "tool" | "skill" | "connection" | "subagent" | "flow";
 
 export interface Edge {
   id: string;

--- a/src/components/Automations/builder/humanCron.ts
+++ b/src/components/Automations/builder/humanCron.ts
@@ -1,0 +1,146 @@
+// Human-friendly schedule presets over cron strings.
+// The graph still stores raw cron ("0 9 * * 1-5") so the Rust writer is unchanged.
+// Custom-cron is no code path in the UI — unrecognized cron parses to `custom`
+// only as a *display* fallback (the readback shows the raw string) so old data
+// stays viewable; the picker never exposes it as a selectable preset.
+
+export type SchedulePreset =
+  | "every-minutes"
+  | "every-hours"
+  | "daily"
+  | "weekdays"
+  | "on-days"          // subset of weekdays at one time  → "M H * * D,D,D"
+  | "times-per-day"    // several hours (shared minute)   → "M H,H,H * * *"
+  | "weekly"
+  | "monthly"
+  | "custom";          // read-only fallback for unknown cron
+
+export interface ScheduleState {
+  preset: SchedulePreset;
+  n: number;              // every-minutes / every-hours
+  hour: number;           // 0-23
+  minute: number;         // 0-59
+  weekday: number;        // 0-6 (Sun=0)  — weekly
+  day: number;            // 1-28         — monthly
+  weekdays: number[];     // sorted subset of 0-6 — on-days
+  hours: number[];        // sorted subset of 0-23 — times-per-day
+}
+
+const DEFAULT: ScheduleState = {
+  preset: "weekdays",
+  n: 15,
+  hour: 9,
+  minute: 0,
+  weekday: 1,
+  day: 1,
+  weekdays: [1, 3, 5],
+  hours: [9, 15],
+};
+
+const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const WEEKDAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function pad(n: number) { return String(n).padStart(2, "0"); }
+
+export function formatTime(h: number, m: number): string {
+  const period = h < 12 ? "AM" : "PM";
+  const h12 = ((h + 11) % 12) + 1;
+  return `${h12}:${pad(m)} ${period}`;
+}
+
+const parseList = (s: string, max: number): number[] | null => {
+  const out: number[] = [];
+  for (const p of s.split(",")) {
+    if (!/^\d+$/.test(p)) return null;
+    const n = +p;
+    if (n < 0 || n > max) return null;
+    out.push(n);
+  }
+  return Array.from(new Set(out)).sort((a, b) => a - b);
+};
+
+// Parse a cron string back into a preset+state. Falls back to "custom" if it
+// doesn't match one of the friendly patterns — the picker treats that as
+// read-only, but readback still shows the raw string.
+export function parseCron(cron: string): ScheduleState {
+  const s = (cron || "").trim();
+  if (!s) return DEFAULT;
+  const parts = s.split(/\s+/);
+  if (parts.length !== 5) return { ...DEFAULT, preset: "custom" };
+  const [mn, hr, dom, mon, dow] = parts;
+
+  const mMin = /^\*\/(\d+)$/.exec(mn);
+  if (mMin && hr === "*" && dom === "*" && mon === "*" && dow === "*") {
+    return { ...DEFAULT, preset: "every-minutes", n: Math.max(1, +mMin[1]) };
+  }
+  const mHr = /^\*\/(\d+)$/.exec(hr);
+  if (mn === "0" && mHr && dom === "*" && mon === "*" && dow === "*") {
+    return { ...DEFAULT, preset: "every-hours", n: Math.max(1, +mHr[1]) };
+  }
+  const isNum = (v: string) => /^\d+$/.test(v);
+
+  // times-per-day: M H1,H2,H3 * * *
+  if (isNum(mn) && mn.length && dom === "*" && mon === "*" && dow === "*" && hr.includes(",")) {
+    const hours = parseList(hr, 23);
+    if (hours) return { ...DEFAULT, preset: "times-per-day", minute: +mn, hours };
+  }
+
+  if (isNum(mn) && isNum(hr) && mon === "*") {
+    const minute = +mn, hour = +hr;
+    if (dom === "*" && dow === "*") return { ...DEFAULT, preset: "daily", hour, minute };
+    if (dom === "*" && dow === "1-5") return { ...DEFAULT, preset: "weekdays", hour, minute };
+    if (dom === "*" && dow.includes(",")) {
+      const weekdays = parseList(dow, 6);
+      if (weekdays) return { ...DEFAULT, preset: "on-days", hour, minute, weekdays };
+    }
+    if (dom === "*" && isNum(dow)) return { ...DEFAULT, preset: "weekly", hour, minute, weekday: +dow };
+    if (isNum(dom) && dow === "*") return { ...DEFAULT, preset: "monthly", hour, minute, day: +dom };
+  }
+  return { ...DEFAULT, preset: "custom" };
+}
+
+export function buildCron(st: ScheduleState): string {
+  switch (st.preset) {
+    case "every-minutes": return `*/${Math.max(1, Math.min(59, st.n | 0))} * * * *`;
+    case "every-hours":   return `0 */${Math.max(1, Math.min(23, st.n | 0))} * * *`;
+    case "daily":         return `${st.minute} ${st.hour} * * *`;
+    case "weekdays":      return `${st.minute} ${st.hour} * * 1-5`;
+    case "on-days": {
+      const ds = (st.weekdays.length ? st.weekdays : [1]).slice().sort((a, b) => a - b).join(",");
+      return `${st.minute} ${st.hour} * * ${ds}`;
+    }
+    case "times-per-day": {
+      const hs = (st.hours.length ? st.hours : [9]).slice().sort((a, b) => a - b).join(",");
+      return `${st.minute} ${hs} * * *`;
+    }
+    case "weekly":        return `${st.minute} ${st.hour} * * ${st.weekday}`;
+    case "monthly":       return `${st.minute} ${st.hour} ${Math.max(1, Math.min(28, st.day | 0))} * *`;
+    case "custom":        return "";
+  }
+}
+
+const listWeekdays = (ds: number[]): string =>
+  ds.length === 0 ? "no days"
+  : ds.length === 1 ? WEEKDAYS[ds[0]]
+  : ds.slice(0, -1).map(d => WEEKDAYS_SHORT[d]).join(", ") + " and " + WEEKDAYS_SHORT[ds[ds.length - 1]];
+
+export function describeCron(cron: string): string {
+  const st = parseCron(cron);
+  switch (st.preset) {
+    case "every-minutes": return `Every ${st.n} minute${st.n === 1 ? "" : "s"}`;
+    case "every-hours":   return `Every ${st.n} hour${st.n === 1 ? "" : "s"}`;
+    case "daily":         return `Every day at ${formatTime(st.hour, st.minute)}`;
+    case "weekdays":      return `Weekdays at ${formatTime(st.hour, st.minute)}`;
+    case "on-days":       return `${listWeekdays(st.weekdays)} at ${formatTime(st.hour, st.minute)}`;
+    case "times-per-day": {
+      const hs = st.hours.map(h => formatTime(h, st.minute)).join(", ");
+      return `Every day at ${hs}`;
+    }
+    case "weekly":        return `Every ${WEEKDAYS[st.weekday]} at ${formatTime(st.hour, st.minute)}`;
+    case "monthly":       return `Day ${st.day} each month at ${formatTime(st.hour, st.minute)}`;
+    case "custom":        return cron ? `Custom cron: ${cron}` : "No schedule set";
+  }
+}
+
+export const WEEKDAY_NAMES = WEEKDAYS;
+export const WEEKDAY_NAMES_SHORT = WEEKDAYS_SHORT;

--- a/src/components/Automations/builder/nodes.tsx
+++ b/src/components/Automations/builder/nodes.tsx
@@ -1,172 +1,316 @@
 import { memo } from "react";
-import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
 import {
-  Bot, Wrench, BookOpen, Plug, Users, Play, Clock,
+  Bot, Wrench, BookOpen, Plug, Users, Play, Clock, AlertCircle,
+  GitBranch, MessageSquare, Send, Layers, Activity, Ticket,
 } from "lucide-react";
 import type {
   AgentData, ToolData, SkillData, ConnectionData, SubagentData,
-  TriggerManualData, TriggerScheduleData,
+  TriggerManualData, TriggerScheduleData, FlowData, TriggerChannelData,
 } from "./graph";
+import { describeCron } from "./humanCron";
+import { NodeConnector } from "./NodeConnector";
 
-// One bottom port on Agent for all sub-node attachments. Edge color derives
-// from the connected sub-node kind (see builder.tsx / edge style). Keeps the
-// component simple; typed handles can come later if visual grouping matters.
-// ponytail: one handle, color the wire; upgrade to 4 typed handles if the
-// visual grouping becomes worth the code.
+// Left-to-right flow, Threads-style connectors:
+//   Trigger — [right]
+//   Agent   [left] — [right]  (right feeds capabilities)
+//   Capability nodes [left] —
+// Handles live in the header row via <NodeConnector />.
+
+type Tone = "trigger" | "agent" | "tool" | "skill" | "connection" | "subagent" | "flow";
 
 function NodeCard(props: {
+  nodeId: string;
   icon: React.ReactNode;
-  title: string;
-  subtitle?: string;
-  tone: "trigger" | "agent" | "tool" | "skill" | "connection" | "subagent";
+  kindLabel: string;
+  primary: string;
+  secondary?: string;
+  needsSetup?: boolean;
+  tone: Tone;
   selected?: boolean;
-  topHandle?: boolean;
-  bottomHandle?: boolean;
-  rightHandle?: boolean;
-  leftHandle?: boolean;
+  hasLeft?: boolean;
+  hasRight?: boolean;
 }) {
   return (
     <div className={`amn amn--${props.tone}${props.selected ? " amn--selected" : ""}`}>
-      {props.topHandle && <Handle type="target" position={Position.Top} id="t" />}
-      {props.leftHandle && <Handle type="target" position={Position.Left} id="l" />}
-      <div className="amn-body">
+      <div className="amn-head">
+        {props.hasLeft && <NodeConnector nodeId={props.nodeId} side="left" />}
         <span className="amn-icon">{props.icon}</span>
-        <div className="amn-text">
-          <span className="amn-title">{props.title}</span>
-          {props.subtitle && <span className="amn-sub">{props.subtitle}</span>}
-        </div>
+        <span className="amn-kind">{props.kindLabel}</span>
+        {props.needsSetup && (
+          <span className="amn-badge" title="This node needs to be set up before it will run">
+            <AlertCircle size={11} /> Set up
+          </span>
+        )}
+        {props.hasRight && <NodeConnector nodeId={props.nodeId} side="right" />}
       </div>
-      {props.rightHandle && <Handle type="source" position={Position.Right} id="r" />}
-      {props.bottomHandle && <Handle type="source" position={Position.Bottom} id="b" />}
+      <div className="amn-primary" title={props.primary}>{props.primary}</div>
+      {props.secondary && (
+        <div className="amn-secondary" title={props.secondary}>{props.secondary}</div>
+      )}
     </div>
   );
 }
 
-const TriggerManualNode = memo(({ data, selected }: NodeProps) => {
+function firstLine(s: string | undefined, max = 60): string | undefined {
+  if (!s) return undefined;
+  const line = s.replace(/^#+\s*/, "").split(/\r?\n/).find(l => l.trim().length > 0);
+  if (!line) return undefined;
+  return line.length > max ? line.slice(0, max - 1) + "…" : line;
+}
+
+function hostOf(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try { return new URL(url).host; } catch { return url.length > 40 ? url.slice(0, 39) + "…" : url; }
+}
+
+function modelName(id: string | undefined): string {
+  if (!id) return "Default model";
+  const slash = id.indexOf("/");
+  return slash > 0 ? id.slice(slash + 1) : id;
+}
+
+const TriggerManualNode = memo(({ id, data, selected }: NodeProps) => {
   const d = data as unknown as TriggerManualData;
   return (
     <NodeCard
+      nodeId={id}
+      tone="trigger"
       icon={<Play size={14} />}
-      title="Manual"
-      subtitle={d.label || "Start button"}
-      tone="trigger"
+      kindLabel="When I click Start"
+      primary={d.label?.trim() || "Start button"}
+      secondary="Click Start in the chat to run this automation"
       selected={selected}
-      rightHandle
+      hasRight
     />
   );
 });
 
-const TriggerScheduleNode = memo(({ data, selected }: NodeProps) => {
+const TriggerScheduleNode = memo(({ id, data, selected }: NodeProps) => {
   const d = data as unknown as TriggerScheduleData;
+  const needsSetup = !d.cron?.trim();
   return (
     <NodeCard
-      icon={<Clock size={14} />}
-      title="Schedule"
-      subtitle={d.cron || "Set cron"}
+      nodeId={id}
       tone="trigger"
+      icon={<Clock size={14} />}
+      kindLabel="On a schedule"
+      primary={describeCron(d.cron || "")}
+      secondary={firstLine(d.prompt) || "No prompt set yet"}
+      needsSetup={needsSetup}
       selected={selected}
-      rightHandle
+      hasRight
     />
   );
 });
 
-const AgentNode = memo(({ data, selected }: NodeProps) => {
+const AgentNode = memo(({ id, data, selected }: NodeProps) => {
   const d = data as unknown as AgentData;
+  const needsSetup = !d.instructions?.trim();
   return (
     <NodeCard
-      icon={<Bot size={14} />}
-      title="Agent"
-      subtitle={d.model || "claude-sonnet-5"}
+      nodeId={id}
       tone="agent"
+      icon={<Bot size={14} />}
+      kindLabel="AI Agent"
+      primary={firstLine(d.instructions) || "No instructions yet"}
+      secondary={`Using ${modelName(d.model)}`}
+      needsSetup={needsSetup}
       selected={selected}
-      leftHandle
-      bottomHandle
+      hasLeft
+      hasRight
     />
   );
 });
 
-const ToolNode = memo(({ data, selected }: NodeProps) => {
+const ToolNode = memo(({ id, data, selected }: NodeProps) => {
   const d = data as unknown as ToolData;
+  const primary = d.description?.trim() || d.name?.trim() || "New tool";
+  const method = d.request?.method || "GET";
+  const url = d.request?.url || "";
+  const secondary = `${method} ${hostOf(url) || "(no URL yet)"}`;
+  const needsSetup = !url.trim();
   return (
     <NodeCard
-      icon={<Wrench size={14} />}
-      title={d.name || "Tool"}
-      subtitle={d.preset === "http" ? `${d.httpMethod || "GET"} ${d.httpUrl || ""}` : "Custom"}
+      nodeId={id}
       tone="tool"
+      icon={<Wrench size={14} />}
+      kindLabel="Tool the agent can call"
+      primary={primary}
+      secondary={secondary}
+      needsSetup={needsSetup}
       selected={selected}
-      topHandle
+      hasLeft
     />
   );
 });
 
-const SkillNode = memo(({ data, selected }: NodeProps) => {
+const SkillNode = memo(({ id, data, selected }: NodeProps) => {
   const d = data as unknown as SkillData;
+  const needsSetup = !d.markdown?.trim();
   return (
     <NodeCard
-      icon={<BookOpen size={14} />}
-      title={d.name || "Skill"}
-      subtitle="Markdown"
+      nodeId={id}
       tone="skill"
+      icon={<BookOpen size={14} />}
+      kindLabel="Skill (instructions on demand)"
+      primary={d.name?.trim() || "New skill"}
+      secondary={firstLine(d.markdown) || "Empty — write what the agent should do"}
+      needsSetup={needsSetup}
       selected={selected}
-      topHandle
+      hasLeft
     />
   );
 });
 
-const ConnectionNode = memo(({ data, selected }: NodeProps) => {
+const ConnectionNode = memo(({ id, data, selected }: NodeProps) => {
   const d = data as unknown as ConnectionData;
+  const needsSetup = !d.url?.trim();
   return (
     <NodeCard
-      icon={<Plug size={14} />}
-      title={d.name || "Connection"}
-      subtitle={`${d.kind?.toUpperCase() || "MCP"}`}
+      nodeId={id}
       tone="connection"
+      icon={<Plug size={14} />}
+      kindLabel={d.kind === "openapi" ? "OpenAPI connection" : "MCP connection"}
+      primary={d.name?.trim() || "New connection"}
+      secondary={hostOf(d.url) || "No URL set"}
+      needsSetup={needsSetup}
       selected={selected}
-      topHandle
+      hasLeft
     />
   );
 });
 
-const SubagentNode = memo(({ data, selected }: NodeProps) => {
+const SubagentNode = memo(({ id, data, selected }: NodeProps) => {
   const d = data as unknown as SubagentData;
+  const needsSetup = !d.description?.trim() || !d.instructions?.trim();
   return (
     <NodeCard
-      icon={<Users size={14} />}
-      title={d.name || "Subagent"}
-      subtitle={d.model || "claude-sonnet-5"}
+      nodeId={id}
       tone="subagent"
+      icon={<Users size={14} />}
+      kindLabel="Helper agent"
+      primary={d.name?.trim() || "New helper"}
+      secondary={firstLine(d.description) || "Describe when to use this helper"}
+      needsSetup={needsSetup}
       selected={selected}
-      topHandle
+      hasLeft
     />
   );
 });
+
+// ── P6/P7: flow node card ───────────────────────────────────────────────────
+const FlowNode = memo(({ id, data, selected }: NodeProps) => {
+  const d = data as unknown as FlowData;
+  const steps = d.steps?.length ?? 0;
+  const needsSetup = steps === 0 || !d.name?.trim();
+  return (
+    <NodeCard
+      nodeId={id}
+      tone="flow"
+      icon={<GitBranch size={14} />}
+      kindLabel="Flow (multi-step tool)"
+      primary={d.name?.trim() || "New flow"}
+      secondary={steps ? `${steps} step${steps === 1 ? "" : "s"}` : "No steps yet"}
+      needsSetup={needsSetup}
+      selected={selected}
+      hasLeft
+    />
+  );
+});
+
+// ── P8: shared trigger-channel card ─────────────────────────────────────────
+function makeChannelTriggerNode(label: string, icon: React.ReactNode) {
+  return memo(({ id, data, selected }: NodeProps) => {
+    const d = data as unknown as TriggerChannelData;
+    const needsSetup = (d.fields?.length ?? 0) === 0;
+    return (
+      <NodeCard
+        nodeId={id}
+        tone="trigger"
+        icon={icon}
+        kindLabel={label}
+        primary={firstLine(d.prompt) || `Runs when ${label.toLowerCase()} fires`}
+        secondary={needsSetup ? "Not configured yet" : "Configured"}
+        needsSetup={needsSetup}
+        selected={selected}
+        hasRight
+      />
+    );
+  });
+}
+
+const TriggerLinearNode   = makeChannelTriggerNode("On Linear event",   <Ticket size={14} />);
+const TriggerDiscordNode  = makeChannelTriggerNode("On Discord event",  <MessageSquare size={14} />);
+const TriggerTelegramNode = makeChannelTriggerNode("On Telegram message", <Send size={14} />);
+const TriggerTeamsNode    = makeChannelTriggerNode("On Teams message",   <Layers size={14} />);
+const TriggerPhotonNode   = makeChannelTriggerNode("On iMessage (Photon)", <MessageSquare size={14} />);
+const TriggerPollNode     = makeChannelTriggerNode("Poll an endpoint",   <Activity size={14} />);
 
 export const nodeTypes = {
   "trigger-manual": TriggerManualNode,
   "trigger-schedule": TriggerScheduleNode,
+  "trigger-linear": TriggerLinearNode,
+  "trigger-discord": TriggerDiscordNode,
+  "trigger-telegram": TriggerTelegramNode,
+  "trigger-teams": TriggerTeamsNode,
+  "trigger-photon": TriggerPhotonNode,
+  "trigger-poll": TriggerPollNode,
   "agent": AgentNode,
   "tool": ToolNode,
   "skill": SkillNode,
   "connection": ConnectionNode,
   "subagent": SubagentNode,
+  "flow": FlowNode,
 };
 
 export const nodeIcon: Record<string, React.ReactNode> = {
   "trigger-manual": <Play size={13} />,
   "trigger-schedule": <Clock size={13} />,
+  "trigger-linear": <Ticket size={13} />,
+  "trigger-discord": <MessageSquare size={13} />,
+  "trigger-telegram": <Send size={13} />,
+  "trigger-teams": <Layers size={13} />,
+  "trigger-photon": <MessageSquare size={13} />,
+  "trigger-poll": <Activity size={13} />,
   "agent": <Bot size={13} />,
   "tool": <Wrench size={13} />,
   "skill": <BookOpen size={13} />,
   "connection": <Plug size={13} />,
   "subagent": <Users size={13} />,
+  "flow": <GitBranch size={13} />,
 };
 
 export const nodeLabel: Record<string, string> = {
   "trigger-manual": "Manual trigger",
   "trigger-schedule": "Schedule trigger",
-  "agent": "Agent",
+  "trigger-linear": "Linear trigger",
+  "trigger-discord": "Discord trigger",
+  "trigger-telegram": "Telegram trigger",
+  "trigger-teams": "Teams trigger",
+  "trigger-photon": "iMessage trigger",
+  "trigger-poll": "HTTP poll trigger",
+  "agent": "AI Agent",
   "tool": "Tool",
   "skill": "Skill",
   "connection": "Connection",
-  "subagent": "Subagent",
+  "subagent": "Helper agent",
+  "flow": "Flow",
+};
+
+export const nodeDescription: Record<string, string> = {
+  "trigger-manual": "Runs when you click Start in the chat.",
+  "trigger-schedule": "Runs automatically on a schedule you pick.",
+  "trigger-linear": "Runs when a Linear issue or comment fires.",
+  "trigger-discord": "Runs when a Discord message or command fires.",
+  "trigger-telegram": "Runs when a Telegram bot receives a message.",
+  "trigger-teams": "Runs when a Teams message hits the bot.",
+  "trigger-photon": "Runs on iMessage via Photon.",
+  "trigger-poll": "Fetches an endpoint on a schedule.",
+  "agent": "The brain. Reads instructions and uses tools.",
+  "tool": "Something the agent can do — call an API, run code.",
+  "skill": "A recipe the agent reads only when it's relevant.",
+  "connection": "A service the agent can talk to (MCP or OpenAPI).",
+  "subagent": "A smaller specialist the agent can delegate to.",
+  "flow": "Multi-step tool with branches, loops, and set/return.",
 };

--- a/src/components/Automations/builder/nodes.tsx
+++ b/src/components/Automations/builder/nodes.tsx
@@ -1,0 +1,172 @@
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import {
+  Bot, Wrench, BookOpen, Plug, Users, Play, Clock,
+} from "lucide-react";
+import type {
+  AgentData, ToolData, SkillData, ConnectionData, SubagentData,
+  TriggerManualData, TriggerScheduleData,
+} from "./graph";
+
+// One bottom port on Agent for all sub-node attachments. Edge color derives
+// from the connected sub-node kind (see builder.tsx / edge style). Keeps the
+// component simple; typed handles can come later if visual grouping matters.
+// ponytail: one handle, color the wire; upgrade to 4 typed handles if the
+// visual grouping becomes worth the code.
+
+function NodeCard(props: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  tone: "trigger" | "agent" | "tool" | "skill" | "connection" | "subagent";
+  selected?: boolean;
+  topHandle?: boolean;
+  bottomHandle?: boolean;
+  rightHandle?: boolean;
+  leftHandle?: boolean;
+}) {
+  return (
+    <div className={`amn amn--${props.tone}${props.selected ? " amn--selected" : ""}`}>
+      {props.topHandle && <Handle type="target" position={Position.Top} id="t" />}
+      {props.leftHandle && <Handle type="target" position={Position.Left} id="l" />}
+      <div className="amn-body">
+        <span className="amn-icon">{props.icon}</span>
+        <div className="amn-text">
+          <span className="amn-title">{props.title}</span>
+          {props.subtitle && <span className="amn-sub">{props.subtitle}</span>}
+        </div>
+      </div>
+      {props.rightHandle && <Handle type="source" position={Position.Right} id="r" />}
+      {props.bottomHandle && <Handle type="source" position={Position.Bottom} id="b" />}
+    </div>
+  );
+}
+
+const TriggerManualNode = memo(({ data, selected }: NodeProps) => {
+  const d = data as unknown as TriggerManualData;
+  return (
+    <NodeCard
+      icon={<Play size={14} />}
+      title="Manual"
+      subtitle={d.label || "Start button"}
+      tone="trigger"
+      selected={selected}
+      rightHandle
+    />
+  );
+});
+
+const TriggerScheduleNode = memo(({ data, selected }: NodeProps) => {
+  const d = data as unknown as TriggerScheduleData;
+  return (
+    <NodeCard
+      icon={<Clock size={14} />}
+      title="Schedule"
+      subtitle={d.cron || "Set cron"}
+      tone="trigger"
+      selected={selected}
+      rightHandle
+    />
+  );
+});
+
+const AgentNode = memo(({ data, selected }: NodeProps) => {
+  const d = data as unknown as AgentData;
+  return (
+    <NodeCard
+      icon={<Bot size={14} />}
+      title="Agent"
+      subtitle={d.model || "claude-sonnet-5"}
+      tone="agent"
+      selected={selected}
+      leftHandle
+      bottomHandle
+    />
+  );
+});
+
+const ToolNode = memo(({ data, selected }: NodeProps) => {
+  const d = data as unknown as ToolData;
+  return (
+    <NodeCard
+      icon={<Wrench size={14} />}
+      title={d.name || "Tool"}
+      subtitle={d.preset === "http" ? `${d.httpMethod || "GET"} ${d.httpUrl || ""}` : "Custom"}
+      tone="tool"
+      selected={selected}
+      topHandle
+    />
+  );
+});
+
+const SkillNode = memo(({ data, selected }: NodeProps) => {
+  const d = data as unknown as SkillData;
+  return (
+    <NodeCard
+      icon={<BookOpen size={14} />}
+      title={d.name || "Skill"}
+      subtitle="Markdown"
+      tone="skill"
+      selected={selected}
+      topHandle
+    />
+  );
+});
+
+const ConnectionNode = memo(({ data, selected }: NodeProps) => {
+  const d = data as unknown as ConnectionData;
+  return (
+    <NodeCard
+      icon={<Plug size={14} />}
+      title={d.name || "Connection"}
+      subtitle={`${d.kind?.toUpperCase() || "MCP"}`}
+      tone="connection"
+      selected={selected}
+      topHandle
+    />
+  );
+});
+
+const SubagentNode = memo(({ data, selected }: NodeProps) => {
+  const d = data as unknown as SubagentData;
+  return (
+    <NodeCard
+      icon={<Users size={14} />}
+      title={d.name || "Subagent"}
+      subtitle={d.model || "claude-sonnet-5"}
+      tone="subagent"
+      selected={selected}
+      topHandle
+    />
+  );
+});
+
+export const nodeTypes = {
+  "trigger-manual": TriggerManualNode,
+  "trigger-schedule": TriggerScheduleNode,
+  "agent": AgentNode,
+  "tool": ToolNode,
+  "skill": SkillNode,
+  "connection": ConnectionNode,
+  "subagent": SubagentNode,
+};
+
+export const nodeIcon: Record<string, React.ReactNode> = {
+  "trigger-manual": <Play size={13} />,
+  "trigger-schedule": <Clock size={13} />,
+  "agent": <Bot size={13} />,
+  "tool": <Wrench size={13} />,
+  "skill": <BookOpen size={13} />,
+  "connection": <Plug size={13} />,
+  "subagent": <Users size={13} />,
+};
+
+export const nodeLabel: Record<string, string> = {
+  "trigger-manual": "Manual trigger",
+  "trigger-schedule": "Schedule trigger",
+  "agent": "Agent",
+  "tool": "Tool",
+  "skill": "Skill",
+  "connection": "Connection",
+  "subagent": "Subagent",
+};

--- a/src/components/Automations/builder/tool/InputSchemaBuilder.tsx
+++ b/src/components/Automations/builder/tool/InputSchemaBuilder.tsx
@@ -1,0 +1,96 @@
+import { Plus, Trash2, ChevronUp, ChevronDown } from "lucide-react";
+import type { ToolInputSchema, ToolInputField, ToolInputType } from "../graph";
+
+interface Props {
+  schema: ToolInputSchema;
+  onChange: (s: ToolInputSchema) => void;
+}
+
+const TYPES: ToolInputType[] = ["string", "number", "boolean", "enum"];
+
+// Slug-check: agent will fail to invoke tools with non-identifier field names.
+function normalizeName(v: string): string {
+  return v.replace(/[^A-Za-z0-9_]/g, "_").replace(/^(\d)/, "_$1");
+}
+
+export function InputSchemaBuilder({ schema, onChange }: Props) {
+  const rows = schema.fields;
+  const setRows = (next: ToolInputField[]) => onChange({ fields: next });
+  const patch = (i: number, p: Partial<ToolInputField>) =>
+    setRows(rows.map((r, ix) => ix === i ? { ...r, ...p } : r));
+  const remove = (i: number) => setRows(rows.filter((_, ix) => ix !== i));
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= rows.length) return;
+    const next = rows.slice();
+    [next[i], next[j]] = [next[j], next[i]];
+    setRows(next);
+  };
+  const add = () => setRows([...rows, { name: "", type: "string", required: true }]);
+
+  return (
+    <div className="am-fields">
+      <div className="am-fields-hint">
+        Declare what the agent must pass to this tool. Names must be identifiers (letters, digits, underscore).
+      </div>
+      {rows.length === 0 && (
+        <div className="am-kv-empty">No inputs — this tool takes nothing.</div>
+      )}
+      {rows.map((f, i) => (
+        <div key={i} className="am-fldrow">
+          <div className="am-fldrow-head">
+            <input
+              className="am-input am-mono am-fldrow-name"
+              value={f.name}
+              onChange={e => patch(i, { name: normalizeName(e.target.value) })}
+              placeholder="city"
+            />
+            <select
+              className="am-input am-fldrow-type"
+              value={f.type}
+              onChange={e => patch(i, { type: e.target.value as ToolInputType })}
+            >
+              {TYPES.map(t => <option key={t}>{t}</option>)}
+            </select>
+            <label className="am-fldrow-req" title="Agent must supply a value">
+              <input
+                type="checkbox"
+                checked={f.required}
+                onChange={e => patch(i, { required: e.target.checked })}
+              />
+              <span>required</span>
+            </label>
+            <button type="button" className="am-fldrow-icon" onClick={() => move(i, -1)} title="Move up" disabled={i === 0}>
+              <ChevronUp size={13} />
+            </button>
+            <button type="button" className="am-fldrow-icon" onClick={() => move(i, 1)} title="Move down" disabled={i === rows.length - 1}>
+              <ChevronDown size={13} />
+            </button>
+            <button type="button" className="am-fldrow-icon am-fldrow-del" onClick={() => remove(i)} title="Remove">
+              <Trash2 size={13} />
+            </button>
+          </div>
+          {f.type === "enum" && (
+            <input
+              className="am-input am-mono am-fldrow-enum"
+              value={(f.enumValues || []).join(", ")}
+              onChange={e => patch(i, {
+                enumValues: e.target.value.split(",").map(s => s.trim()).filter(Boolean),
+              })}
+              placeholder="metric, imperial, kelvin"
+            />
+          )}
+          <input
+            className="am-input am-fldrow-desc"
+            value={f.description || ""}
+            onChange={e => patch(i, { description: e.target.value })}
+            placeholder="Description — shown to the agent"
+          />
+        </div>
+      ))}
+      <button type="button" className="am-kv-add" onClick={add}>
+        <Plus size={12} /> Add input
+      </button>
+    </div>
+  );
+}

--- a/src/components/Automations/builder/tool/KVRows.tsx
+++ b/src/components/Automations/builder/tool/KVRows.tsx
@@ -1,0 +1,68 @@
+import { Plus, Trash2 } from "lucide-react";
+import type { KV, ToolInputField } from "../graph";
+import { ValueChipsInput } from "./ValueChipsInput";
+
+interface Props {
+  rows: KV[];
+  onChange: (rows: KV[]) => void;
+  fields: ToolInputField[];
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  addLabel?: string;
+  monoValue?: boolean;
+}
+
+// ponytail: enabled toggle via checkbox is more discoverable than a right-click.
+export function KVRows({
+  rows, onChange, fields, keyPlaceholder, valuePlaceholder, addLabel, monoValue,
+}: Props) {
+  const patch = (i: number, p: Partial<KV>) =>
+    onChange(rows.map((r, ix) => ix === i ? { ...r, ...p } : r));
+  const remove = (i: number) => onChange(rows.filter((_, ix) => ix !== i));
+  const add = () => onChange([...rows, { key: "", value: "", enabled: true }]);
+
+  return (
+    <div className="am-kv">
+      {rows.length === 0 && (
+        <div className="am-kv-empty">No rows yet.</div>
+      )}
+      {rows.map((r, i) => (
+        <div key={i} className={`am-kv-row${r.enabled ? "" : " am-kv-row--off"}`}>
+          <input
+            type="checkbox"
+            className="am-kv-check"
+            checked={r.enabled}
+            onChange={e => patch(i, { enabled: e.target.checked })}
+            title={r.enabled ? "Included" : "Skipped"}
+          />
+          <input
+            className="am-input am-mono am-kv-key"
+            value={r.key}
+            onChange={e => patch(i, { key: e.target.value })}
+            placeholder={keyPlaceholder || "key"}
+          />
+          <div className="am-kv-val">
+            <ValueChipsInput
+              value={r.value}
+              onChange={v => patch(i, { value: v })}
+              fields={fields}
+              placeholder={valuePlaceholder || "value"}
+              mono={monoValue}
+            />
+          </div>
+          <button
+            type="button"
+            className="am-kv-del"
+            onClick={() => remove(i)}
+            title="Remove row"
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      ))}
+      <button type="button" className="am-kv-add" onClick={add}>
+        <Plus size={12} /> {addLabel || "Add row"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Automations/builder/tool/RequestBuilder.tsx
+++ b/src/components/Automations/builder/tool/RequestBuilder.tsx
@@ -1,0 +1,250 @@
+import type {
+  HttpRequest, HttpMethod, HttpAuth, HttpBody, ToolInputField,
+} from "../graph";
+import { KVRows } from "./KVRows";
+import { ValueChipsInput } from "./ValueChipsInput";
+
+interface Props {
+  request: HttpRequest;
+  onChange: (r: HttpRequest) => void;
+  fields: ToolInputField[];
+}
+
+const METHODS: HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+const AUTH_KINDS: { id: HttpAuth["kind"]; label: string }[] = [
+  { id: "none", label: "None" },
+  { id: "bearer", label: "Bearer token" },
+  { id: "basic", label: "Basic (user/pass)" },
+  { id: "apiKey", label: "API key" },
+];
+const BODY_KINDS: { id: HttpBody["kind"]; label: string }[] = [
+  { id: "none", label: "None" },
+  { id: "json", label: "JSON" },
+  { id: "form", label: "Form" },
+  { id: "raw", label: "Raw" },
+];
+
+export function RequestBuilder({ request, onChange, fields }: Props) {
+  const set = <K extends keyof HttpRequest>(k: K, v: HttpRequest[K]) =>
+    onChange({ ...request, [k]: v });
+
+  const setAuth = (a: HttpAuth) => set("auth", a);
+  const setBody = (b: HttpBody) => set("body", b);
+
+  const switchAuth = (kind: HttpAuth["kind"]) => {
+    if (kind === "none") setAuth({ kind: "none" });
+    else if (kind === "bearer") setAuth({ kind: "bearer", token: "" });
+    else if (kind === "basic") setAuth({ kind: "basic", user: "", pass: "" });
+    else setAuth({ kind: "apiKey", in: "header", name: "", value: "" });
+  };
+  const switchBody = (kind: HttpBody["kind"]) => {
+    if (kind === "none") setBody({ kind: "none" });
+    else if (kind === "raw") setBody({ kind: "raw", contentType: "text/plain", text: "" });
+    else setBody({ kind, fields: [] });
+  };
+
+  return (
+    <div className="am-req">
+      <div className="am-row">
+        <label className="am-field am-field--fixed">
+          <span>Method</span>
+          <select
+            className="am-input"
+            value={request.method}
+            onChange={e => set("method", e.target.value as HttpMethod)}
+          >
+            {METHODS.map(m => <option key={m}>{m}</option>)}
+          </select>
+        </label>
+        <label className="am-field am-field--grow">
+          <span>URL</span>
+          <ValueChipsInput
+            value={request.url}
+            onChange={v => set("url", v)}
+            fields={fields}
+            placeholder="https://api.example.com/v1/things/{{input.id}}"
+            mono
+          />
+        </label>
+      </div>
+
+      <div className="am-req-section">
+        <div className="am-req-section-head">Query parameters</div>
+        <KVRows
+          rows={request.queryParams}
+          onChange={rows => set("queryParams", rows)}
+          fields={fields}
+          keyPlaceholder="param"
+          valuePlaceholder="value"
+          addLabel="Add parameter"
+        />
+      </div>
+
+      <div className="am-req-section">
+        <div className="am-req-section-head">Headers</div>
+        <KVRows
+          rows={request.headers}
+          onChange={rows => set("headers", rows)}
+          fields={fields}
+          keyPlaceholder="Header-Name"
+          valuePlaceholder="value"
+          addLabel="Add header"
+        />
+      </div>
+
+      <div className="am-req-section">
+        <div className="am-req-section-head">Auth</div>
+        <select
+          className="am-input"
+          value={request.auth.kind}
+          onChange={e => switchAuth(e.target.value as HttpAuth["kind"])}
+        >
+          {AUTH_KINDS.map(a => <option key={a.id} value={a.id}>{a.label}</option>)}
+        </select>
+        {request.auth.kind === "bearer" && (
+          <label className="am-field">
+            <span>Token</span>
+            <ValueChipsInput
+              value={request.auth.token}
+              onChange={v => setAuth({ kind: "bearer", token: v })}
+              fields={fields}
+              placeholder="{{input.apiKey}} or a literal"
+              mono
+            />
+          </label>
+        )}
+        {request.auth.kind === "basic" && (
+          <div className="am-row">
+            <label className="am-field am-field--grow">
+              <span>User</span>
+              <ValueChipsInput
+                value={request.auth.user}
+                onChange={v => setAuth({ ...request.auth as { kind: "basic"; user: string; pass: string }, user: v })}
+                fields={fields}
+                mono
+              />
+            </label>
+            <label className="am-field am-field--grow">
+              <span>Password</span>
+              <ValueChipsInput
+                value={request.auth.pass}
+                onChange={v => setAuth({ ...request.auth as { kind: "basic"; user: string; pass: string }, pass: v })}
+                fields={fields}
+                mono
+              />
+            </label>
+          </div>
+        )}
+        {request.auth.kind === "apiKey" && (
+          <>
+            <div className="am-row">
+              <label className="am-field am-field--fixed">
+                <span>Send in</span>
+                <select
+                  className="am-input"
+                  value={request.auth.in}
+                  onChange={e => {
+                    const a = request.auth as Extract<HttpAuth, { kind: "apiKey" }>;
+                    setAuth({ ...a, in: e.target.value as "header" | "query" });
+                  }}
+                >
+                  <option value="header">Header</option>
+                  <option value="query">Query string</option>
+                </select>
+              </label>
+              <label className="am-field am-field--grow">
+                <span>Name</span>
+                <input
+                  className="am-input am-mono"
+                  value={request.auth.name}
+                  onChange={e => {
+                    const a = request.auth as Extract<HttpAuth, { kind: "apiKey" }>;
+                    setAuth({ ...a, name: e.target.value });
+                  }}
+                  placeholder="X-Api-Key or api_key"
+                />
+              </label>
+            </div>
+            <label className="am-field">
+              <span>Value</span>
+              <ValueChipsInput
+                value={request.auth.value}
+                onChange={v => {
+                  const a = request.auth as Extract<HttpAuth, { kind: "apiKey" }>;
+                  setAuth({ ...a, value: v });
+                }}
+                fields={fields}
+                mono
+              />
+            </label>
+          </>
+        )}
+      </div>
+
+      <div className="am-req-section">
+        <div className="am-req-section-head">Body</div>
+        <select
+          className="am-input"
+          value={request.body.kind}
+          onChange={e => switchBody(e.target.value as HttpBody["kind"])}
+          disabled={request.method === "GET"}
+          title={request.method === "GET" ? "GET requests carry no body" : ""}
+        >
+          {BODY_KINDS.map(b => <option key={b.id} value={b.id}>{b.label}</option>)}
+        </select>
+        {request.method !== "GET" && request.body.kind === "json" && (
+          <KVRows
+            rows={request.body.fields}
+            onChange={rows => setBody({ kind: "json", fields: rows })}
+            fields={fields}
+            keyPlaceholder="field"
+            valuePlaceholder="value (chips allowed)"
+            addLabel="Add JSON field"
+          />
+        )}
+        {request.method !== "GET" && request.body.kind === "form" && (
+          <KVRows
+            rows={request.body.fields}
+            onChange={rows => setBody({ kind: "form", fields: rows })}
+            fields={fields}
+            keyPlaceholder="field"
+            valuePlaceholder="value"
+            addLabel="Add form field"
+          />
+        )}
+        {request.method !== "GET" && request.body.kind === "raw" && (
+          <>
+            <label className="am-field">
+              <span>Content-Type</span>
+              <input
+                className="am-input am-mono"
+                value={request.body.contentType}
+                onChange={e => setBody({
+                  kind: "raw",
+                  contentType: e.target.value,
+                  text: (request.body as Extract<HttpBody, { kind: "raw" }>).text,
+                })}
+                placeholder="application/xml"
+              />
+            </label>
+            <label className="am-field">
+              <span>Body text</span>
+              <ValueChipsInput
+                value={request.body.text}
+                onChange={v => setBody({
+                  kind: "raw",
+                  contentType: (request.body as Extract<HttpBody, { kind: "raw" }>).contentType,
+                  text: v,
+                })}
+                fields={fields}
+                multiline
+                rows={5}
+                mono
+              />
+            </label>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Automations/builder/tool/ResponseMapper.tsx
+++ b/src/components/Automations/builder/tool/ResponseMapper.tsx
@@ -1,0 +1,268 @@
+import { useState } from "react";
+import { Play, Loader2, X } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import type { HttpRequest, ResponseMap, ToolInputField } from "../graph";
+
+interface Props {
+  response: ResponseMap;
+  onChange: (r: ResponseMap) => void;
+  request: HttpRequest;
+  fields: ToolInputField[];
+}
+
+interface TryResult {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;   // parsed JSON when possible; otherwise the raw string
+  ms: number;
+}
+
+type TryHttpArgs = {
+  request: HttpRequest;
+  sample: Record<string, unknown>;
+} & Record<string, unknown>;
+
+// Returned by the Rust command; shape matches TryHttpResult in automations.rs.
+interface RustTryResult {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  ms: number;
+}
+
+export function ResponseMapper({ response, onChange, request, fields }: Props) {
+  const [sample, setSample] = useState<Record<string, string>>({});
+  const [result, setResult] = useState<TryResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const patchSample = (name: string, v: string) => setSample(s => ({ ...s, [name]: v }));
+
+  // Coerce string inputs to their declared types before shipping to the request.
+  // Booleans and numbers arrive as strings from <input>; JSON body etc. wants
+  // the real value.
+  const coerce = (): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    for (const f of fields) {
+      const raw = sample[f.name] ?? "";
+      if (raw === "" && !f.required) continue;
+      if (f.type === "number") out[f.name] = Number(raw);
+      else if (f.type === "boolean") out[f.name] = raw === "true" || raw === "1";
+      else out[f.name] = raw;
+    }
+    return out;
+  };
+
+  const run = async () => {
+    setBusy(true); setError(null); setResult(null);
+    try {
+      const args: TryHttpArgs = { request, sample: coerce() };
+      const raw = await invoke<RustTryResult>("try_http_request", args);
+      let body: unknown = raw.body;
+      try { body = JSON.parse(raw.body); } catch { /* keep raw */ }
+      setResult({ status: raw.status, headers: raw.headers, body, ms: raw.ms });
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="am-resp">
+      <label className="am-field">
+        <span>What should this tool return to the agent?</span>
+        <select
+          className="am-input"
+          value={response.kind}
+          onChange={e => onChange(
+            e.target.value === "pick"
+              ? { kind: "pick", pick: response.pick || "" }
+              : { kind: "raw" }
+          )}
+        >
+          <option value="raw">Whole response body</option>
+          <option value="pick">Pick one field from the response</option>
+        </select>
+      </label>
+
+      {response.kind === "pick" && (
+        <label className="am-field">
+          <span>Path</span>
+          <div className="am-row am-row--tight">
+            <input
+              className="am-input am-mono"
+              value={response.pick || ""}
+              onChange={e => onChange({ kind: "pick", pick: e.target.value })}
+              placeholder="data.items[0].name"
+              readOnly={!!result}
+            />
+            {response.pick && (
+              <button
+                type="button"
+                className="am-fldrow-icon"
+                onClick={() => onChange({ kind: "pick", pick: "" })}
+                title="Clear"
+              >
+                <X size={13} />
+              </button>
+            )}
+          </div>
+          <span className="am-hint-block">Click a value in the response tree below to fill this in.</span>
+        </label>
+      )}
+
+      <div className="am-resp-try">
+        <div className="am-req-section-head">Try it with sample inputs</div>
+        {fields.length === 0 ? (
+          <div className="am-kv-empty">No inputs declared — Try it will run with none.</div>
+        ) : (
+          <div className="am-resp-sample">
+            {fields.map(f => (
+              <label key={f.name} className="am-field">
+                <span>{f.name} <span className="am-hint">({f.type}{f.required ? ", required" : ""})</span></span>
+                <input
+                  className="am-input am-mono"
+                  value={sample[f.name] ?? ""}
+                  onChange={e => patchSample(f.name, e.target.value)}
+                  placeholder={f.type === "boolean" ? "true / false" : f.description}
+                />
+              </label>
+            ))}
+          </div>
+        )}
+        <button
+          type="button"
+          className="am-modal-primary am-resp-run"
+          onClick={run}
+          disabled={busy || !request.url.trim()}
+        >
+          {busy ? <><Loader2 size={13} className="am-spin" /> Running…</> : <><Play size={13} /> Try it</>}
+        </button>
+      </div>
+
+      {error && <div className="am-callout am-callout--err">{error}</div>}
+      {result && (
+        <div className="am-resp-result">
+          <div className="am-resp-status">
+            <span className={`am-resp-status-code am-resp-status-code--${statusClass(result.status)}`}>{result.status}</span>
+            <span className="am-hint">{result.ms} ms</span>
+          </div>
+          <JsonTree
+            value={result.body}
+            path=""
+            onPick={p => response.kind === "pick" && onChange({ kind: "pick", pick: p })}
+            active={response.kind === "pick" ? (response.pick || "") : ""}
+            selectable={response.kind === "pick"}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function statusClass(s: number): string {
+  if (s >= 200 && s < 300) return "ok";
+  if (s >= 300 && s < 400) return "redirect";
+  if (s >= 400) return "err";
+  return "unk";
+}
+
+// ── JSON tree ───────────────────────────────────────────────────────────────
+// Renders arbitrary parsed JSON as a collapsible tree. Clicking a leaf path
+// calls onPick with the JSONPath-ish string ("data.items[0].name").
+
+interface JsonTreeProps {
+  value: unknown;
+  path: string;
+  onPick: (p: string) => void;
+  active: string;
+  selectable: boolean;
+}
+
+function JsonTree({ value, path, onPick, active, selectable }: JsonTreeProps) {
+  if (value === null) return <Leaf label="null" path={path} onPick={onPick} active={active} selectable={selectable} kind="null" />;
+  const t = typeof value;
+  if (t === "string") return <Leaf label={JSON.stringify(value)} path={path} onPick={onPick} active={active} selectable={selectable} kind="str" />;
+  if (t === "number" || t === "boolean") return <Leaf label={String(value)} path={path} onPick={onPick} active={active} selectable={selectable} kind={t as "number" | "boolean"} />;
+  if (Array.isArray(value)) return <ArrayNode items={value} path={path} onPick={onPick} active={active} selectable={selectable} />;
+  if (t === "object") return <ObjectNode obj={value as Record<string, unknown>} path={path} onPick={onPick} active={active} selectable={selectable} />;
+  return <Leaf label={String(value)} path={path} onPick={onPick} active={active} selectable={selectable} kind="str" />;
+}
+
+function Leaf({ label, path, onPick, active, selectable, kind }: {
+  label: string; path: string; onPick: (p: string) => void; active: string; selectable: boolean;
+  kind: "str" | "number" | "boolean" | "null";
+}) {
+  const on = selectable && path && path === active;
+  return (
+    <span
+      className={`am-json-leaf am-json-leaf--${kind}${selectable && path ? " am-json-leaf--pick" : ""}${on ? " am-json-leaf--on" : ""}`}
+      onClick={() => selectable && path && onPick(path)}
+      title={selectable && path ? `Click to use ${path}` : ""}
+    >{label}</span>
+  );
+}
+
+function ObjectNode({ obj, path, onPick, active, selectable }: {
+  obj: Record<string, unknown>; path: string; onPick: (p: string) => void; active: string; selectable: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return <span className="am-json-empty">{"{ }"}</span>;
+  return (
+    <div className="am-json-obj">
+      <button type="button" className="am-json-toggle" onClick={() => setOpen(o => !o)}>
+        {open ? "▾" : "▸"} {`{${keys.length}}`}
+      </button>
+      {open && (
+        <div className="am-json-body">
+          {keys.map(k => {
+            const child = path ? `${path}.${k}` : k;
+            return (
+              <div key={k} className="am-json-row">
+                <span
+                  className={`am-json-key${selectable ? " am-json-key--pick" : ""}${selectable && child === active ? " am-json-key--on" : ""}`}
+                  onClick={() => selectable && onPick(child)}
+                >{k}</span>
+                <span className="am-json-colon">:</span>
+                <JsonTree value={obj[k]} path={child} onPick={onPick} active={active} selectable={selectable} />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ArrayNode({ items, path, onPick, active, selectable }: {
+  items: unknown[]; path: string; onPick: (p: string) => void; active: string; selectable: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+  if (items.length === 0) return <span className="am-json-empty">{"[]"}</span>;
+  return (
+    <div className="am-json-obj">
+      <button type="button" className="am-json-toggle" onClick={() => setOpen(o => !o)}>
+        {open ? "▾" : "▸"} {`[${items.length}]`}
+      </button>
+      {open && (
+        <div className="am-json-body">
+          {items.map((v, i) => {
+            const child = `${path}[${i}]`;
+            return (
+              <div key={i} className="am-json-row">
+                <span
+                  className={`am-json-key am-json-key--idx${selectable ? " am-json-key--pick" : ""}${selectable && child === active ? " am-json-key--on" : ""}`}
+                  onClick={() => selectable && onPick(child)}
+                >{i}</span>
+                <span className="am-json-colon">:</span>
+                <JsonTree value={v} path={child} onPick={onPick} active={active} selectable={selectable} />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Automations/builder/tool/ValueChipsInput.tsx
+++ b/src/components/Automations/builder/tool/ValueChipsInput.tsx
@@ -1,0 +1,97 @@
+import { useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import type { ToolInputField } from "../graph";
+
+// Plain text field with a `{{ input.<name> }}` insert menu. Stored value is the
+// literal template string — the Rust writer resolves chips at runtime by
+// substituting `{{input.<name>}}` against the tool's `input` object.
+// ponytail: inline chip rendering (colored pills mid-text) is a polish upgrade;
+// the insert menu already removes the need to memorise template syntax.
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+  fields: ToolInputField[];
+  placeholder?: string;
+  mono?: boolean;
+  className?: string;
+  multiline?: boolean;
+  rows?: number;
+}
+
+export function ValueChipsInput({
+  value, onChange, fields, placeholder, mono, className, multiline, rows,
+}: Props) {
+  const ref = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const insert = (name: string) => {
+    const el = ref.current;
+    const token = `{{input.${name}}}`;
+    if (!el) { onChange((value || "") + token); setOpen(false); return; }
+    const start = el.selectionStart ?? value.length;
+    const end = el.selectionEnd ?? value.length;
+    const next = value.slice(0, start) + token + value.slice(end);
+    onChange(next);
+    setOpen(false);
+    // put caret after the inserted token on next tick
+    requestAnimationFrame(() => {
+      const pos = start + token.length;
+      el.focus();
+      el.setSelectionRange(pos, pos);
+    });
+  };
+
+  const inputCls = `am-input${mono ? " am-mono" : ""} ${className || ""}`.trim();
+
+  return (
+    <div className="am-chipin">
+      {multiline ? (
+        <textarea
+          ref={ref as React.RefObject<HTMLTextAreaElement>}
+          className={`am-textarea${mono ? " am-mono" : ""}`}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          rows={rows ?? 3}
+        />
+      ) : (
+        <input
+          ref={ref as React.RefObject<HTMLInputElement>}
+          className={inputCls}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+        />
+      )}
+      <button
+        type="button"
+        className="am-chipin-btn"
+        onClick={() => setOpen(o => !o)}
+        title={fields.length ? "Insert an input" : "No inputs declared yet"}
+        disabled={fields.length === 0}
+      >
+        {`{ }`} <ChevronDown size={11} />
+      </button>
+      {open && fields.length > 0 && (
+        <>
+          <div className="am-chipin-scrim" onClick={() => setOpen(false)} />
+          <div className="am-chipin-menu">
+            <div className="am-chipin-menu-head">Insert input</div>
+            {fields.map(f => (
+              <button
+                key={f.name}
+                type="button"
+                className="am-chipin-menu-item"
+                onClick={() => insert(f.name)}
+              >
+                <span className="am-chipin-menu-name">{f.name}</span>
+                <span className="am-chipin-menu-type">{f.type}</span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Automations/builder/triggers/TriggerChannelModal.tsx
+++ b/src/components/Automations/builder/triggers/TriggerChannelModal.tsx
@@ -1,0 +1,155 @@
+import type { TriggerChannelData, KV } from "../graph";
+import { Plus, Trash2 } from "lucide-react";
+
+// P8: one modal serves all six channel trigger kinds. The schema-per-kind
+// mapping stays here so the Rust writer's schema is echoed 1:1 in the UI —
+// two places, but each is tiny. If a kind grows an odd option (OAuth flow,
+// per-channel signature schemes), split it into its own modal then.
+
+type Kind =
+  | "trigger-linear" | "trigger-discord" | "trigger-telegram"
+  | "trigger-teams"  | "trigger-photon"  | "trigger-poll";
+
+interface FieldDef {
+  key: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;    // secret fields default to a `{{secrets.<slug>}}` chip
+  suggestedSecret?: string;
+}
+
+const SCHEMAS: Record<Kind, FieldDef[]> = {
+  "trigger-linear": [
+    { key: "apiKey",         label: "Linear API key", secret: true, suggestedSecret: "LINEAR_API_KEY" },
+    { key: "webhookSecret",  label: "Webhook secret (optional)", secret: true, suggestedSecret: "LINEAR_WEBHOOK_SECRET" },
+  ],
+  "trigger-discord": [
+    { key: "botToken",  label: "Bot token", secret: true, suggestedSecret: "DISCORD_BOT_TOKEN" },
+    { key: "publicKey", label: "Public key (verifies interactions)", placeholder: "hex string" },
+  ],
+  "trigger-telegram": [
+    { key: "botToken", label: "Bot token", secret: true, suggestedSecret: "TELEGRAM_BOT_TOKEN" },
+  ],
+  "trigger-teams": [
+    { key: "appId",       label: "App ID" },
+    { key: "appPassword", label: "App password", secret: true, suggestedSecret: "TEAMS_APP_PASSWORD" },
+  ],
+  "trigger-photon": [
+    { key: "apiKey", label: "Photon API key", secret: true, suggestedSecret: "PHOTON_API_KEY" },
+  ],
+  "trigger-poll": [
+    { key: "url",             label: "Endpoint URL", placeholder: "https://api.example.com/status" },
+    { key: "intervalMinutes", label: "Poll every (minutes)", placeholder: "15" },
+    { key: "onlyOnChange",    label: "Only fire when response changed (true/false)", placeholder: "true" },
+  ],
+};
+
+interface Props {
+  kind: Kind;
+  data: TriggerChannelData;
+  onChange: (d: TriggerChannelData) => void;
+}
+
+export function TriggerChannelModal({ kind, data, onChange }: Props) {
+  const schema = SCHEMAS[kind];
+  const getField = (key: string): string =>
+    data.fields.find(f => f.key === key)?.value ?? "";
+
+  const setField = (key: string, value: string) => {
+    const existing = data.fields.findIndex(f => f.key === key);
+    let next: KV[];
+    if (existing >= 0) {
+      next = data.fields.map((f, i) => i === existing ? { ...f, value } : f);
+    } else {
+      next = [...data.fields, { key, value, enabled: true }];
+    }
+    onChange({ ...data, fields: next });
+  };
+
+  const addSecret = (slug: string) => {
+    if (!slug) return;
+    if (data.secrets.some(s => s.slug === slug)) return;
+    onChange({ ...data, secrets: [...data.secrets, { slug, value: "" }] });
+  };
+  const setSecret = (i: number, patch: Partial<{ slug: string; value: string }>) => {
+    const next = [...data.secrets]; next[i] = { ...next[i], ...patch };
+    onChange({ ...data, secrets: next });
+  };
+  const rmSecret = (i: number) =>
+    onChange({ ...data, secrets: data.secrets.filter((_, j) => j !== i) });
+
+  return (
+    <>
+      <label className="am-field">
+        <span>What should the agent do when this fires?</span>
+        <textarea
+          className="am-textarea"
+          value={data.prompt}
+          onChange={e => onChange({ ...data, prompt: e.target.value })}
+          rows={3}
+          placeholder="Read the incoming message and reply politely."
+        />
+      </label>
+      <div className="am-req-section">
+        <div className="am-req-section-head">Channel config</div>
+        {schema.map(f => (
+          <label key={f.key} className="am-field">
+            <span>{f.label}</span>
+            <div className="am-row am-row--tight">
+              <input
+                className="am-input am-mono am-field--grow"
+                value={getField(f.key)}
+                onChange={e => setField(f.key, e.target.value)}
+                placeholder={
+                  f.placeholder ??
+                  (f.secret ? `{{secrets.${f.suggestedSecret ?? "SECRET_NAME"}}}` : "")
+                }
+              />
+              {f.secret && f.suggestedSecret && (
+                <button
+                  type="button"
+                  className="am-step-add-btn"
+                  onClick={() => {
+                    setField(f.key, `{{secrets.${f.suggestedSecret!}}}`);
+                    addSecret(f.suggestedSecret!);
+                  }}
+                  title="Insert a secret reference and add it to the secret bag"
+                >Use secret</button>
+              )}
+            </div>
+          </label>
+        ))}
+      </div>
+      <div className="am-req-section">
+        <div className="am-req-section-head">Secrets (written to .env at build)</div>
+        {data.secrets.length === 0 && (
+          <div className="am-hint">No secrets yet. Click "Use secret" above to add one.</div>
+        )}
+        {data.secrets.map((s, i) => (
+          <div key={i} className="am-row am-row--tight">
+            <input
+              className="am-input am-mono am-input--fit"
+              value={s.slug}
+              onChange={e => setSecret(i, { slug: e.target.value })}
+              placeholder="SECRET_NAME"
+            />
+            <input
+              className="am-input am-mono am-field--grow"
+              type="password"
+              value={s.value}
+              onChange={e => setSecret(i, { value: e.target.value })}
+              placeholder="paste value once"
+            />
+            <button type="button" className="am-step-del" onClick={() => rmSecret(i)}>
+              <Trash2 size={12} />
+            </button>
+          </div>
+        ))}
+        <button type="button" className="am-step-add-btn"
+          onClick={() => addSecret(`SECRET_${data.secrets.length + 1}`)}>
+          <Plus size={11} /> Add secret
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/ThreadsView.tsx
+++ b/src/components/ThreadsView.tsx
@@ -470,7 +470,7 @@ export function ThreadsView({
         proOptions={{ hideAttribution: true }}
         colorMode={theme.type}
       >
-        <Background bgColor="var(--tempest-bg-editor)" color="var(--tempest-border-subtle)" gap={28} size={2.5} />
+        <Background id="threads-bg" bgColor="var(--tempest-bg-editor)" color="var(--tempest-border-subtle)" gap={28} size={2.5} />
         <Controls />
         <MiniMap pannable zoomable />
         <Panel position="top-center">

--- a/src/components/WorkspaceView.css
+++ b/src/components/WorkspaceView.css
@@ -698,6 +698,19 @@
   color: var(--tempest-fg-default);
 }
 
+.sidebar-nav-badge {
+  margin-left: auto;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--tempest-accent-subtle, var(--tempest-bg-hover));
+  color: var(--tempest-accent, var(--tempest-fg-muted));
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
 /* Agents section */
 
 .sidebar-section-label {

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -87,6 +87,7 @@ import { startModelManifestFetch } from "../lib/remoteConfig";
 import { startAgentHooks } from "../store/agentHooks";
 import { AtlasIndexModal } from "./AtlasIndexModal";
 import { KnowledgeBasePage } from "./KnowledgeBasePage";
+import { AutomationsPage } from "./Automations/AutomationsPage";
 import { Toolbar } from "./Toolbar";
 import AgentTabs from "./AgentTabs";
 import IconCapsule from "./IconCapsule";
@@ -2810,7 +2811,7 @@ export function WorkspaceView({ zen, name, path }: Props) {
               <KnowledgeBasePage />
             )}
             {!activeSessionId && activeSection === "automations" && (
-              <div className="overview-page" />
+              <AutomationsPage />
             )}
             {!activeSessionId && activeSection === "overview" && (
               <div className="overview-page">

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -1960,6 +1960,7 @@ export function WorkspaceView({ zen, name, path }: Props) {
             <button className={navBtn("automations")} onClick={() => goTo("automations")}>
               <Workflow size={16} />
               <span>Automations</span>
+              <span className="sidebar-nav-badge">Beta</span>
             </button>
           </div>
 

--- a/src/components/onboarding/WelcomePage.tsx
+++ b/src/components/onboarding/WelcomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { Component, type ReactNode, useState, useEffect } from 'react';
 import { CircleArrowRight } from 'lucide-react';
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -7,6 +7,16 @@ import { useTheme } from '../../themes/ThemeContext';
 import { TempestLogo } from '../../assets/TempestLogo';
 
 interface Props { onComplete: () => void; }
+
+// A decorative WebGL effect must never take down the app. WebKitGTK (Linux)
+// exposes OffscreenCanvas but not an OffscreenCanvas WebGL context, so metal-fx
+// throws "WebGL not supported" on mount. Isolate it and fall back to the plain
+// child button so onboarding still renders.
+class GfxBoundary extends Component<{ fallback: ReactNode; children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() { return { failed: true }; }
+  render() { return this.state.failed ? this.props.fallback : this.props.children; }
+}
 
 // ── Page 0 — Welcome ────────────────────────────────────────────
 export default function WelcomePage({ onComplete }: Props) {
@@ -31,12 +41,23 @@ export default function WelcomePage({ onComplete }: Props) {
         }}>
           Run your AI coding agents in parallel with 64% fewer tokens and deeper codebase understanding
         </p>
-        <MetalFx className="ob-metal" preset="chromatic" strength={0.78} theme={isDark ? 'light' : 'dark'} borderRadius={8} ringCssPx={3}>
-          <button className="ob-blank-btn" onClick={onComplete}>
-            Get Started
-            <CircleArrowRight size={21} />
-          </button>
-        </MetalFx>
+        <GfxBoundary
+          fallback={
+            <div className="ob-metal">
+              <button className="ob-blank-btn" onClick={onComplete}>
+                Get Started
+                <CircleArrowRight size={21} />
+              </button>
+            </div>
+          }
+        >
+          <MetalFx className="ob-metal" preset="chromatic" strength={0.78} theme={isDark ? 'light' : 'dark'} borderRadius={8} ringCssPx={3}>
+            <button className="ob-blank-btn" onClick={onComplete}>
+              Get Started
+              <CircleArrowRight size={21} />
+            </button>
+          </MetalFx>
+        </GfxBoundary>
       </div>
 
       <div className="ob-box" />

--- a/web/public/blogs/ai-agent-boundary-violations.mdx
+++ b/web/public/blogs/ai-agent-boundary-violations.mdx
@@ -1,0 +1,69 @@
+---
+slug: ai-agent-boundary-violations
+title: "AI Agent Boundary Violations: Why Agents Guess When Instructions Leave Gaps"
+date: 2026-08-06
+type: blog
+description: "Research shows most AI agent runs violate at least one scope boundary when instructions are underspecified. The fix is not stronger guardrails — it is a clearer specification."
+author: "Tempest Team"
+tags: [agents, workflow, safety, engineering]
+---
+
+Developers who have run AI coding agents long enough accumulate a class of stories that all sound roughly the same. The agent was given a task. The task was clear, or seemed clear. At some point the agent hit a constraint — a file it was not supposed to touch, a decision it did not have enough information to make, a boundary it was supposed to stay within. It did not stop. It did not ask. It inferred that the right move was to proceed anyway, and it did.
+
+The instinct is to call this misbehavior. The more useful framing is to call it specification behavior. The agent did not break your rules. It filled the gaps in your rules with its best guess about what you would have wanted. And it was wrong.
+
+How widespread is this? A recent survey found only 8% of organizations report that AI agents never exceed their intended permissions. The other 92% have seen it happen — occasionally, frequently, or regularly. The problem is not confined to edge cases.
+
+## Why agents cross scope boundaries instead of asking
+
+The default behavior of a language model when it encounters ambiguity is to resolve the ambiguity by inference. It reads the available context — the instruction, the conversation history, the code it can see, the tools it has access to — and it picks the most plausible continuation. This is what makes it useful. It is also what makes it dangerous at the edges of task scope.
+
+When an instruction is underspecified, the agent has two options: ask for clarification, or infer a reasonable completion. Asking for clarification stops progress and requires human intervention. Inference keeps progress moving. Models are trained on data that rewards getting things done, and getting things done usually means inferring rather than stopping. So they infer.
+
+Researchers recently measured this directly. In [Coding Agents Are Guessing: Measuring Action-Boundary Violations in Underspecified DevOps Instructions](https://arxiv.org/abs/2607.02294) (arXiv, 2026), they found that most agent runs violated at least one boundary when the instructions left gaps. The agents were not trying to violate boundaries. They were filling in the missing specification with what seemed like the most plausible interpretation — and the most plausible interpretation was usually to proceed.
+
+## What AI agent boundary violations look like in practice
+
+The pattern is consistent enough to describe clearly: an agent gets a task, encounters a wall, and improvises around it. The wall might be a permissions boundary, a file it was told not to modify, a decision that requires information it does not have, or a dependency that is not in scope. Rather than stopping at the wall, the agent finds a path around it.
+
+Sometimes the improvisation is harmless — the agent modifies a file adjacent to the one it was supposed to touch, and the result is fine. Sometimes it is not. The common thread is not that the agent made a bad decision, but that it made a decision it was not authorized to make, without signaling that it had done so.
+
+This is the failure mode that makes AI agent boundary violations hard to catch. The agent's output does not advertise what it did. The code it produced may be correct. The tests may pass. The unauthorized action may not surface until something breaks later, or until a careful audit of the diff reveals a change that should not have been made.
+
+## The specificity gap
+
+Most agent instructions fail not because they prohibit the wrong things but because they leave too much unprescribed. Telling an agent to "refactor the authentication module" leaves open what it means to refactor — whether it can modify the tests, whether it can rename exported types, whether it can change the interface that other modules depend on, whether it can create new files. Each of those gaps is a place where the agent will make an inference.
+
+The inference is not random. The agent will infer the most plausible completion given its context. But "most plausible" and "what you intended" are different things, and the gap between them is the source of most boundary violations.
+
+The fix is not to write longer instructions. It is to write instructions that close the specific gaps that matter. The question to ask for any task is not "have I said what I want?" but "have I said what I do not want, and do those prohibitions cover the inferences the agent is most likely to make?"
+
+Scope guards — explicit lists of what the agent must not touch — are more useful than general scope statements. "Refactor the authentication module" is a general scope statement. "Do not modify any files outside `src/auth/`; do not change any exported type signatures; do not modify the test files" is a set of scope guards. The guards address the specific inferences an agent is likely to make that would take it outside intended scope. The arXiv researchers found this class of prohibition — explicit "not included" constraints — to be the single most effective structural change in reducing boundary violations.
+
+## Why broad permissions amplify the problem
+
+Boundary violations are not just a specification problem. They are also a permissions problem. An agent can only overstep in domains where it has been granted access.
+
+An agent with write access to the entire repository and the ability to run arbitrary shell commands can improvise much more widely than an agent limited to a specific directory with read access to the rest of the codebase. When the agent hits a wall and infers a path around it, the set of available paths is defined by what permissions it has.
+
+This means that reducing permissions is not just a security practice — it is a specification practice. An agent that cannot write outside its target directory cannot improvise outside its target directory. You have not fixed the underlying tendency to infer; you have bounded the scope in which inference can cause problems. The blast radius of a wrong inference is limited by what the agent can do with the inference.
+
+Worktree isolation provides this naturally for file access. An agent working in its own worktree cannot modify files in main. It cannot touch another session's working state. The scope of its possible improvisation is bounded by the directory it lives in.
+
+## The stopping condition problem
+
+There is one more gap that causes boundary violations that scope guards cannot directly address: the failure to specify when to stop and ask rather than proceeding.
+
+Agents infer rather than stop because the instruction did not tell them when stopping is the right choice. Adding an explicit stopping condition changes this. For any task where there is a class of decision you would want to make yourself — a decision that significantly affects the interface, touches critical infrastructure, or changes behavior that other systems depend on — make that explicit in the instruction.
+
+"If you encounter anything that would require modifying files outside `src/auth/`, stop and report back" is a stopping condition. "If implementing this would require changing any exported type signatures, stop and describe what change would be needed before making it" is a stopping condition. The agent will follow these if they are present. It will infer past them if they are not.
+
+The difference between an agent that stays in bounds and one that does not is usually not the model. It is whether the instruction anticipated where the boundaries were most likely to be tested.
+
+---
+
+## Further reading
+
+- [Context Rot: Why Your AI Agent Gets Worse the Longer It Runs](/blog/context-rot-why-your-ai-agent-gets-worse)
+- [Why Parallel Agents Change Everything](/blog/why-parallel-agents-change-everything)
+- [The Case Against Context Switching Between AI Agents](/blog/the-case-against-context-switching)

--- a/web/public/blogs/comprehension-debt-the-hidden-cost-of-ai-code-review.mdx
+++ b/web/public/blogs/comprehension-debt-the-hidden-cost-of-ai-code-review.mdx
@@ -1,0 +1,74 @@
+---
+slug: comprehension-debt-the-hidden-cost-of-ai-code-review
+title: "Comprehension Debt: The AI Code Review Problem Teams Aren't Measuring"
+date: 2026-08-06
+type: blog
+description: "Comprehension debt — reviewing AI-generated code faster than you understand it — is accumulating silently in engineering teams. Here is what the research shows and how to slow it down."
+author: "Tempest Team"
+tags: [workflow, code-review, agents, engineering]
+---
+
+The productivity numbers for AI coding agents look extraordinary until you look at the review numbers alongside them. Teams using AI agents heavily are merging dramatically more pull requests. They are also spending dramatically more time in review. The output went up. So did the cost of understanding it.
+
+This is not a coincidence. It is a predictable consequence of a specific failure mode that does not have a common name yet, even though most developers working with AI agents have experienced it. The name, coined by developer advocate Addy Osmani in early 2026, is comprehension debt.
+
+## What comprehension debt is
+
+Comprehension debt accumulates when you review code faster than you can understand it. The review passes — no obvious bugs, tests pass, the implementation looks plausible — but you have not actually built a mental model of what the code does. You approved something you could not reconstruct from memory.
+
+This is different from approving code written by a colleague whose work you generally trust, where you are making a judgment call about review depth. Comprehension debt is the specific case where you are reading AI-generated code, the volume is high, and the cognitive cost of actually understanding it is high enough that you skim. The code is not wrong enough to catch your attention. It is right enough to pass.
+
+Survey data from Addy Osmani's 2026 research puts numbers on what developers already report anecdotally: 38% of developers find reviewing AI-generated code requires more effort than reviewing human-written code ([Addy Osmani](https://addyosmani.com/blog/comprehension-debt/), 2026). Only 48% say they consistently review AI output before committing. These two numbers together describe a population of developers merging code they have partially reviewed, some of which they would struggle to explain later.
+
+## Why AI-generated code is harder to review
+
+Human-written code carries the author's reasoning in its structure. The shape of a function, the names chosen, the abstractions introduced — these reflect a thinking process you can reconstruct. When code is confusing, you can ask the author what they were thinking and get useful context.
+
+AI-generated code does not carry reasoning in the same way. The model selects implementations that satisfy the stated requirements, but the selection is not based on the same tradeoffs a human engineer would make. The code may be correct but structured in a way no human would have structured it — not because it is wrong, but because it is optimizing for different things. It can be harder to reason about, not easier, even when it works.
+
+There is also an output volume problem. A developer writing code produces code at a rate roughly matched to the rate at which they can think about it. An AI agent produces code at a rate that far outpaces the developer's review capacity. The bottleneck shifts from generation to comprehension, and nothing about the tooling or the workflow has changed to accommodate that shift.
+
+A randomized controlled trial with 52 software engineers makes this gap concrete. Participants using AI assistance to learn a new library completed their tasks in roughly the same time as a control group but scored 17% lower on a follow-up comprehension quiz — with the largest drops in debugging ability. The pattern inside the AI group was equally striking: developers using AI for code generation scored below 40% on comprehension tests, while those using AI for conceptual inquiry — asking questions, exploring tradeoffs — scored above 65%. The mode of use matters as much as the tool itself.
+
+## The trap: easy to review, hard to understand
+
+The specific psychological trap of comprehension debt is that AI-generated code is often easy to review superficially and hard to understand deeply. The implementations are syntactically correct, follow the patterns of the codebase, pass the tests, and look fine on a first pass. There is nothing to catch your attention.
+
+A human reviewer catching a subtle bug has to notice something that does not look right. But if the code looks right — if it is plausible, coherent, and consistent with the surrounding code — the reviewer's attention passes over it. You approved code you could not explain because nothing in the review experience prompted you to try to explain it.
+
+This is what makes comprehension debt compound over time. Code you approved without fully understanding becomes part of the codebase. Future AI agents read it. Future reviews are conducted against it. The debt accumulates silently until something breaks in a way that requires actually understanding the code, at which point the accumulated misunderstanding becomes expensive.
+
+## What the 91% review time increase means
+
+A 91% increase in review time alongside a 98% increase in merged pull requests means that review is not keeping pace with output. Developers are reviewing more code but spending less time per unit of code. The per-PR review time is dropping even as total review time goes up.
+
+This is exactly the pattern that creates comprehension debt at scale. High volume, reduced per-unit attention, no natural forcing function to slow down and build a mental model. The workflow accommodates the output rate of the AI agent rather than the comprehension rate of the reviewing engineer.
+
+The consequences are not immediate. Code merges, features ship, tests pass. The debt becomes visible later, when the code needs to be modified and no one on the team can confidently describe what it does, or when a subtle bug surfaces that a careful reader would have caught and that a quick reviewer did not.
+
+## Practical countermeasures
+
+The countermeasure is not to merge less AI-generated code. It is to change the conditions under which review happens so that comprehension is the default rather than an afterthought.
+
+The most effective change is to treat the review step as a separate cognitive task rather than an extension of the delegation step. Do not review immediately after delegating. The urgency bias of a completed PR creates pressure to approve quickly. Reviewing after a gap, when you come to the diff cold, changes what you see.
+
+Ask a forcing question during review: could I modify this code confidently without looking anything up? If the answer is no, you have identified a comprehension gap. That does not necessarily mean the code should not be merged — sometimes it is fine to ship code you would need to revisit before modifying. But it means you know what you have, and you can record the gap explicitly rather than discovering it later under pressure.
+
+Scope-constrained agent sessions help with this. An agent working on a single, well-defined task produces a diff with a clear boundary. You know what the code is supposed to do because you specified it. Review becomes a question of whether the implementation does what you asked, rather than a question of what the implementation does at all.
+
+## The skill atrophy problem
+
+Comprehension debt has a longer-term consequence that is harder to measure: skill atrophy. When developers review code they did not write and do not deeply understand, they are not exercising the skills required to write that code themselves. Over time, the ability to construct mental models of complex code, to design abstractions from first principles, to debug unfamiliar systems — these erode.
+
+This matters not as a philosophical point about craftsmanship, but as a practical risk. The developers least able to catch subtle errors in AI-generated code are the developers who have been reviewing AI-generated code for the longest time without deeply understanding it. The debt compounds in the person, not just the codebase.
+
+The countermeasure here is deliberate practice on code you wrote without AI assistance. Not as a political statement, but as a way to keep the diagnostic skills sharp enough to be useful when you need them.
+
+---
+
+## Further reading
+
+- [Comprehension Debt — Addy Osmani](https://addyosmani.com/blog/comprehension-debt/)
+- [The Case Against Context Switching Between AI Agents](/blog/the-case-against-context-switching)
+- [Why Parallel Agents Change Everything](/blog/why-parallel-agents-change-everything)
+- [Context Rot: Why Your AI Agent Gets Worse the Longer It Runs](/blog/context-rot-why-your-ai-agent-gets-worse)

--- a/web/public/blogs/context-rot-why-your-ai-agent-gets-worse.mdx
+++ b/web/public/blogs/context-rot-why-your-ai-agent-gets-worse.mdx
@@ -1,0 +1,69 @@
+---
+slug: context-rot-why-your-ai-agent-gets-worse
+title: "Context Rot: Why Your AI Agent Gets Worse the Longer It Runs"
+date: 2026-08-06
+type: blog
+description: "Context rot is what happens when a long AI coding session fills with failed exploration and the agent stops taking new direction. Here is why it happens and how to clear it."
+author: "Tempest Team"
+tags: [context, workflow, agents, performance]
+---
+
+There is a failure mode that most developers eventually notice but rarely name. You start a session with an AI coding agent, give it a task, and it does excellent work. An hour in, you realize the approach is wrong. You redirect it. The agent acknowledges your direction, then continues doing roughly what it was doing before. You redirect again. Same result. The agent is not ignoring you — it is stuck.
+
+This is context rot. And unlike most AI agent problems, it is not a model capability issue. It is a physics problem.
+
+## What context rot is and why it compounds
+
+Every conversation with an AI coding agent is a growing document. Every message, every tool call, every file read, every intermediate result — all of it accumulates in the context window. The model reads the entire document every time it needs to respond.
+
+The problem is that language models do not treat all tokens equally in the way a human reader would. A human reading a long document can decide which sections are still relevant and which ones represent abandoned thinking. Models cannot do this reliably. When the context contains 10,000 tokens of work on a particular approach, and you then add 200 tokens redirecting the agent to a different approach, the model has to reconcile a massive volume of work pointing one way with a small signal pointing another. The prior work wins — not through any intentional choice, but because it dominates the evidence.
+
+The result is an agent that technically understands your new direction but behaviorally follows the old one. Its responses reflect the accumulated momentum of everything that came before.
+
+## The specific trigger: failed explorations
+
+Context rot is worst when the context contains failed work. Successful work that gets incorporated into the codebase is at least grounded in reality — there are files and outputs that correspond to it. Failed explorations are pure context pollution. The agent tried an approach, hit a wall, the approach was abandoned, but the entire reasoning chain for that approach is still in the window.
+
+If you have ever had a session where the agent kept reverting to a discarded approach even after you explicitly ruled it out, you have experienced this. The agent is not being stubborn. It is being statistically honest: the preponderance of evidence in its context window points toward that approach, and your correction is a small counter-signal against a large prior. Practitioners call this specific state context poisoning — the condition where the weight of prior failed work actively resists new direction, independent of how clearly that direction is stated.
+
+This makes long, exploratory sessions especially prone to context rot. The sessions where you most want an agent's help — messy problems where you are figuring things out as you go — are exactly the sessions where context accumulates the most unhelpful history.
+
+## Why redirecting does not always work
+
+When context rot sets in, the natural instinct is to give a stronger redirect. Add emphasis. Be more explicit. Add more instructions. This frequently makes things worse.
+
+More instructions add more tokens to an already contaminated window. The signal-to-noise ratio deteriorates further. Each new instruction competes with a larger volume of prior context, and the accumulated momentum of the earlier work continues to exert gravitational pull on the agent's responses.
+
+The redirect failure is not a failure of the model to understand your instruction. It is a failure of the architecture to let new direction override old. The model understands what you are asking. It simply cannot reconcile that request with what its context window is telling it to do.
+
+## The cure: controlled context resets
+
+The only reliable fix for context rot is to reduce the contaminated context — ideally by replacing it with a clean summary that retains what was useful and discards what was not.
+
+In Claude Code, `/compact` does a version of this automatically: it summarizes the conversation history into a compressed form and replaces the raw history with the summary. This is meaningfully different from just shortening the context. It lets the model reestablish what it knows with a fresh frame, rather than continuing to navigate a context full of contradictory signals.
+
+The more powerful approach is to spawn a new session entirely when a major direction change is needed. Take what you learned from the failed exploration, write a clean brief for the new approach, and start fresh. This feels like lost work but it is often the fastest path forward. A new session with 200 tokens of well-synthesized direction outperforms a contaminated session with 20,000 tokens of accumulated history.
+
+The scale of what compaction has to process makes this tradeoff concrete. A heavy session can accumulate hundreds of thousands of tokens of history. Standard in-session compaction is slow — often two minutes or more — and loses information in the compression. That specialized tooling for context compaction has become a category of its own ([FlashCompact by Morph](https://morph.so), among others) is a reasonable measure of how acute the context rot problem has become for developers running long agent sessions.
+
+## What to do about it proactively
+
+The agents least likely to rot are those working on tightly scoped tasks with clearly bounded files. The more a session is allowed to sprawl — exploring different parts of the codebase, trying multiple approaches, reading files loosely related to the core task — the more quickly context rot sets in.
+
+Scoped tasks resist rot. When you give an agent a task with a defined file list, a specific output, and a clear definition of done, there is much less opportunity for exploratory context to accumulate. Failed approaches get tried within a smaller surface area. The context stays focused on a coherent unit of work.
+
+This is one reason why the worktree-per-session model matters beyond isolation. A session that is scoped to one task, on one branch, with a clear output is a session that is less likely to accumulate the unfocused history that causes rot. You do not need to reset a session that never strayed in the first place.
+
+## When to reset versus when to persist
+
+Not every long session needs a reset. If the agent is making progress and you are redirecting small details rather than entire approaches, the context is doing its job — accumulating useful history that makes the agent better informed. Reset when the agent has stopped taking direction in a way that matches what you are observing, not on a timer.
+
+The signal is behavioral: the agent acknowledges new direction in its responses but executes old direction in its outputs. When what it says and what it does diverge consistently, the context is poisoned and persistence is cheaper than fighting it.
+
+---
+
+## Further reading
+
+- [The Case Against Context Switching Between AI Agents](/blog/the-case-against-context-switching)
+- [How to Reduce AI Agent Token Costs When Running Multiple Sessions](/blog/reduce-ai-agent-token-costs)
+- [Token Intelligence: Eliminating Redundant File Reads Across Agent Sessions](/blog/token-intelligence-eliminating-redundant-reads)

--- a/web/public/blogs/index.json
+++ b/web/public/blogs/index.json
@@ -1,5 +1,61 @@
 [
   {
+    "slug": "ai-agent-boundary-violations",
+    "title": "AI Agent Boundary Violations: Why Agents Guess When Instructions Leave Gaps",
+    "date": "2026-08-06",
+    "type": "blog",
+    "description": "Research shows most AI agent runs violate at least one scope boundary when instructions are underspecified. The fix is not stronger guardrails — it is a clearer specification.",
+    "author": "Tempest Team",
+    "tags": [
+      "agents",
+      "workflow",
+      "safety",
+      "engineering"
+    ]
+  },
+  {
+    "slug": "comprehension-debt-the-hidden-cost-of-ai-code-review",
+    "title": "Comprehension Debt: The AI Code Review Problem Teams Aren't Measuring",
+    "date": "2026-08-06",
+    "type": "blog",
+    "description": "Comprehension debt — reviewing AI-generated code faster than you understand it — is accumulating silently in engineering teams. Here is what the research shows and how to slow it down.",
+    "author": "Tempest Team",
+    "tags": [
+      "workflow",
+      "code-review",
+      "agents",
+      "engineering"
+    ]
+  },
+  {
+    "slug": "context-rot-why-your-ai-agent-gets-worse",
+    "title": "Context Rot: Why Your AI Agent Gets Worse the Longer It Runs",
+    "date": "2026-08-06",
+    "type": "blog",
+    "description": "Context rot is what happens when a long AI coding session fills with failed exploration and the agent stops taking new direction. Here is why it happens and how to clear it.",
+    "author": "Tempest Team",
+    "tags": [
+      "context",
+      "workflow",
+      "agents",
+      "performance"
+    ]
+  },
+  {
+    "slug": "reduce-ai-agent-token-costs",
+    "title": "How to Reduce AI Agent Token Costs When Running Multiple Sessions",
+    "date": "2026-07-25",
+    "type": "blog",
+    "description": "Running multiple AI agents in parallel multiplies token costs — unless you share context between sessions. Here is how Token Intelligence cuts usage by up to 64%.",
+    "author": "Tempest Team",
+    "tags": [
+      "token-intelligence",
+      "cost",
+      "parallel-agents",
+      "performance"
+    ]
+  },
+  {
     "slug": "tempest-v013-release",
     "title": "Tempest v0.1.3: Chat",
     "date": "2026-07-11",


### PR DESCRIPTION
## Summary
- **Automations (Eve runtime):** DB schema, Tauri commands, and initial UI scaffold for the agent runtime
- **Visual builder:** n8n-style canvas with palette, node modal, custom edges/connectors, model picker, and per-domain editors — flow (Condition, Step), tool (Input schema, Request, Response, KV rows, Value chips), and triggers (channel modal); human-readable cron helper
- **Fixes:** global scope for builder, correct palette drop position, click-to-add
- **Sidebar:** `Beta` badge on the Automations nav button
- **Content:** three new blog posts (AI agent boundary violations, comprehension debt in AI code review, context rot) + `blogs/index.json` update
- Misc: README, `Cargo.toml/lock`, onboarding welcome copy

## Test plan
- [ ] Open Automations from sidebar — Beta badge renders inside the button, right-aligned
- [ ] Create a new automation; drag nodes from palette (drop position accurate) and click-to-add
- [ ] Configure a trigger, a tool node (request → response mapping), and a flow condition/step; save
- [ ] Run the automation via Eve runtime; verify persistence across app restart
- [ ] Verify onboarding welcome still handles the WebKitGTK/WebGL fallback from #19
- [ ] CI: Frontend ✅ · Rust ✅ · Vercel preview loads