### PR TITLE
Release v0.1.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Something isn't working the way it should
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more we know, the faster we can fix it.
+
+        **Security issue?** Please don't file it here — email gsvprharsha@tempestai.dev. See [SECURITY.md](../../SECURITY.md).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I clicked X, Y happened. I expected Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The smallest sequence of steps that triggers the bug.
+      placeholder: |
+        1. Open Tempest
+        2. Create a new canvas
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Tempest version
+      description: Find it in the app's About / title bar, or from the installer filename.
+      placeholder: "0.1.12"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows 11
+        - Windows 10
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      placeholder: "e.g. Windows 11 23H2, macOS 14.5, Ubuntu 24.04"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: DevTools console output, terminal output, or screenshots. Redact anything sensitive.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been reported yet
+          required: true
+        - label: I'm on the latest version, or I've noted the version above
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/tempestai-dev/tempest/security/policy
+    about: Do not open a public issue. See our security policy for private reporting.
+  - name: Question or discussion
+    url: https://github.com/tempestai-dev/tempest/discussions
+    about: For open-ended questions, ideas, or help using Tempest.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Suggest a new capability or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea. The best requests explain the problem first, then the shape of the solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: What are you trying to do that Tempest doesn't let you do today?
+      placeholder: I want to ... but currently I have to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would the solution look like?
+      description: How would this work from the user's point of view? Sketches, mockups, or example flows help.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other approaches, workarounds, or tools that partially solve this.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this touch?
+      multiple: true
+      options:
+        - Threads / canvas
+        - Chat nodes (BYOK)
+        - Chat nodes (Claude Code bridge)
+        - Agent / terminal nodes
+        - Token Intelligence
+        - Database Branches
+        - Hephaestus (isolation)
+        - Automations
+        - Settings / preferences
+        - Mobile / remote
+        - Docs / website
+        - Other
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been requested yet
+          required: true
+        - label: This is aligned with the direction in ROADMAP.md, or I've explained why it should be
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thanks for the contribution. A few things that make PRs easier to review:
+- One focused change per PR
+- Link the issue this closes (Closes #123) if there is one
+- Note anything reviewers should look at closely or test manually
+-->
+
+## What changed
+
+<!-- A short description of the change and why. -->
+
+## Related issue
+
+<!-- Closes #123, or "N/A" -->
+
+## How was this tested
+
+<!-- Manual steps, screenshots, or automated tests. If UI, before/after screenshots help. -->
+
+## Checklist
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `cargo check` passes (if backend changed)
+- [ ] I've tested this on my OS — noted which: <!-- Windows / macOS / Linux -->
+- [ ] Docs updated if user-facing behaviour changed
+- [ ] No secrets, tokens, or personal paths in the diff

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,23 +4,50 @@
 
 Be respectful. Assume good intent. Focus on the work.
 
-## Expected behavior
+## Our commitment
+
+We want Tempest to be a project where anyone — regardless of experience level, background, or identity — can contribute, ask questions, and be heard. Everyone participating in this project agrees to uphold this code of conduct.
+
+## Expected behaviour
 
 - Use welcoming and inclusive language
-- Accept constructive feedback gracefully
+- Respect differing viewpoints and experiences
+- Accept constructive feedback gracefully, and give it kindly
 - Focus on what is best for the project and its users
 - Show patience with contributors of all experience levels
+- Assume good intent, and clarify before escalating
 
-## Unacceptable behavior
+## Unacceptable behaviour
 
-- Harassment, insults, or personal attacks
-- Trolling or sustained disruption of discussions
-- Publishing others' private information without consent
-
-## Enforcement
-
-Violations can be reported by opening a private issue or emailing the maintainer directly. Reports will be reviewed and acted on at the maintainer's discretion. Depending on severity, consequences range from a warning to a permanent ban from the project.
+- Harassment, insults, or personal attacks of any kind
+- Discriminatory jokes or language
+- Trolling, deliberate misinformation, or sustained disruption of discussions
+- Publishing others' private information (doxxing) without explicit consent
+- Sexualised language, imagery, or unwelcome sexual attention
+- Any conduct that a reasonable person would find inappropriate in a professional setting
 
 ## Scope
 
-This code of conduct applies in all project spaces — GitHub issues, pull requests, discussions, and any other official channels.
+This code of conduct applies in all project spaces — GitHub issues, pull requests, discussions, commit messages, review comments — and in any other space where an individual is representing the project or its community (social media, events, external channels).
+
+## Enforcement
+
+Violations can be reported privately by emailing **[gsvprharsha@tempestai.dev](mailto:gsvprharsha@tempestai.dev)**. Please include:
+
+- What happened, with links or screenshots if relevant
+- Who was involved
+- Whether the incident is ongoing
+
+Reports are reviewed confidentially. We will respond within a reasonable timeframe and will not disclose the reporter's identity without their consent.
+
+Consequences are decided by the maintainers based on severity and pattern, and may include:
+
+1. **Warning** — a private note that the behaviour was unacceptable, with an explanation of why
+2. **Temporary ban** — no interaction with the project or maintainers for a set period
+3. **Permanent ban** — permanent removal from all project spaces
+
+Maintainers who fail to enforce this code in good faith may face temporary or permanent consequences as determined by the project's leadership.
+
+## Attribution
+
+This code of conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,31 @@
 # Contributing to Tempest
 
-Thanks for your interest in contributing. This document covers how to get set up and what to expect when submitting changes.
+Thanks for your interest in contributing. Tempest is an open, early-stage project — bug reports, small fixes, and larger contributions are all welcome. This guide covers how to get set up, how the repo is organised, and what to expect when you open a pull request.
+
+## Table of contents
+
+- [Ways to contribute](#ways-to-contribute)
+- [Repository layout](#repository-layout)
+- [Prerequisites](#prerequisites)
+- [Getting started](#getting-started)
+- [Running individual pieces](#running-individual-pieces)
+- [Type checking](#type-checking)
+- [Making changes](#making-changes)
+- [Submitting a pull request](#submitting-a-pull-request)
+- [Reporting bugs](#reporting-bugs)
+- [Security issues](#security-issues)
+- [Commit style](#commit-style)
+- [License](#license)
+
+## Ways to contribute
+
+- **File a bug** — use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml)
+- **Suggest a feature** — use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml), or check [ROADMAP.md](ROADMAP.md) for open workstreams
+- **Send a pull request** — small fixes need no discussion; for larger changes, open an issue first so we can align on approach
+- **Improve docs** — the marketing site (`web/`) and Mintlify docs (`docs/`) are in this same repo
+- **Report a vulnerability** — see [SECURITY.md](SECURITY.md); do not open a public issue for security problems
+
+If you want to work on something bigger, the **Tempest Bridge** workstream on the roadmap is the front door for collaboration.
 
 ## Repository layout
 
@@ -18,7 +43,7 @@ tempest-git/
 - [Node.js](https://nodejs.org/) 20 or later
 - [Rust](https://rustup.rs/) (stable)
 - [Tauri CLI](https://tauri.app/start/prerequisites/) dependencies for your OS
-- On Windows: WebView2 (ships with Windows 11; standalone installer available for Windows 10)
+- Windows only: WebView2 (ships with Windows 11; standalone installer available for Windows 10)
 
 ## Getting started
 
@@ -47,35 +72,37 @@ npm run dev:docs     # Documentation      (localhost:3001)
 
 ## Type checking
 
+Both must pass clean before a PR can be merged:
+
 ```bash
 npx tsc --noEmit          # Frontend TypeScript
 cargo check               # Rust backend
 ```
 
-Both must pass clean before a PR is merged.
+Please run these locally rather than relying on CI to catch issues.
 
 ## Making changes
 
-### Desktop app (src/ + src-tauri/)
+### Desktop app (`src/` + `src-tauri/`)
 
-- Frontend lives in `src/` — React 19, Vite, TypeScript
-- Backend lives in `src-tauri/src/lib.rs` — Tauri commands, PTY, git operations
-- CSS variables only — no hardcoded colors; all values go through `--tempest-*` vars
-- No `React.StrictMode` — it double-invokes effects and breaks PTY spawning
+- Frontend: React 19, Vite, TypeScript — lives in `src/`
+- Backend: Tauri commands, PTY, git operations — lives in `src-tauri/src/lib.rs`
+- **CSS variables only** — no hardcoded colours; all values go through `--tempest-*` vars so themes work
+- **No `React.StrictMode`** — it double-invokes effects and breaks PTY spawning
 
-### Atlas package (packages/atlas/)
+### Atlas package (`packages/atlas/`)
 
 - Run `npm run build:atlas` after any changes before testing in the app
 - `tsc --noEmit` must pass inside `packages/atlas/`
 
-### Website (web/)
+### Website (`web/`)
 
 ```bash
 npm run dev:web
 npm run build:web
 ```
 
-### Docs (docs/)
+### Docs (`docs/`)
 
 ```bash
 npm run dev:docs
@@ -85,27 +112,39 @@ npm run build:docs
 ## Submitting a pull request
 
 1. Fork the repo and create a branch from `main`
-2. Make your changes
+2. Make your changes — keep the PR focused on one thing
 3. Run `npx tsc --noEmit` and `cargo check` — fix any errors
-4. Open a PR against `main` with a clear description of what changed and why
-5. Keep PRs focused — one thing per PR is easier to review and safer to merge
+4. Push and open a PR against `main`; the [PR template](.github/PULL_REQUEST_TEMPLATE.md) will guide you
+5. Link the issue you're closing, and note anything a reviewer should test manually
+6. Be responsive to review feedback — small, iterative rounds land faster than one giant push
+
+We aim to give an initial response within a few days. If a PR goes quiet for longer, feel free to ping.
 
 ## Reporting bugs
 
-Open an issue on GitHub. Include:
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml). Include:
+
 - OS and version
 - Tempest version
 - Steps to reproduce
 - What you expected vs what happened
+- Logs or screenshots if you have them (redact anything sensitive)
 
-For security issues, email directly instead of opening a public issue.
+## Security issues
+
+**Do not open a public issue.** Email **[gsvprharsha@tempestai.dev](mailto:gsvprharsha@tempestai.dev)** — full policy in [SECURITY.md](SECURITY.md).
 
 ## Commit style
 
-Plain imperative subject line, no emoji, no period at the end:
+Plain imperative subject line, no emoji, no period at the end. A conventional prefix is helpful but not required.
 
 ```
 fix: resolve atlas indexing in production builds
 feat: add command palette
 chore: update dependencies
+docs: clarify Hephaestus scope in README
 ```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE) that covers the project.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Both behaviours are toggles in **Settings → Security**. You stay in control.
 
 See [ROADMAP.md](ROADMAP.md) for the full picture. **Star this repo** — we announce here first.
 
+## Project
+
+- [Roadmap](ROADMAP.md) — where Tempest is going and what's currently being built
+- [Contributing](CONTRIBUTING.md) — setup, workflow, and how to send a PR
+- [Code of Conduct](CODE_OF_CONDUCT.md) — how we behave in project spaces
+- [Security policy](SECURITY.md) — reporting vulnerabilities (please do not open a public issue)
+- [License](LICENSE) — Apache 2.0
+
 ## Build from source
 
 Pre-built binaries are available for Windows, macOS, and Linux.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,47 +6,57 @@ This document describes where Tempest is going and why. It is a living record of
 
 Parallel agent sessions are the foundation. Tempest is an engineering platform where multiple agents work on a codebase the way a team does — with isolation guarantees, shared context, and full tooling to review and ship their work. Every workstream below serves that: making each agent smarter and safer, and making the surface you orchestrate them from feel like one coherent space rather than a stack of terminals.
 
-## Now building: Threads — the canvas workspace
+## Foundation (shipped)
 
-We are migrating Tempest's single, linear chat into **Threads**: a spatial, node-based canvas where research, discussion, and agent-launching happen as **nodes** instead of one scrolling pane. The canvas is the planning and orchestration surface; execution (agents, terminals) binds to git branches.
-
-Why this matters: a linear chat can only hold one line of thought. Real engineering work forks — you are weighing three approaches, running two agents on two branches, and keeping notes alongside both. A canvas lets those coexist and share ambient context without collapsing into one thread.
-
-The model, in short:
-
-- **One canvas per tab.** A project has many canvases (listed in the sidebar Threads dropdown); each is a flat surface of nodes.
-- **Nodes** are the atomic unit: `chat`, `text`, `agent`, `terminal`. Thinking nodes (chat, text) carry no branch; execution nodes (agent, terminal) bind to a git branch and a real PTY session.
-- **Ambient context, not file dumps.** The canvas shares node types, titles, and output summaries. Full code enters context only through a specific agent node's own working directory.
-- **Reuse over rebuild.** Agent/terminal nodes render existing PTY sessions; the chat node reuses the existing streaming and tool infrastructure. Git context is a callable tool, not a silent prepend.
-
-Chat nodes are **BYOK** (bring your own key) for now — direct API via the existing streaming path.
-
-## Tempest Bridge: connect any CLI agent
-
-Separate from the BYOK chat node, we want to build the **bridge between Tempest and the CLI coding agents developers already use** — driving an existing agent (starting with Claude Code, via its Agent SDK) as a first-class backend inside Tempest, without hand-parsing terminal bytes. A user with no API key should be able to point Tempest at their installed CLI and get the same node experience.
-
-This is an open, wanted workstream and a great place to collaborate directly. It needs a design pass first (transport, account- vs per-node connection, which CLIs, how the agent's own tools coexist with ours). The plan's §12 captures the current thinking and the known risk (Windows process spawning). If you want to help build the bridge, this is the front door.
-
-## Foundation
+**Threads — the canvas workspace.** The linear chat is gone. Every tab is now a spatial, node-based canvas where research, discussion, and agent-launching happen as **nodes** instead of one scrolling pane. Nodes come in four types: `chat`, `text`, `agent`, `terminal`. Thinking nodes carry no branch; execution nodes bind to a git branch and a real PTY session. The canvas shares ambient context (node types, titles, output summaries) without collapsing everything into one thread.
 
 **Token Intelligence.** A local code-knowledge graph, built per project, that agents query directly instead of firing repeated file reads and blind searches. Benchmarked across 7 real-world projects (TypeScript, Python, Rust, Go, Java, Swift): up to 64% fewer tokens on large codebases and 58% fewer tool calls on average. Built in — no configuration, no separate service.
 
 **Database Branches.** Every agent gets its own live, isolated Postgres connection — a real copy of your source database it can migrate, break, and reset without ever touching production or another agent's database. When the session ends, the branch is cleaned up. Real backend work, in parallel, with zero blast radius.
 
+**Tempest Bridge.** Claude Code runs as a first-class chat backend inside canvas nodes via the Claude Agent SDK — no API key required if you already have the CLI installed. This is the pattern we'll extend to other CLI agents next.
+
+## Now building
+
+**Threads polish.** Threads shipped as an MVP: the model works, the surface doesn't yet feel finished. Node layout, selection, keyboard flow, canvas navigation, and the empty-state onboarding all need another pass. If you've used it and it felt rough somewhere specific, open an issue — that's the shortlist.
+
+**Hephaestus hardening.** Hephaestus is the per-agent isolation layer (Job Objects on Windows, `sandbox-exec` on macOS, bubblewrap on Linux). It's live, but agents can still escape in cases we know about. Closing those holes and reaching parity across all three OSes is a priority — this is the guarantee the rest of the platform is built on, and it has to actually hold.
+
+**Automations.** Currently in beta. The runtime works; the authoring surface, model routing, and failure-recovery story need to catch up before it graduates. Per-automation model overrides landed recently; scheduling, retries, and observability are next.
+
+**More agents.** Bridge proved the pattern with Claude Code. We want the same first-class node experience for other CLI coding agents (Codex, Gemini CLI, and whatever comes next), plus additional API providers in BYOK chat nodes.
+
+**Desktop notifications.** Long-running agents shouldn't require you to sit and watch them. Native OS notifications for agent completion, approval prompts, and errors — cross-platform.
+
 ## On the roadmap
 
-**macOS support** — the core architecture is cross-platform; macOS packaging and testing is in progress, Linux follows.
+**Mobile apps (iOS + Android).** Built with Expo. Not a mini IDE — a companion surface: check on agents, approve or redirect them mid-run, review diffs, get notified when something needs you. Backed by remote agents (below) so the desktop app can be closed.
 
-**Multi-agent coordination** — agents aware of each other's work, not just isolated from it: shared task context, merge-ready handoffs, composable workflows without giving up the isolation guarantees.
+**Remote agents.** Agents still execute locally on your machine — but the control plane is remote-accessible. Launch, monitor, and steer them from the mobile app, from another laptop, or from a script. Local-only execution keeps the isolation and cost story intact; remote control unlocks the "my agents are working, I'm not at my desk" use case.
 
-**Enterprise controls** — audit logs, SSO, team workspaces, usage governance, for environments where those are not optional.
+**macOS + Linux.** The core architecture is cross-platform; macOS packaging and testing is in progress, Linux follows.
 
-**Context / retrieval layer** — semantic search across a canvas and RAG fallback when connected context overflows the model's window. Deliberately deferred until a real canvas hits that ceiling; the ambient metadata graph covers the common case today.
+**Multi-agent coordination.** Agents aware of each other's work, not just isolated from it: shared task context, merge-ready handoffs, composable workflows without giving up the isolation guarantees.
+
+**Richer node types.** Document, web, image, and diff nodes; @mention-a-node context; canvas-wide semantic search. The node model is meant to grow.
+
+**Context / retrieval layer.** Semantic search across a canvas and RAG fallback when connected context overflows the model's window. Deliberately deferred until a real canvas hits that ceiling; Token Intelligence covers the common case today.
+
+## Cloud & team layer
+
+Tempest is local-first and stays that way. On top of that, we're planning an optional hosted layer for teams and organizations:
+
+- **Sync & handoff** — pick up a canvas on another machine, or hand it to a teammate
+- **Team workspaces** — shared canvases, shared context, shared automations
+- **Enterprise controls** — audit logs, SSO, usage governance, centrally-managed policy
+- **Managed remote agents** — for teams that don't want to run the control plane themselves
+
+The local app remains fully functional without any of this. Cloud is additive.
 
 ## Feature requests welcome
 
-Threads is young and the node model is meant to grow — document, web, image, and diff nodes; @mention-a-node context; richer canvas search. If you want a node type or a canvas capability that isn't here, open an issue. Requests that sharpen the orchestration surface are exactly what we're looking for.
+If you want a node type, an agent integration, or a canvas capability that isn't here, open an issue. Requests that sharpen the orchestration surface are exactly what we're looking for.
 
 ## How this document works
 
-Shipping order changes. This document reflects current priorities, not a fixed timeline. When something ships, it moves out of this file and into the changelog. Star the repo to get notified when that happens.
+Shipping order changes. This document reflects current priorities, not a fixed timeline. When something ships, it moves out of the "Now building" section. Star the repo to get notified when that happens.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,8 @@ Parallel agent sessions are the foundation. Tempest is an engineering platform w
 
 **Desktop notifications.** Long-running agents shouldn't require you to sit and watch them. Native OS notifications for agent completion, approval prompts, and errors — cross-platform.
 
+**Keyboard-native everything.** Several surfaces today still require a mouse — canvas navigation, node selection and creation, workspace switching, and various menus. The goal is that every function in Tempest has a keyboard path, so a mouse is a preference, not a requirement. We plan to get to this soon ourselves, but if it's something you'd enjoy working on, we'd be very glad to have your help — please open an issue and we'll support you through it.
+
 ## On the roadmap
 
 **Mobile apps (iOS + Android).** Built with Expo. Not a mini IDE — a companion surface: check on agents, approve or redirect them mid-run, review diffs, get notified when something needs you. Backed by remote agents (below) so the desktop app can be closed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Policy
+
+Thank you for helping keep Tempest and its users safe.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+Email **[gsvprharsha@tempestai.dev](mailto:gsvprharsha@tempestai.dev)** with:
+
+- A description of the issue and its impact
+- Steps to reproduce (proof-of-concept, minimal test case, or screenshots)
+- The affected version(s) — see below
+- The platform you observed it on (Windows / macOS / Linux)
+- Any suggested remediation, if you have one
+
+If you'd prefer an encrypted channel, mention that in your first email and we'll arrange one.
+
+## What to expect
+
+- **Acknowledgement** within 3 business days
+- **Initial assessment** (severity, affected versions, whether we can reproduce) within 7 business days
+- **Fix or mitigation timeline** shared with you once assessment is done
+- **Public disclosure** coordinated with you — typically after a fix has shipped and users have had a reasonable window to update
+
+We'll credit you in the release notes and this file's acknowledgements section unless you'd rather stay anonymous.
+
+## Scope
+
+In scope:
+
+- The Tempest desktop application (Tauri shell, React frontend, Rust core)
+- The Claude Code bridge (`src-tauri/resources/claude-bridge/`)
+- The Hephaestus isolation layer (Windows Job Objects, macOS `sandbox-exec`, Linux bubblewrap)
+- Database Branches (isolation guarantees, credential handling)
+- Token Intelligence (local knowledge graph — data handling, path traversal, etc.)
+- Automations runtime
+- Build & release artifacts published on GitHub Releases
+
+Out of scope:
+
+- Vulnerabilities in upstream dependencies that have already been reported upstream (please report those directly to the maintainer). We're happy to hear about them, but we can't take credit for fixes we don't own.
+- Issues that require an attacker to already have code execution on the user's machine or physical access, unless they cross an isolation boundary Tempest claims to enforce (e.g. an agent escaping Hephaestus is in scope).
+- Social engineering of users or maintainers.
+- Findings from automated scanners without a demonstrated impact.
+
+## Supported versions
+
+Tempest is pre-1.0 and moves fast. We support the **latest released version** on the `main` branch. Security fixes are shipped in a new patch release; we do not backport to older minor versions.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x (latest) | ✅ |
+| < 0.1.12 | ❌ |
+
+## Safe harbor
+
+We consider security research conducted under this policy to be authorized. We will not pursue legal action against researchers who:
+
+- Make a good-faith effort to avoid privacy violations, data destruction, and service disruption
+- Report the issue promptly and give us a reasonable opportunity to fix it before public disclosure
+- Do not exploit the issue beyond what is necessary to demonstrate it
+
+If in doubt, ask first — email us and we'll work it out.
+
+## Acknowledgements
+
+Researchers who have responsibly disclosed issues will be listed here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tempest",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tempest",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "hasInstallScript": true,
       "workspaces": [
         "web",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempest",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "workspaces": [
     "web",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2339,6 +2339,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2502,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -3049,6 +3077,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3194,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -4281,6 +4347,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +4531,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempest"
 version = "0.1.12"
 dependencies = [
@@ -4465,6 +4561,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "tempest"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "base64 0.22.1",
  "dashmap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ dashmap = "6"
 rusqlite = { version = "0.32", features = ["bundled"] }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-notification = "2"
 # Verifies the signed remote agents manifest (config/agents.json). Already in the
 # tree via tauri-plugin-updater; named here so the verify command can use it.
 minisign-verify = "0.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 [package]
 name = "tempest"
-version = "0.1.12"
+version = "0.1.13"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-maximize",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4051,6 +4051,7 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_notification::init())
         .manage(PtyState(Arc::new(DashMap::new())))
         .manage(ZenState(Mutex::new(std::collections::HashMap::new())))
         .manage(DaemonState(Mutex::new(std::collections::HashMap::new())))

--- a/src-tauri/src/quota/claude.rs
+++ b/src-tauri/src/quota/claude.rs
@@ -215,7 +215,10 @@ fn parse_usage(v: &Value) -> ProviderUsage {
 
 fn window_from(id: &str, label: &str, v: &Value) -> Option<Window> {
     // `utilization` is Anthropic's field name; some scoped rows use `used_pct`.
-    let used = v.get("utilization").or_else(|| v.get("used_pct")).and_then(|x| x.as_f64());
+    // Both come back as 0–100 percentages; our shared shape is 0–1.
+    let used = v.get("utilization").or_else(|| v.get("used_pct"))
+        .and_then(|x| x.as_f64())
+        .map(|p| p / 100.0);
     let resets_at = v.get("resets_at").or_else(|| v.get("reset_at")).and_then(to_epoch_ms);
     // No used and no reset → nothing worth showing.
     if used.is_none() && resets_at.is_none() { return None; }

--- a/src-tauri/src/quota/claude.rs
+++ b/src-tauri/src/quota/claude.rs
@@ -186,10 +186,14 @@ fn parse_usage(v: &Value) -> ProviderUsage {
         if let Some(w) = v.get(key) { if let Some(win) = window_from(key, label, w) { windows.push(win); } }
     }
     // Newer API versions moved the scoped windows under `limits: [...]`.
+    // Skip `session` / `weekly_all` — they duplicate the top-level `five_hour`
+    // and `seven_day` windows we already surface.
     if let Some(limits) = v.get("limits").and_then(|x| x.as_array()) {
         for item in limits {
             let kind = item.get("kind").and_then(|x| x.as_str()).unwrap_or("");
             let name = item.get("name").and_then(|x| x.as_str()).unwrap_or(kind);
+            let n = name.to_ascii_lowercase();
+            if n == "session" || n == "weekly_all" || n == "weekly-all" { continue; }
             let id = format!("limits:{name}");
             if let Some(win) = window_from(&id, &humanize(name), item) { windows.push(win); }
         }

--- a/src-tauri/src/quota/claude.rs
+++ b/src-tauri/src/quota/claude.rs
@@ -20,16 +20,27 @@ const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
 const OAUTH_BETA: &str = "oauth-2025-04-20";
 
+// The CLI writes `~/.claude/.credentials.json` as
+//   { "claudeAiOauth": { accessToken, refreshToken, expiresAt, ... },
+//     "mcpOAuth": { ... } }
+// We own only the `claudeAiOauth` slot; every other top-level key + every
+// unknown key inside it is preserved verbatim across a refresh write so we
+// don't stomp MCP tokens or future fields.
 #[derive(Debug, Deserialize)]
-struct Credentials {
+struct OauthSlot {
     #[serde(rename = "accessToken")]
     access_token: Option<String>,
     #[serde(rename = "refreshToken")]
     refresh_token: Option<String>,
-    // Preserved verbatim across a refresh — the file may carry keys we don't
-    // model (subscription hints, expiry, feature flags) and we mustn't drop them.
     #[serde(flatten)]
     extra: std::collections::BTreeMap<String, Value>,
+}
+
+#[derive(Debug)]
+struct Credentials {
+    oauth: OauthSlot,
+    /// Every top-level key other than `claudeAiOauth`, kept intact on write.
+    other: std::collections::BTreeMap<String, Value>,
 }
 
 pub fn fetch() -> ProviderUsage {
@@ -39,20 +50,20 @@ pub fn fetch() -> ProviderUsage {
         Ok(None) => return ProviderUsage::unavailable(ID, NAME),
         Err(e) => return ProviderUsage::errored(ID, NAME, e),
     };
-    let Some(access) = creds.access_token.clone() else {
+    let Some(access) = creds.oauth.access_token.clone() else {
         return ProviderUsage::unavailable(ID, NAME);
     };
 
     match call_usage(&access) {
         Ok(v) => parse_usage(&v),
         Err(FetchError::Unauthorized) => {
-            let Some(refresh) = creds.refresh_token.clone() else {
+            let Some(refresh) = creds.oauth.refresh_token.clone() else {
                 return ProviderUsage::errored(ID, NAME, "sign in expired — re-run `claude`");
             };
             match refresh_tokens(&refresh) {
                 Ok((new_access, new_refresh)) => {
-                    creds.access_token = Some(new_access.clone());
-                    if let Some(r) = new_refresh { creds.refresh_token = Some(r); }
+                    creds.oauth.access_token = Some(new_access.clone());
+                    if let Some(r) = new_refresh { creds.oauth.refresh_token = Some(r); }
                     // Persist first, then retry: a successful refresh whose
                     // write failed still leaves the *new* token in memory, but
                     // the next Tempest launch would reuse the *stale* one and
@@ -88,19 +99,33 @@ impl std::fmt::Display for FetchError {
 }
 
 fn read_credentials(path: &std::path::Path) -> Result<Option<Credentials>, String> {
-    match std::fs::read_to_string(path) {
-        Ok(s) => serde_json::from_str::<Credentials>(&s).map(Some).map_err(|e| format!("credentials.json unreadable: {e}")),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(format!("credentials.json unreadable: {e}")),
-    }
+    let s = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("credentials.json unreadable: {e}")),
+    };
+    let mut top: std::collections::BTreeMap<String, Value> = serde_json::from_str(&s)
+        .map_err(|e| format!("credentials.json unreadable: {e}"))?;
+    let oauth_val = top.remove("claudeAiOauth").unwrap_or(Value::Null);
+    // Missing/null slot → treated as signed-out, not a parse error. Anything
+    // else that is present but wrong-shaped IS an error worth surfacing.
+    let oauth: OauthSlot = if oauth_val.is_null() {
+        return Ok(None);
+    } else {
+        serde_json::from_value(oauth_val).map_err(|e| format!("credentials.json unreadable: {e}"))?
+    };
+    Ok(Some(Credentials { oauth, other: top }))
 }
 
 fn write_credentials(path: &std::path::Path, c: &Credentials) -> Result<(), String> {
-    let mut map = serde_json::Map::new();
-    if let Some(a) = &c.access_token { map.insert("accessToken".into(), Value::String(a.clone())); }
-    if let Some(r) = &c.refresh_token { map.insert("refreshToken".into(), Value::String(r.clone())); }
-    for (k, v) in &c.extra { map.insert(k.clone(), v.clone()); }
-    let text = serde_json::to_string_pretty(&Value::Object(map)).map_err(|e| e.to_string())?;
+    let mut oauth_map = serde_json::Map::new();
+    if let Some(a) = &c.oauth.access_token { oauth_map.insert("accessToken".into(), Value::String(a.clone())); }
+    if let Some(r) = &c.oauth.refresh_token { oauth_map.insert("refreshToken".into(), Value::String(r.clone())); }
+    for (k, v) in &c.oauth.extra { oauth_map.insert(k.clone(), v.clone()); }
+    let mut top = serde_json::Map::new();
+    for (k, v) in &c.other { top.insert(k.clone(), v.clone()); }
+    top.insert("claudeAiOauth".into(), Value::Object(oauth_map));
+    let text = serde_json::to_string_pretty(&Value::Object(top)).map_err(|e| e.to_string())?;
     // Non-atomic; a torn write here would delete a user's login. Write to a
     // sibling temp file and rename — same pattern as `hooks_write_atomic`.
     let tmp = path.with_extension("json.tmp");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,8 @@
     "createUpdaterArtifacts": true,
     "targets": ["nsis", "msi"],
     "resources": [
-      "resources/atlas/**/*"
+      "resources/atlas/**/*",
+      "icons/128x128.png"
     ],
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tempest",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "com.user.tempest",
   "build": {
     "beforeDevCommand": "npm run dev:frontend",

--- a/src/components/BranchSessionMenu.tsx
+++ b/src/components/BranchSessionMenu.tsx
@@ -58,7 +58,7 @@ export function BranchSessionMenu({
   // Flat list of every row, in render order. Unavailable agents stay in the list
   // (so they render) but are skipped by keyboard navigation.
   const items = useMemo<NavItem[]>(() => {
-    const agentItems: NavItem[] = AGENT_CONFIGS.map((agent) => ({
+    const agentItems: NavItem[] = AGENT_CONFIGS.filter((a) => !a.disabled).map((agent) => ({
       kind: "agent" as const,
       agent,
       available: available[agent.hint] !== false, // true until confirmed absent

--- a/src/components/NewSessionMenu.tsx
+++ b/src/components/NewSessionMenu.tsx
@@ -2,8 +2,27 @@ import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } fr
 import { createPortal } from "react-dom";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAgentAvailability } from "../store/agentAvailability";
-import { TerminalSquare, Globe, Waypoints, Download, ChevronDown, GitBranch, ArrowRight } from "lucide-react";
+import { TerminalSquare, Globe, Waypoints, Download, ChevronDown, GitBranch, ArrowRight, Terminal, Bot, Code2, Command, Cpu, Zap, Sparkles, Package, Rocket, Wrench, Ghost, Play } from "lucide-react";
 import { useAgents, getAgent, getIconDataUrl, remoteIconUrl, type AgentConfig } from "../lib/agentRegistry";
+
+// Curated Lucide icon set for user-added agents. A closed set (not free text)
+// so the picker stays scannable and CSP-safe — no runtime dynamic import into
+// the full ~1400-icon bundle. Reference by `lucide:<name>` in `AgentConfig.icon`.
+const LUCIDE_ICONS: Record<string, React.ComponentType<{ size?: number; className?: string }>> = {
+  terminal: Terminal,
+  bot: Bot,
+  code: Code2,
+  command: Command,
+  cpu: Cpu,
+  zap: Zap,
+  sparkles: Sparkles,
+  package: Package,
+  rocket: Rocket,
+  wrench: Wrench,
+  ghost: Ghost,
+  play: Play,
+};
+export const LUCIDE_ICON_NAMES = Object.keys(LUCIDE_ICONS);
 import type { BranchInfo } from "../types/git";
 import "./NewSessionMenu.css";
 
@@ -16,6 +35,13 @@ export function AgentIcon({ hint, size, className }: { hint?: string; size: numb
   useAgents(); // re-render when an icon finishes downloading (setIconDataUrl notifies)
   const [failedSrc, setFailedSrc] = useState<string>();
   const config = getAgent(hint ?? "");
+  // Lucide icons for user-added agents render inline (no fetch, no data URL).
+  // Checked before the download pipeline so `lucide:*` never looks like a bare
+  // filename to `remoteIconUrl`.
+  if (config?.icon?.startsWith("lucide:")) {
+    const Comp = LUCIDE_ICONS[config.icon.slice("lucide:".length)];
+    if (Comp) return <Comp size={size} className={className} />;
+  }
   // Prefer a cached (downloaded) icon, then a bundled asset, then the repo URL.
   const src = config
     ? (getIconDataUrl(config.id) ?? (config.iconSrc || remoteIconUrl(config.icon)))
@@ -111,11 +137,17 @@ export function NewSessionMenu({
 
   // Terminal first, then the agent registry — one flat list, no submenu.
   const rows = useMemo<Row[]>(() => {
-    const agentRows: Row[] = agents.map((agent) => ({
-      kind: "agent" as const,
-      agent,
-      available: available[agent.hint] !== false, // true until confirmed absent
-    }));
+    const agentRows: Row[] = agents
+      // Disabled entries (user hid them in Settings → Agents) don't belong in
+      // the launcher; existing sessions bound to them keep working. A custom
+      // entry mid-edit with no command yet is also skipped — there's nothing
+      // to spawn until the user fills it in.
+      .filter((agent) => !agent.disabled && !!agent.hint)
+      .map((agent) => ({
+        kind: "agent" as const,
+        agent,
+        available: available[agent.hint] !== false, // true until confirmed absent
+      }));
     return [{ kind: "terminal" }, ...agentRows];
   }, [agents, available]);
 

--- a/src/components/QuotaIsland.css
+++ b/src/components/QuotaIsland.css
@@ -21,6 +21,7 @@
   border: 1px solid transparent;
   border-radius: 10px;
   color: var(--tempest-fg-subtle);
+  font-family: inherit;
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
@@ -76,6 +77,7 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
   color: var(--tempest-fg-default);
   z-index: 200;
+  font-family: inherit;
   font-size: 11px;
   display: flex;
   flex-direction: column;

--- a/src/components/QuotaIsland.css
+++ b/src/components/QuotaIsland.css
@@ -67,46 +67,67 @@
 
 .quota-panel {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + 8px);
   right: 0;
-  width: 300px;
-  padding: 8px;
+  width: 340px;
+  padding: 16px;
   background: var(--tempest-bg-elevated, var(--tempest-bg-base));
   border: 1px solid var(--tempest-border-subtle);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28), 0 2px 6px rgba(0, 0, 0, 0.12);
   color: var(--tempest-fg-default);
   z-index: 200;
   font-family: inherit;
-  font-size: 11px;
+  font-size: 13px;
+  line-height: 1.4;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 14px;
 }
 
 .quota-panel-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--tempest-fg-subtle);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--tempest-fg-default);
 }
 
 .quota-refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   background: transparent;
-  border: none;
+  border: 1px solid var(--tempest-border-subtle);
   color: var(--tempest-fg-subtle);
   font: inherit;
+  font-size: 11px;
+  font-weight: 500;
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
 }
 
-.quota-refresh:hover {
+.quota-refresh:hover:not(:disabled) {
   background: var(--tempest-bg-hover);
   color: var(--tempest-fg-default);
+  border-color: var(--tempest-border-default, var(--tempest-border-subtle));
+}
+
+.quota-refresh:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.quota-refresh-spin {
+  animation: quota-refresh-spin 0.8s linear infinite;
+}
+
+@keyframes quota-refresh-spin {
+  to { transform: rotate(360deg); }
 }
 
 /* ─── Rows ─────────────────────────────────────────────────────────────────── */
@@ -114,8 +135,8 @@
 .quota-row {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 6px 4px;
+  gap: 10px;
+  padding-top: 14px;
   border-top: 1px solid var(--tempest-border-subtle);
 }
 
@@ -128,32 +149,38 @@
 
 .quota-row-head {
   display: flex;
-  align-items: baseline;
-  gap: 6px;
+  align-items: center;
+  gap: 8px;
 }
 
 .quota-row-name {
   font-weight: 600;
+  font-size: 13px;
   color: var(--tempest-fg-default);
+  letter-spacing: -0.01em;
 }
 
 .quota-row-plan {
   color: var(--tempest-fg-subtle);
-  font-size: 10px;
-  text-transform: lowercase;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--tempest-bg-hover);
 }
 
 .quota-chip {
   margin-left: auto;
-  font-size: 9px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 7px;
+  border-radius: 4px;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .quota-chip--unavailable {
-  background: var(--tempest-border-subtle);
+  background: var(--tempest-bg-hover);
   color: var(--tempest-fg-subtle);
 }
 
@@ -163,7 +190,7 @@
 }
 
 .quota-row-err {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--tempest-accent-red, #ef4444);
 }
 
@@ -172,57 +199,65 @@
 .quota-bar-wrap {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 6px;
 }
 
 .quota-bar-line {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  gap: 6px;
+  align-items: center;
+  gap: 8px;
 }
 
 .quota-bar-label {
   color: var(--tempest-fg-default);
+  font-size: 12px;
 }
 
 .quota-bar-meta {
   display: flex;
-  gap: 6px;
+  align-items: center;
+  gap: 8px;
   color: var(--tempest-fg-subtle);
-  font-size: 10px;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
 }
 
-.quota-bar-pct--ok     { color: var(--tempest-accent-green, #22c55e); }
+.quota-bar-pct {
+  font-weight: 500;
+}
+
+.quota-bar-pct--ok     { color: var(--tempest-fg-default); }
 .quota-bar-pct--warn   { color: var(--tempest-accent-orange, #f59e0b); }
 .quota-bar-pct--crit   { color: var(--tempest-accent-red, #ef4444); }
 
 .quota-bar-track {
-  height: 3px;
-  background: var(--tempest-border-subtle);
-  border-radius: 2px;
+  height: 6px;
+  background: var(--tempest-bg-hover);
+  border-radius: 999px;
   overflow: hidden;
 }
 
 .quota-bar-fill {
   height: 100%;
+  border-radius: 999px;
   transition: width 200ms ease;
 }
 
-.quota-bar-fill--ok     { background: var(--tempest-accent-green, #22c55e); }
+.quota-bar-fill--ok     { background: var(--tempest-fg-default); opacity: 0.85; }
 .quota-bar-fill--warn   { background: var(--tempest-accent-orange, #f59e0b); }
 .quota-bar-fill--crit   { background: var(--tempest-accent-red, #ef4444); }
 
 .quota-row-detail {
   display: flex;
   justify-content: space-between;
-  gap: 6px;
+  gap: 8px;
   color: var(--tempest-fg-subtle);
-  font-size: 10px;
+  font-size: 11px;
 }
 
 .quota-row-detail > span:last-child {
   color: var(--tempest-fg-default);
   text-align: right;
+  font-variant-numeric: tabular-nums;
 }

--- a/src/components/QuotaIsland.tsx
+++ b/src/components/QuotaIsland.tsx
@@ -5,6 +5,7 @@
 // user always sees the full picture without leaving the title bar.
 
 import { useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
 import {
   CRIT, WARN, formatReset, levelOf, peakQuota, pct,
   windowsFromProviders,
@@ -18,6 +19,12 @@ export function QuotaIsland() {
   useEffect(() => { startQuotaPolling(); }, []);
 
   const [hover, setHover] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  async function doRefresh() {
+    if (refreshing) return;
+    setRefreshing(true);
+    try { await refreshQuotas(); } finally { setRefreshing(false); }
+  }
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Debounced close so the pointer can bridge the ~4px gap between the pill and
   // the popup without collapsing it (same trick the notification island uses).
@@ -48,7 +55,7 @@ export function QuotaIsland() {
         type="button"
         className={`quota-island quota-island--${level ?? "idle"}${expanded ? " quota-island--open" : ""}`}
         aria-label="Agent quota"
-        onClick={() => { setHover((v) => !v); void refreshQuotas(); }}
+        onClick={() => { setHover((v) => !v); void doRefresh(); }}
       >
         <span className={`quota-dot quota-dot--${level ?? "idle"}`} />
         {expanded && peak && (
@@ -64,8 +71,9 @@ export function QuotaIsland() {
              onMouseLeave={scheduleClose}>
           <div className="quota-panel-head">
             <span>Agent quotas</span>
-            <button className="quota-refresh" onClick={() => void refreshQuotas()} type="button">
-              Refresh
+            <button className="quota-refresh" onClick={() => void doRefresh()} type="button" disabled={refreshing}>
+              {refreshing && <Loader2 size={11} className="quota-refresh-spin" />}
+              {refreshing ? "Refreshing" : "Refresh"}
             </button>
           </div>
           {providers.map((p) => <ProviderRow key={p.providerId} p={p} />)}

--- a/src/components/SettingsPanel.css
+++ b/src/components/SettingsPanel.css
@@ -1415,3 +1415,51 @@
   color: var(--tempest-accent-yellow, #d29922);
   margin: 6px 0 0;
 }
+
+.sp-agent-custom {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 8px;
+  background: var(--tempest-bg-subtle, transparent);
+}
+.sp-agent-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.sp-agent-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+  gap: 6px;
+  margin-top: 4px;
+  margin-bottom: 10px;
+}
+.sp-agent-icon-swatch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: 1px solid var(--tempest-border-default);
+  background: transparent;
+  color: var(--tempest-fg-default);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+.sp-agent-icon-swatch:hover { border-color: var(--tempest-border-subtle); }
+.sp-agent-icon-swatch--on {
+  border-color: var(--tempest-accent, #6366f1);
+  background: color-mix(in oklab, var(--tempest-accent, #6366f1) 15%, transparent);
+}
+.sp-agent-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  cursor: pointer;
+}

--- a/src/components/SettingsPanel/AgentsSection.tsx
+++ b/src/components/SettingsPanel/AgentsSection.tsx
@@ -1,35 +1,86 @@
-import { useState } from "react";
-import { ChevronRight, ChevronDown } from "lucide-react";
-import { useAgents } from "../../lib/agentRegistry";
+import { useMemo, useState } from "react";
+import { ChevronRight, ChevronDown, Trash2, Copy, Plus } from "lucide-react";
+import { useAgents, getCustomAgents, setCustomAgents } from "../../lib/agentRegistry";
+import type { AgentConfig } from "../../lib/agentManifest";
 import { getAgentConfig, setAgentConfig } from "../../lib/runtimeState";
 import {
   parseArgs, argsToText, parseEnv, envToText,
 } from "../../lib/agentConfig";
+import { LUCIDE_ICON_NAMES, AgentIcon } from "../NewSessionMenu";
+import { Terminal, Bot, Code2, Command as CommandIcon, Cpu, Zap, Sparkles, Package, Rocket, Wrench, Ghost, Play } from "lucide-react";
 
-// Settings → Agents. Per-agent-type launch defaults, applied globally to every
-// session of that type. See src/lib/agentConfig.ts for the model and precedence.
+// Local copy of the picker's icon map. Kept in sync with LUCIDE_ICON_NAMES
+// (the single source of truth for which icon slugs are legal). Duplicated
+// here so the picker can render an icon by slug directly, without going
+// through AgentIcon (which needs a live agent hint to resolve).
+const LUCIDE_ICON_LOOKUP: Record<string, React.ComponentType<{ size?: number }>> = {
+  terminal: Terminal, bot: Bot, code: Code2, command: CommandIcon, cpu: Cpu,
+  zap: Zap, sparkles: Sparkles, package: Package, rocket: Rocket, wrench: Wrench,
+  ghost: Ghost, play: Play,
+};
+
+// Settings → Agents. Two responsibilities:
+//   1. Per-agent-type LAUNCH DEFAULTS (args/env/subdir) applied globally — kept
+//      for both built-in and custom entries. See src/lib/agentConfig.ts for the
+//      merge model and precedence.
+//   2. USER-ADDED AGENTS: full add/edit/clone/delete + a disable toggle for
+//      hiding an agent from the launcher without deleting it. Custom entries
+//      live in runtimeState.customAgents; built-ins can only be disabled.
+
+// Reserve one id per open Add form. Not a user-facing string — it just keeps
+// the freshly-created row addressable for the auto-expand + name input focus.
+function nextCustomId(existing: readonly AgentConfig[]): string {
+  const taken = new Set(existing.map((a) => a.id));
+  for (let n = 1; ; n++) {
+    const id = `custom-${n}`;
+    if (!taken.has(id)) return id;
+  }
+}
+
+/// The command field reaches Rust as a bare token (or a couple of them, e.g.
+/// `gh copilot`). Reject spaces-as-arguments / shell metacharacters — a stray
+/// `|` or `;` here would be executed by whatever spawns the PTY.
+const CMD_RE = /^[A-Za-z0-9_.-]+( [A-Za-z0-9_.-]+)*$/;
+
 export function AgentsSection() {
   const agents = useAgents();
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
+  function addCustom() {
+    const id = nextCustomId(agents);
+    const next = [
+      ...getCustomAgents(),
+      { id, name: "New agent", hint: "", custom: true, icon: "lucide:terminal" },
+    ];
+    setCustomAgents(next);
+    setExpandedId(id);
+  }
+
   return (
     <div className="sp-section">
-      <div className="sp-section-heading">Agents</div>
+      <div className="sp-section-heading">
+        Agents
+        <button
+          className="sp-btn"
+          style={{ float: "right", display: "inline-flex", alignItems: "center", gap: 6 }}
+          onClick={addCustom}
+        >
+          <Plus size={13} /> Add agent
+        </button>
+      </div>
       <p className="sp-section-desc">
-        Defaults applied every time you launch an agent of this type, in every project.
-        Flags are appended to the command, environment variables are injected into the
-        session, and the working subdirectory is entered relative to the worktree.
-        A project's <code>tempest.yml</code> overrides these per repository.
+        Launch defaults for every session of an agent type. Custom agents you add here
+        appear in the launcher alongside the built-ins. Placeholders you can use in flags:
+        {" "}<code>{"{UUID}"}</code>, <code>{"{MODEL}"}</code>, <code>{"{WORKSPACE_NAME}"}</code>,
+        {" "}<code>{"{WORKSPACE_SLUG}"}</code>, <code>{"{WORKSPACE_PATH}"}</code>,
+        {" "}<code>{"{WORKSPACE_ID}"}</code>.
       </p>
 
       <div className="sp-agents-list">
         {agents.map((a) => (
           <AgentRow
             key={a.id}
-            id={a.id}
-            name={a.name}
-            iconSrc={a.iconSrc}
-            mono={a.mono}
+            agent={a}
             open={expandedId === a.id}
             onToggle={() => setExpandedId(expandedId === a.id ? null : a.id)}
           />
@@ -40,23 +91,24 @@ export function AgentsSection() {
 }
 
 function AgentRow({
-  id, name, iconSrc, mono, open, onToggle,
+  agent, open, onToggle,
 }: {
-  id: string; name: string; iconSrc: string; mono?: boolean;
-  open: boolean; onToggle: () => void;
+  agent: AgentConfig;
+  open: boolean;
+  onToggle: () => void;
 }) {
-  const cfg = getAgentConfig(id);
+  // Per-agent launch defaults (args/env/subdir) — applies to both built-in and
+  // custom agents.
+  const cfg = getAgentConfig(agent.id);
   const [argsText, setArgsText] = useState(() => argsToText(cfg.args));
   const [envText, setEnvText]   = useState(() => envToText(cfg.env));
   const [subdir, setSubdir]     = useState(() => cfg.subdir);
   const [envWarnings, setEnvWarnings] = useState<string[]>([]);
 
-  // Coarse writes on blur, not per keystroke — the textareas are free text, so
-  // committing on every character would churn the runtime blob to disk.
-  function commit() {
+  function commitDefaults() {
     const { env, warnings } = parseEnv(envText);
     setEnvWarnings(warnings);
-    setAgentConfig(id, { args: parseArgs(argsText), env, subdir: subdir.trim() });
+    setAgentConfig(agent.id, { args: parseArgs(argsText), env, subdir: subdir.trim() });
   }
 
   const configured = cfg.args.length > 0 || Object.keys(cfg.env).length > 0 || !!cfg.subdir;
@@ -65,25 +117,21 @@ function AgentRow({
     <div className={`sp-agent-row${open ? " sp-agent-row--open" : ""}`}>
       <button className="sp-agent-head" onClick={onToggle}>
         {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-        {iconSrc && (
-          <img
-            src={iconSrc}
-            alt=""
-            width={16}
-            height={16}
-            className={mono ? "sp-agent-logo-invert" : ""}
-            style={{ objectFit: "contain", flexShrink: 0 }}
-            onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
-          />
-        )}
-        <span className="sp-agent-name">{name}</span>
+        <AgentIcon hint={agent.hint} size={16} />
+        <span className="sp-agent-name">{agent.name}</span>
+        {agent.custom && <span className="sp-agent-badge">custom</span>}
+        {agent.disabled && <span className="sp-agent-badge">disabled</span>}
         {configured && !open && <span className="sp-agent-badge">configured</span>}
       </button>
 
       {open && (
         <div className="sp-agent-body">
+          {agent.custom && <CustomAgentEditor agent={agent} />}
+
+          <DisableToggle agent={agent} />
+
           <label className="sp-agent-label">
-            Flags <span className="sp-agent-hint">one per line</span>
+            Extra flags <span className="sp-agent-hint">one per line, appended to every launch</span>
           </label>
           <textarea
             className="sp-agent-textarea"
@@ -92,7 +140,7 @@ function AgentRow({
             placeholder={"--verbose\n--permission-mode=plan"}
             spellCheck={false}
             onChange={(e) => setArgsText(e.target.value)}
-            onBlur={commit}
+            onBlur={commitDefaults}
             onKeyDown={(e) => e.stopPropagation()}
           />
 
@@ -106,7 +154,7 @@ function AgentRow({
             placeholder={"ANTHROPIC_BASE_URL=https://gateway.corp.internal"}
             spellCheck={false}
             onChange={(e) => setEnvText(e.target.value)}
-            onBlur={commit}
+            onBlur={commitDefaults}
             onKeyDown={(e) => e.stopPropagation()}
           />
           {envWarnings.map((w, i) => (
@@ -122,10 +170,234 @@ function AgentRow({
             placeholder="packages/api"
             spellCheck={false}
             onChange={(e) => setSubdir(e.target.value)}
-            onBlur={commit}
+            onBlur={commitDefaults}
+            onKeyDown={(e) => e.stopPropagation()}
+          />
+
+          <RowActions agent={agent} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/// Custom-agent editor. Only rendered when `agent.custom` — every field here
+/// mutates the persisted `customAgents` blob. Debounce isn't needed: writes
+/// go through `setCustomAgents` on blur / toggle, not per keystroke.
+function CustomAgentEditor({ agent }: { agent: AgentConfig }) {
+  const [name, setName] = useState(agent.name);
+  const [hint, setHint] = useState(agent.hint);
+  const [icon, setIcon] = useState(agent.icon ?? "lucide:terminal");
+  const [autoApprove, setAutoApprove] = useState(() => (agent.autoApproveArgs ?? []).join("\n"));
+  const [resumeArgs, setResumeArgs] = useState(() => (agent.resumeArgs ?? []).join("\n"));
+  const [sessionArgs, setSessionArgs] = useState(() => (agent.sessionIdArgs ?? []).join("\n"));
+  const [modelArgs, setModelArgs] = useState(() => (agent.modelArgs ?? []).join("\n"));
+  const [downloadUrl, setDownloadUrl] = useState(agent.downloadUrl ?? "");
+  const [hintErr, setHintErr] = useState<string | null>(null);
+
+  function persist(patch: Partial<AgentConfig>) {
+    const list = getCustomAgents().map((a) =>
+      a.id === agent.id ? { ...a, ...patch } : a,
+    );
+    setCustomAgents(list);
+  }
+
+  function commitHint() {
+    const v = hint.trim();
+    if (v && !CMD_RE.test(v)) { setHintErr("Command must be a bare binary name (letters, digits, . _ -)"); return; }
+    setHintErr(null);
+    persist({ hint: v });
+  }
+
+  function toArgList(text: string): string[] {
+    return text.split("\n").map((l) => l.trim()).filter(Boolean);
+  }
+
+  return (
+    <div className="sp-agent-custom">
+      <div className="sp-agent-grid">
+        <div>
+          <label className="sp-agent-label">Display name</label>
+          <input
+            className="sp-agent-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={() => persist({ name: name.trim() || agent.id })}
             onKeyDown={(e) => e.stopPropagation()}
           />
         </div>
+        <div>
+          <label className="sp-agent-label">Command <span className="sp-agent-hint">binary on PATH</span></label>
+          <input
+            className="sp-agent-input"
+            value={hint}
+            placeholder="my-agent"
+            onChange={(e) => setHint(e.target.value)}
+            onBlur={commitHint}
+            onKeyDown={(e) => e.stopPropagation()}
+          />
+          {hintErr && <p className="sp-agent-warn">{hintErr}</p>}
+        </div>
+      </div>
+
+      <label className="sp-agent-label">Icon</label>
+      <IconPicker value={icon} onChange={(v) => { setIcon(v); persist({ icon: v }); }} />
+
+      <label className="sp-agent-label">
+        Session-start args <span className="sp-agent-hint">first launch; supports {"{UUID}"}</span>
+      </label>
+      <textarea
+        className="sp-agent-textarea" rows={2} value={sessionArgs}
+        placeholder={"--session-id\n{UUID}"}
+        spellCheck={false}
+        onChange={(e) => setSessionArgs(e.target.value)}
+        onBlur={() => persist({ sessionIdArgs: toArgList(sessionArgs) })}
+        onKeyDown={(e) => e.stopPropagation()}
+      />
+
+      <label className="sp-agent-label">
+        Resume args <span className="sp-agent-hint">reopens a saved session; supports {"{UUID}"}</span>
+      </label>
+      <textarea
+        className="sp-agent-textarea" rows={2} value={resumeArgs}
+        placeholder={"--resume\n{UUID}"}
+        spellCheck={false}
+        onChange={(e) => setResumeArgs(e.target.value)}
+        onBlur={() => persist({ resumeArgs: toArgList(resumeArgs) })}
+        onKeyDown={(e) => e.stopPropagation()}
+      />
+
+      <label className="sp-agent-label">
+        Model args <span className="sp-agent-hint">optional; supports {"{MODEL}"}</span>
+      </label>
+      <textarea
+        className="sp-agent-textarea" rows={2} value={modelArgs}
+        placeholder={"--model\n{MODEL}"}
+        spellCheck={false}
+        onChange={(e) => setModelArgs(e.target.value)}
+        onBlur={() => persist({ modelArgs: toArgList(modelArgs) })}
+        onKeyDown={(e) => e.stopPropagation()}
+      />
+
+      <label className="sp-agent-label">
+        Auto-approve args <span className="sp-agent-hint">only applied when the global Auto setting is on</span>
+      </label>
+      <textarea
+        className="sp-agent-textarea" rows={2} value={autoApprove}
+        placeholder={"--dangerously-skip-permissions"}
+        spellCheck={false}
+        onChange={(e) => setAutoApprove(e.target.value)}
+        onBlur={() => persist({ autoApproveArgs: toArgList(autoApprove) })}
+        onKeyDown={(e) => e.stopPropagation()}
+      />
+
+      <label className="sp-agent-label">
+        Download URL <span className="sp-agent-hint">shown when the command isn't on PATH</span>
+      </label>
+      <input
+        className="sp-agent-input"
+        value={downloadUrl}
+        placeholder="https://example.com/install"
+        onChange={(e) => setDownloadUrl(e.target.value)}
+        onBlur={() => persist({ downloadUrl: /^https:\/\//i.test(downloadUrl.trim()) ? downloadUrl.trim() : undefined })}
+        onKeyDown={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}
+
+function IconPicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const options = useMemo(() => LUCIDE_ICON_NAMES.map((n) => `lucide:${n}`), []);
+  return (
+    <div className="sp-agent-icon-grid">
+      {options.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          className={`sp-agent-icon-swatch${value === opt ? " sp-agent-icon-swatch--on" : ""}`}
+          onClick={() => onChange(opt)}
+          title={opt.slice("lucide:".length)}
+        >
+          {(() => {
+            const key = opt.slice("lucide:".length);
+            const Comp = LUCIDE_ICON_LOOKUP[key];
+            return Comp ? <Comp size={16} /> : <span style={{ fontSize: 10 }}>{key}</span>;
+          })()}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function DisableToggle({ agent }: { agent: AgentConfig }) {
+  const disabled = !!agent.disabled;
+  function toggle() {
+    if (agent.custom) {
+      const list = getCustomAgents().map((a) =>
+        a.id === agent.id ? { ...a, disabled: !disabled } : a,
+      );
+      setCustomAgents(list);
+      return;
+    }
+    // Built-ins aren't in customAgents yet; disabling one adds a minimal patch
+    // that inherits every other field from the bundled entry via the merge.
+    const list = getCustomAgents();
+    const idx = list.findIndex((a) => a.id === agent.id);
+    if (idx >= 0) list[idx] = { ...list[idx], disabled: !disabled };
+    else list.push({ id: agent.id, name: agent.name, hint: agent.hint, disabled: !disabled });
+    setCustomAgents([...list]);
+  }
+  return (
+    <div className="sp-agent-toggle-row" onClick={toggle}>
+      <span className="sp-agent-label" style={{ margin: 0 }}>Hide from launcher</span>
+      <button
+        className={`sp-toggle${disabled ? " sp-toggle--on" : ""}`}
+        role="switch"
+        aria-checked={disabled}
+        onClick={(e) => { e.stopPropagation(); toggle(); }}
+      >
+        <span className="sp-toggle-thumb" />
+      </button>
+    </div>
+  );
+}
+
+function RowActions({ agent }: { agent: AgentConfig }) {
+  function clone() {
+    const base = agent.name.replace(/-copy(\s\d+)?$/, "");
+    const existing = getCustomAgents();
+    let n = 2;
+    while (existing.some((a) => a.id === `${agent.id}-${n}`)) n++;
+    const copy: AgentConfig = {
+      ...agent,
+      id: `${agent.id}-${n}`,
+      name: `${base} copy`,
+      custom: true,
+      extends: agent.id,
+    };
+    // Strip fields the sanitizer doesn't accept from cloned entries (resolved
+    // iconSrc, compiled RegExps): only the serializable shape survives.
+    delete (copy as Partial<AgentConfig>).iconSrc;
+    delete (copy as Partial<AgentConfig>).capturePattern;
+    setCustomAgents([...existing, copy]);
+  }
+  function remove() {
+    if (!agent.custom) return;
+    setCustomAgents(getCustomAgents().filter((a) => a.id !== agent.id));
+  }
+  return (
+    <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+      <button className="sp-btn" onClick={clone}>
+        <Copy size={12} /> Clone
+      </button>
+      {agent.custom && (
+        <button
+          className="sp-btn"
+          style={{ color: "var(--tempest-danger, #ef4444)" }}
+          onClick={remove}
+        >
+          <Trash2 size={12} /> Delete
+        </button>
       )}
     </div>
   );

--- a/src/components/SettingsPanel/SecuritySection.tsx
+++ b/src/components/SettingsPanel/SecuritySection.tsx
@@ -75,6 +75,24 @@ export function SecuritySection() {
           </button>
         </div>
 
+        <div className="sp-toggle-row" onClick={() => updateSetting("desktopNotifications", !s.desktopNotifications)}>
+          <div className="sp-toggle-text">
+            <span className="sp-toggle-label">Desktop notifications</span>
+            <span className="sp-toggle-desc">
+              Send an OS notification when an agent finishes or asks for permission
+              while the Tempest window is unfocused. Suppressed while Tempest has focus.
+            </span>
+          </div>
+          <button
+            className={`sp-toggle${s.desktopNotifications ? " sp-toggle--on" : ""}`}
+            onClick={(e) => { e.stopPropagation(); updateSetting("desktopNotifications", !s.desktopNotifications); }}
+            role="switch"
+            aria-checked={s.desktopNotifications}
+          >
+            <span className="sp-toggle-thumb" />
+          </button>
+        </div>
+
         <div className="sp-toggle-row" onClick={() => setTelemetryEnabled(!s.telemetryEnabled)}>
           <div className="sp-toggle-text">
             <span className="sp-toggle-label">Share anonymous usage data</span>

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -23,7 +23,7 @@
   gap: 2px;
   padding-right: 6px;
   -webkit-app-region: no-drag;
-  z-index: 1;
+  z-index: 9999;
   flex-shrink: 0;
 }
 

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -820,7 +820,9 @@ export function WorkspaceView({ zen, name, path }: Props) {
       // Assemble the agent's full argument list (session/resume flags + prompt) here in
       // TypeScript so Rust receives a ready-to-run command. originalId is present only
       // when resuming an existing conversation.
-      const args = agent ? buildAgentArgs(agent, sessionId, originalId, prompt, model) : null;
+      const args = agent
+        ? buildAgentArgs(agent, sessionId, originalId, prompt, model, { sessionName, cwd })
+        : null;
 
       const config = agent ? AGENT_CONFIGS.find((a) => a.hint === agent) : null;
       // Per-agent launch defaults (global, set in Settings → Agents). Only agent

--- a/src/components/threads/nodes/SessionNode.tsx
+++ b/src/components/threads/nodes/SessionNode.tsx
@@ -180,7 +180,7 @@ function SessionNode({ id, data, isAgent }: { id: string; data?: { collapsed?: b
               {picker}
               <div style={{ marginBottom: 6 }}>Launch an agent:</div>
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))", gap: 6 }}>
-                {AGENT_CONFIGS.map((a) => (
+                {AGENT_CONFIGS.filter((a) => !a.disabled).map((a) => (
                   <button
                     key={a.id}
                     onClick={() => launch(a.hint)}

--- a/src/lib/agentArgs.ts
+++ b/src/lib/agentArgs.ts
@@ -6,8 +6,61 @@ import { getAgentConfig } from "./runtimeState";
 // bundled and remote agent runs through here — the only per-agent knowledge is
 // the flag templates in the registry entry, not code.
 //
-// Placeholders substituted per flag group: "{UUID}" (session/conversation id) and
-// "{MODEL}" (chosen model). The prompt is appended last as a positional arg.
+// Placeholders substituted in EVERY arg group (session, resume, model, capture,
+// autoApprove, user args): "{UUID}", "{MODEL}", "{WORKSPACE_ID/NAME/SLUG/PATH}",
+// "{BRANCH}", "{PORT}". Unknown placeholders pass through unchanged so a stray
+// `{foo}` doesn't get mangled into empty. Case-insensitive keys — `{uuid}` and
+// `{UUID}` both work — so user-authored args in the settings UI aren't sensitive
+// to the exact spelling shown in placeholder chips.
+//
+// Custom, user-added agents rely on these placeholders to parameterize wrappers
+// (e.g. `docker exec -w /work/{WORKSPACE_SLUG} ...`); the built-in agents only
+// use {UUID}/{MODEL}, but there's no harm in the wider expansion running on
+// their templates too — a template that doesn't reference a key is unaffected.
+
+/// Slugify a workspace/session name into a safe token for paths, branches, and
+/// display: lowercase alphanumerics + dashes, no leading/trailing/repeat dashes.
+/// Empty input → "workspace" so a template never expands to nothing.
+function slugify(s: string): string {
+  const t = s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return t || "workspace";
+}
+
+export interface AgentArgContext {
+  sessionName?: string;
+  cwd?: string;
+  branch?: string;
+  port?: number;
+}
+
+function expand(arg: string, vars: Record<string, string>): string {
+  return arg.replace(/\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (m, k) => {
+    const v = vars[k] ?? vars[k.toLowerCase()] ?? vars[k.toUpperCase()];
+    return v ?? m;
+  });
+}
+
+function buildVars(
+  sessionId: string,
+  conversationId: string | undefined,
+  model: string | undefined,
+  ctx: AgentArgContext | undefined,
+): Record<string, string> {
+  const v: Record<string, string> = {
+    UUID: conversationId ?? sessionId,
+  };
+  if (model) v.MODEL = model;
+  const name = ctx?.sessionName;
+  if (name) {
+    v.WORKSPACE_NAME = name;
+    v.WORKSPACE_SLUG = slugify(name);
+  }
+  if (sessionId) v.WORKSPACE_ID = sessionId;
+  if (ctx?.cwd) v.WORKSPACE_PATH = ctx.cwd;
+  if (ctx?.branch) v.BRANCH = ctx.branch;
+  if (ctx?.port !== undefined) v.PORT = String(ctx.port);
+  return v;
+}
 
 export function buildAgentArgs(
   agent: string,
@@ -15,44 +68,41 @@ export function buildAgentArgs(
   conversationId?: string,
   prompt?: string,
   model?: string,
+  ctx?: AgentArgContext,
 ): string[] {
   const config = getAgent(agent);
   const args: string[] = [];
+  // The {UUID} slot depends on which resume mode fires — keep the id-scoped
+  // vars local so each block sees the right one.
+  const baseVars = buildVars(sessionId, conversationId, model, ctx);
 
-  // Model flag is structured (modelArgs), so a new agent declares its own spelling
-  // in the manifest rather than being added to a hardcoded list here.
   if (model && config?.modelArgs) {
-    for (const arg of config.modelArgs) args.push(arg.replace("{MODEL}", model));
+    for (const arg of config.modelArgs) args.push(expand(arg, baseVars));
   }
 
   if (config && conversationId && config.resumeArgs) {
-    for (const arg of config.resumeArgs) {
-      args.push(arg.replace("{UUID}", conversationId));
-    }
+    const vars = { ...baseVars, UUID: conversationId };
+    for (const arg of config.resumeArgs) args.push(expand(arg, vars));
   } else if (config && conversationId && config.captureResumeArgs) {
-    for (const arg of config.captureResumeArgs) {
-      args.push(arg.replace("{UUID}", conversationId));
-    }
+    const vars = { ...baseVars, UUID: conversationId };
+    for (const arg of config.captureResumeArgs) args.push(expand(arg, vars));
   } else if (config && !conversationId && config.sessionIdArgs) {
-    for (const arg of config.sessionIdArgs) {
-      args.push(arg.replace("{UUID}", sessionId));
-    }
+    const vars = { ...baseVars, UUID: sessionId };
+    for (const arg of config.sessionIdArgs) args.push(expand(arg, vars));
   }
 
   // Auto-approve flags are applied ONLY when the user's local Auto setting is on.
   // The manifest supplies the flag syntax; this gate supplies the consent — a
   // manifest can never force Auto mode on.
   if (config?.autoApproveArgs && getSettings().autoApprove) {
-    for (const arg of config.autoApproveArgs) {
-      args.push(arg);
-    }
+    for (const arg of config.autoApproveArgs) args.push(expand(arg, baseVars));
   }
 
   // User-configured per-agent flags (global, applied to every launch of this
   // agent type). Appended after the structured flags, before the positional
   // prompt. Keyed by stable id so it survives an agent's CLI command changing.
   if (config) {
-    for (const arg of getAgentConfig(config.id).args) args.push(arg);
+    for (const arg of getAgentConfig(config.id).args) args.push(expand(arg, baseVars));
   }
 
   if (prompt) args.push(prompt);

--- a/src/lib/agentManifest.ts
+++ b/src/lib/agentManifest.ts
@@ -49,6 +49,15 @@ export interface AgentConfig {
   autoApproveArgs?: string[];
   // URL to download/install the agent when it isn't on PATH.
   downloadUrl?: string;
+  // User-added local agent (Settings → Agents → Add). Bundled + signed-remote
+  // entries have this false/absent. Only custom entries are removable from
+  // the UI and only their fields are freely editable.
+  custom?: boolean;
+  // User toggle: hide from launchers and pickers without deleting. Absent = shown.
+  disabled?: boolean;
+  // Informational: id of the agent this one was cloned from. No behavior; just
+  // shown in the settings header so the lineage is visible.
+  extends?: string;
 }
 
 /// A validated manifest entry. It PATCHES an agent of the same id (so an override
@@ -133,6 +142,59 @@ function sanitizeEntry(a: unknown): RemotePatch | null {
 export function sanitizeManifestAgents(list: unknown): RemotePatch[] {
   if (!Array.isArray(list)) return [];
   return list.map(sanitizeEntry).filter((a): a is RemotePatch => a !== null);
+}
+
+// Icons for user-added agents may also be a "lucide:name" reference — a bundled
+// icon-set key that AgentIcon renders as an inline SVG. Keeps user icons offline
+// and CSP-clean without any download step. Never accepted from the signed
+// manifest so remote entries always resolve through the standard icon pipeline.
+const iconRefLocal = (v: unknown): string | undefined => {
+  if (typeof v !== "string") return undefined;
+  if (/^lucide:[a-z0-9-]+$/i.test(v)) return v;
+  return iconRef(v);
+};
+
+/// Sanitize a single user-added agent. Same validation as the signed manifest,
+/// with two extras: `lucide:*` icon refs are allowed, and the `custom: true`
+/// marker is always stamped on so the merge path can tell local entries apart
+/// from bundled/remote ones.
+export function sanitizeCustomAgent(a: unknown): RemotePatch | null {
+  if (!a || typeof a !== "object") return null;
+  const e = a as Record<string, unknown>;
+  const { id, name, hint } = e;
+  if (typeof id !== "string" || !/^[a-z0-9][a-z0-9_-]*$/i.test(id)) return null;
+  if (typeof name !== "string" || !name.trim()) return null;
+  // Custom entries may be saved with an empty `hint` while the user is still
+  // filling in the form; the launcher hides them until it validates. A
+  // NON-empty hint that fails CMD_RE is still a spawn-injection risk → drop.
+  if (typeof hint !== "string") return null;
+  if (hint !== "" && !CMD_RE.test(hint)) return null;
+
+  const patch: RemotePatch & { custom: true } = { id, name: name.trim(), hint, custom: true };
+  const icon = iconRefLocal(e.icon);
+  if (icon) patch.icon = icon;
+  if (e.mono === true) patch.mono = true;
+  const session = strList(e.sessionIdArgs);
+  if (session) patch.sessionIdArgs = session;
+  const resume = strList(e.resumeArgs);
+  if (resume) patch.resumeArgs = resume;
+  const model = strList(e.modelArgs);
+  if (model) patch.modelArgs = model;
+  const autoApprove = strList(e.autoApproveArgs);
+  if (autoApprove) patch.autoApproveArgs = autoApprove;
+  const dl = typeof e.downloadUrl === "string" && /^https:\/\//i.test(e.downloadUrl) ? e.downloadUrl : undefined;
+  if (dl) patch.downloadUrl = dl;
+  const capture = captureSpec(e.capture);
+  if (capture) patch.capture = capture;
+  if (e.disabled === true) patch.disabled = true;
+  if (typeof e.extends === "string" && e.extends) patch.extends = e.extends;
+  return patch;
+}
+
+/// Sanitize the whole custom-agents array read out of persisted state.
+export function sanitizeCustomAgents(list: unknown): RemotePatch[] {
+  if (!Array.isArray(list)) return [];
+  return list.map(sanitizeCustomAgent).filter((a): a is RemotePatch => a !== null);
 }
 
 /// Re-guard patches loaded from the local cache: identity + `hint` shape. Capture

--- a/src/lib/agentRegistry.ts
+++ b/src/lib/agentRegistry.ts
@@ -9,7 +9,8 @@ import gooseSrc from "../assets/agent-icons/goose.svg";
 import codexSrc from "../assets/agent-icons/codex.svg";
 import antigravitySrc from "../assets/agent-icons/antigravity.svg";
 import bundledManifest from "../../config/agents.json";
-import { mergeAgents, sanitizeManifestAgents, sanitizeCachedPatches, type AgentConfig, type RemotePatch } from "./agentManifest";
+import { mergeAgents, sanitizeManifestAgents, sanitizeCachedPatches, sanitizeCustomAgents, type AgentConfig, type RemotePatch } from "./agentManifest";
+import { getRuntimeState, setRuntimeState } from "./runtimeState";
 
 // The agent registry — the single source of truth for which CLI agents Tempest
 // can launch and how it builds their argv. There is no hardcoded agent list:
@@ -79,8 +80,17 @@ function loadCachedRemote(): RemotePatch[] {
 
 let _remote: RemotePatch[] = loadCachedRemote();
 
+/// User-added agents live in runtimeState, so a hot-reload of appState (which
+/// runs after registry init) is reflected on the next build().
+function loadCustom(): RemotePatch[] {
+  return sanitizeCustomAgents(getRuntimeState().customAgents);
+}
+
 function build(): AgentConfig[] {
-  return resolveIcons(mergeAgents(BUNDLED_AGENTS, _remote));
+  // Custom agents are merged LAST so a user can override a bundled/remote entry
+  // (e.g. point "claude" at a local wrapper script). Removing the custom entry
+  // reveals the shipped one again.
+  return resolveIcons(mergeAgents(mergeAgents(BUNDLED_AGENTS, _remote), loadCustom()));
 }
 
 export let AGENT_CONFIGS: AgentConfig[] = build();
@@ -88,6 +98,13 @@ export let AGENT_CONFIGS: AgentConfig[] = build();
 function notify() {
   AGENT_CONFIGS = build();
   listeners.forEach((l) => l());
+}
+
+/// Trigger a registry rebuild + subscriber notify. Called by `main.tsx` once
+/// `loadAppState` has hydrated `runtimeState.customAgents` — the initial
+/// `AGENT_CONFIGS = build()` at module load ran with an empty runtime slot.
+export function refreshAgentRegistry(): void {
+  notify();
 }
 
 /// Apply a verified, sanitized downloaded manifest. Caches it for the next offline
@@ -115,6 +132,23 @@ export function useAgents(): AgentConfig[] {
     (cb) => { listeners.add(cb); return () => listeners.delete(cb); },
     () => AGENT_CONFIGS,
   );
+}
+
+// ── custom (user-added) agents ───────────────────────────────────────────────
+// Persisted in runtimeState.customAgents. Written through here so the registry
+// rebuild + subscriber notify happen atomically with the persist.
+
+/// The raw persisted list — for the settings UI editor. Every entry has
+/// `custom: true` (stamped by `sanitizeCustomAgent`).
+export function getCustomAgents(): RemotePatch[] {
+  return sanitizeCustomAgents(getRuntimeState().customAgents);
+}
+
+/// Persist a new custom list and rebuild the registry. The list is re-sanitized
+/// on the way in so a bad entry from the UI can never reach a spawn.
+export function setCustomAgents(list: RemotePatch[]): void {
+  setRuntimeState({ customAgents: sanitizeCustomAgents(list) });
+  notify();
 }
 
 // ── icon cache ───────────────────────────────────────────────────────────────

--- a/src/lib/runtimeState.ts
+++ b/src/lib/runtimeState.ts
@@ -2,6 +2,7 @@ import { dbLoadAppState, dbSetAppState } from "./db";
 import type { AppSettings } from "../store/appSettings";
 import type { ActionId, Shortcut } from "../store/keybindings";
 import { EMPTY_AGENT_CONFIG, isEmptyAgentConfig, type PerAgentConfig } from "./agentConfig";
+import type { RemotePatch } from "./agentManifest";
 
 // App-global preferences. Persisted as a single JSON row in the `app_state`
 // table (key = "runtime"). Entity collections (projects, sessions, branches,
@@ -16,6 +17,7 @@ export interface RuntimeState {
   prompts: Array<{ id: string; title: string; body: string; enabled: boolean; isBuiltin: boolean }>;
   atlasProjects: Record<string, boolean>; // projectPath → indexed? (Token Intelligence decision)
   agentConfigs: Record<string, PerAgentConfig>; // agent id → per-agent launch defaults
+  customAgents: RemotePatch[];    // user-added agents, merged over bundled+remote
   theme?: string;         // active theme name
   chatProvider?: string;  // last selected chat provider id
   chatModel?: string;     // last selected chat model id
@@ -31,6 +33,7 @@ const DEFAULT_STATE: RuntimeState = {
   prompts: [],
   atlasProjects: {},
   agentConfigs: {},
+  customAgents: [],
 };
 
 const KEY = "runtime";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import "./fonts.css";
 import App from "./App";
 import { ThemeProvider } from "./themes/ThemeContext";
 import { loadAppState } from "./lib/runtimeState";
+import { refreshAgentRegistry } from "./lib/agentRegistry";
 import { loadSessions } from "./store/sessions";
 import { loadProjects } from "./store/openProjects";
 import { loadRecents } from "./store/recents";
@@ -17,6 +18,9 @@ import { loadTabs } from "./store/tabs";
   await Promise.all([
     loadAppState(), loadSessions(), loadProjects(), loadRecents(), loadTabs(),
   ]);
+  // AGENT_CONFIGS was built at module load with an empty runtime state; now
+  // that customAgents is hydrated, rebuild so user-added entries appear.
+  refreshAgentRegistry();
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <ThemeProvider>
       <App />

--- a/src/store/appSettings.ts
+++ b/src/store/appSettings.ts
@@ -22,6 +22,9 @@ export interface AppSettings {
   // working/waiting/done status. Off uninstalls them and falls back to the
   // PTY-scraping heuristic. See src/lib/agentHooks.
   preciseAgentStatus: boolean;
+  // OS desktop notifications when an agent finishes or asks for permission
+  // while the Tempest window is unfocused. Suppressed while focused.
+  desktopNotifications: boolean;
   // Anonymous usage telemetry (PostHog). Default false — nothing is loaded or
   // sent until the user explicitly opts in. Flip only via setTelemetryEnabled
   // in src/lib/telemetry.ts, never updateSetting directly.
@@ -43,6 +46,7 @@ export const SETTINGS_DEFAULTS: AppSettings = {
   isolateAgents: true,
   autoApprove: true,
   preciseAgentStatus: true,
+  desktopNotifications: true,
   telemetryEnabled: false,
 };
 

--- a/src/store/islandNotifs.ts
+++ b/src/store/islandNotifs.ts
@@ -1,6 +1,20 @@
 import { getSession } from "./sessions";
 import { getSettings } from "./appSettings";
 import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
+import { resolveResource } from "@tauri-apps/api/path";
+
+// Windows toast notifications only show an app icon when the app is installed
+// with a Start Menu shortcut (AppUserModelID). In dev — and even sometimes in
+// installed builds — the OS falls back to a generic icon. Passing an absolute
+// `icon` path forces the notification to render our logo. Resolved once and
+// cached; resolveResource is a filesystem lookup, no need to repeat it.
+let _iconPathPromise: Promise<string | undefined> | null = null;
+function getIconPath(): Promise<string | undefined> {
+  if (!_iconPathPromise) {
+    _iconPathPromise = resolveResource("icons/128x128.png").catch(() => undefined);
+  }
+  return _iconPathPromise;
+}
 
 export type IslandNotifType = "permission" | "done";
 
@@ -63,7 +77,8 @@ async function fireDesktopNotif(n: Omit<IslandNotif, "id">): Promise<void> {
     const body = n.type === "permission"
       ? `${n.agent} is asking for permission${n.detail ? ` — ${n.detail}` : ""}`
       : `${n.agent} finished`;
-    sendNotification({ title: n.title, body });
+    const icon = await getIconPath();
+    sendNotification({ title: n.title, body, icon });
   } catch { /* notification plugin unavailable; ignore */ }
 }
 

--- a/src/store/islandNotifs.ts
+++ b/src/store/islandNotifs.ts
@@ -1,4 +1,6 @@
 import { getSession } from "./sessions";
+import { getSettings } from "./appSettings";
+import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
 
 export type IslandNotifType = "permission" | "done";
 
@@ -46,6 +48,23 @@ export function pushIslandNotif(n: Omit<IslandNotif, "id">): void {
   const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
   _notifs = [{ ...n, id }, ..._notifs.filter((e) => !(e.sessionId === n.sessionId && e.type === n.type))].slice(0, MAX);
   emit();
+  // OS-level notification when the user is away (window unfocused). The
+  // in-app island already covers the "focused, different tab" case; only the
+  // away case needs to break through to the desktop.
+  if (!document.hasFocus() && getSettings().desktopNotifications) {
+    void fireDesktopNotif(n);
+  }
+}
+
+async function fireDesktopNotif(n: Omit<IslandNotif, "id">): Promise<void> {
+  try {
+    const granted = (await isPermissionGranted()) || (await requestPermission()) === "granted";
+    if (!granted) return;
+    const body = n.type === "permission"
+      ? `${n.agent} is asking for permission${n.detail ? ` — ${n.detail}` : ""}`
+      : `${n.agent} finished`;
+    sendNotification({ title: n.title, body });
+  } catch { /* notification plugin unavailable; ignore */ }
 }
 
 export function dismissIslandNotif(id: string): void {


### PR DESCRIPTION
## Summary

Cleanup release around v0.1.12's two big landings.

- **Custom agents** — add/edit/clone/delete your own agents in Settings → Agents; toggle built-ins off without deleting.
- **Quota Island fixes** — Claude Code token slot (`claudeAiOauth`), 0-100 → 0-1 utilization scaling, panel z-index above workspace overlays, Geist font.
- **Desktop notifications** — Windows toasts now carry the Tempest logo instead of the default shell icon.
- **Repo hygiene** — `SECURITY.md`, issue templates, PR template, refreshed `CONTRIBUTING.md` / `CODE_OF_CONDUCT.md`, ROADMAP pass.