### PR TITLE
feat(atlas): rung 3 — asset nodes, describes edges, chunking, PDF, CLI write path

### DIFF
--- a/packages/atlas/__tests__/assets.test.ts
+++ b/packages/atlas/__tests__/assets.test.ts
@@ -48,11 +48,11 @@ describe('assets — Rung 3 lifecycle', () => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('adds a markdown asset, links it, lists it, then unlinks and removes it', () => {
+  it('adds a markdown asset, links it, lists it, then unlinks and removes it', async () => {
     const notePath = join(projectRoot, 'docs', 'auth-notes.md');
     writeFileSync(notePath, '# Auth Notes\n\nRotate the JWT secret on incident.', 'utf-8');
 
-    const asset = atlas.addAsset(notePath);
+    const asset = await atlas.addAsset(notePath);
     expect(asset.name).toBe('auth-notes.md');
     expect(asset.sourcePath).toBe('docs/auth-notes.md');
     expect(asset.contentType).toBe('text/markdown');
@@ -91,22 +91,22 @@ describe('assets — Rung 3 lifecycle', () => {
     expect(atlas.listAssets()).toEqual([]);
   });
 
-  it('re-adding an existing asset refreshes its extracted text without duplicating', () => {
+  it('re-adding an existing asset refreshes its extracted text without duplicating', async () => {
     const p = join(projectRoot, 'docs', 'plan.md');
     writeFileSync(p, 'v1 content', 'utf-8');
-    const first = atlas.addAsset(p);
+    const first = await atlas.addAsset(p);
     writeFileSync(p, 'v2 content', 'utf-8');
-    const second = atlas.addAsset(p);
+    const second = await atlas.addAsset(p);
 
     expect(second.id).toBe(first.id);
     expect(atlas.listAssets()).toHaveLength(1);
     expect(atlas.getAsset(second.id)?.extractedText).toBe('v2 content');
   });
 
-  it('records a binary/unsupported file as an asset with null extracted text', () => {
+  it('records a binary/unsupported file as an asset with null extracted text', async () => {
     const p = join(projectRoot, 'docs', 'diagram.png');
     writeFileSync(p, Buffer.from([0x89, 0x50, 0x4e, 0x47])); // PNG magic bytes
-    const asset = atlas.addAsset(p);
+    const asset = await atlas.addAsset(p);
 
     expect(asset.contentType).toBe('application/octet-stream');
     expect(asset.extractedText).toBeNull();
@@ -114,10 +114,27 @@ describe('assets — Rung 3 lifecycle', () => {
     expect(atlas.listAssets().map((a) => a.id)).toContain(asset.id);
   });
 
-  it('throws when linking to a missing symbol so callers see an actionable error', () => {
+  it('throws when linking to a missing symbol so callers see an actionable error', async () => {
     const p = join(projectRoot, 'docs', 'x.md');
     writeFileSync(p, 'x', 'utf-8');
-    const asset = atlas.addAsset(p);
+    const asset = await atlas.addAsset(p);
     expect(() => atlas.linkAsset(asset.id, 'symbol:does-not-exist')).toThrow(/Symbol not found/);
+  });
+
+  it('splits long docs into chunks and clears them on re-add of a short version', async () => {
+    const p = join(projectRoot, 'docs', 'long.md');
+    // 5000 chars > CHUNK_SIZE (1500) → should produce multiple chunks with overlap.
+    writeFileSync(p, 'x'.repeat(5000), 'utf-8');
+    const asset = await atlas.addAsset(p);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const queries = (atlas as any).queries;
+    const countLong = queries.db.prepare('SELECT COUNT(*) AS n FROM asset_chunks WHERE asset_id = ?').get(asset.id) as { n: number };
+    expect(countLong.n).toBeGreaterThan(1);
+
+    // Re-add with a short body → chunk set gets cleared (empty chunks table for this asset).
+    writeFileSync(p, 'short', 'utf-8');
+    await atlas.addAsset(p);
+    const countShort = queries.db.prepare('SELECT COUNT(*) AS n FROM asset_chunks WHERE asset_id = ?').get(asset.id) as { n: number };
+    expect(countShort.n).toBe(0);
   });
 });

--- a/packages/atlas/__tests__/assets.test.ts
+++ b/packages/atlas/__tests__/assets.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Atlas from '../src';
+import type { Node } from '../src/types';
+
+// End-to-end asset lifecycle: add → link → list → content → unlink → remove.
+// A real SQLite instance behind a real Atlas — the FK cascade, FTS trigger, and
+// edge dedup are the exact interactions we want to lock down, so mocks would
+// hide the bugs this test exists to catch.
+
+function seedCodeNode(atlas: Atlas): Node {
+  // Insert a synthetic code node directly through the query layer so the test
+  // doesn't depend on tree-sitter grammars loading. It's a `function` kind so
+  // an asset can attach to something realistic.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const queries = (atlas as any).queries;
+  const node: Node = {
+    id: 'fn:test:doThing',
+    kind: 'function',
+    name: 'doThing',
+    qualifiedName: 'src/example.ts::doThing',
+    filePath: 'src/example.ts',
+    language: 'typescript',
+    startLine: 10,
+    endLine: 20,
+    startColumn: 0,
+    endColumn: 0,
+    updatedAt: Date.now(),
+  };
+  queries.insertNode(node);
+  return node;
+}
+
+describe('assets — Rung 3 lifecycle', () => {
+  let projectRoot: string;
+  let atlas: Atlas;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'atlas-assets-'));
+    mkdirSync(join(projectRoot, 'docs'), { recursive: true });
+    atlas = Atlas.initSync(projectRoot);
+  });
+
+  afterEach(() => {
+    atlas.close();
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('adds a markdown asset, links it, lists it, then unlinks and removes it', () => {
+    const notePath = join(projectRoot, 'docs', 'auth-notes.md');
+    writeFileSync(notePath, '# Auth Notes\n\nRotate the JWT secret on incident.', 'utf-8');
+
+    const asset = atlas.addAsset(notePath);
+    expect(asset.name).toBe('auth-notes.md');
+    expect(asset.sourcePath).toBe('docs/auth-notes.md');
+    expect(asset.contentType).toBe('text/markdown');
+    expect(asset.extractedText).toContain('Rotate the JWT secret');
+    expect(asset.id).toMatch(/^asset:/);
+
+    // Deterministic id: resolveAssetIdByPath must match addAsset's id.
+    expect(atlas.resolveAssetIdByPath('docs/auth-notes.md')).toBe(asset.id);
+
+    const code = seedCodeNode(atlas);
+    atlas.linkAsset(asset.id, code.id);
+
+    // Idempotent link — calling twice must not double-insert (edges UNIQUE index).
+    atlas.linkAsset(asset.id, code.id);
+    expect(atlas.getAssetLinks(asset.id)).toEqual([code.id]);
+
+    // Listing by contentType prefix + linkedTo filter both surface the asset.
+    expect(atlas.listAssets().map((a) => a.id)).toEqual([asset.id]);
+    expect(atlas.listAssets({ contentType: 'text/' }).map((a) => a.id)).toEqual([asset.id]);
+    expect(atlas.listAssets({ linkedTo: code.id }).map((a) => a.id)).toEqual([asset.id]);
+
+    // getAsset returns the full extracted text.
+    const fetched = atlas.getAsset(asset.id);
+    expect(fetched?.extractedText).toContain('Rotate the JWT secret');
+
+    // Unlink then confirm the edge is gone but the asset remains.
+    expect(atlas.unlinkAsset(asset.id, code.id)).toBe(true);
+    expect(atlas.unlinkAsset(asset.id, code.id)).toBe(false); // second call no-op
+    expect(atlas.getAssetLinks(asset.id)).toEqual([]);
+    expect(atlas.getAsset(asset.id)).not.toBeNull();
+
+    // Removal: asset + its companion row + any residual edges all vanish.
+    expect(atlas.removeAsset(asset.id)).toBe(true);
+    expect(atlas.removeAsset(asset.id)).toBe(false);
+    expect(atlas.getAsset(asset.id)).toBeNull();
+    expect(atlas.listAssets()).toEqual([]);
+  });
+
+  it('re-adding an existing asset refreshes its extracted text without duplicating', () => {
+    const p = join(projectRoot, 'docs', 'plan.md');
+    writeFileSync(p, 'v1 content', 'utf-8');
+    const first = atlas.addAsset(p);
+    writeFileSync(p, 'v2 content', 'utf-8');
+    const second = atlas.addAsset(p);
+
+    expect(second.id).toBe(first.id);
+    expect(atlas.listAssets()).toHaveLength(1);
+    expect(atlas.getAsset(second.id)?.extractedText).toBe('v2 content');
+  });
+
+  it('records a binary/unsupported file as an asset with null extracted text', () => {
+    const p = join(projectRoot, 'docs', 'diagram.png');
+    writeFileSync(p, Buffer.from([0x89, 0x50, 0x4e, 0x47])); // PNG magic bytes
+    const asset = atlas.addAsset(p);
+
+    expect(asset.contentType).toBe('application/octet-stream');
+    expect(asset.extractedText).toBeNull();
+    // Still fully listable and linkable — presence in the graph is the value.
+    expect(atlas.listAssets().map((a) => a.id)).toContain(asset.id);
+  });
+
+  it('throws when linking to a missing symbol so callers see an actionable error', () => {
+    const p = join(projectRoot, 'docs', 'x.md');
+    writeFileSync(p, 'x', 'utf-8');
+    const asset = atlas.addAsset(p);
+    expect(() => atlas.linkAsset(asset.id, 'symbol:does-not-exist')).toThrow(/Symbol not found/);
+  });
+});

--- a/packages/atlas/package.json
+++ b/packages/atlas/package.json
@@ -29,6 +29,9 @@
     "tree-sitter-wasms": "^0.1.11",
     "web-tree-sitter": "^0.25.3"
   },
+  "optionalDependencies": {
+    "pdf-parse": "^1.1.1"
+  },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^20.19.30",

--- a/packages/atlas/src/assets/index.ts
+++ b/packages/atlas/src/assets/index.ts
@@ -2,16 +2,19 @@
  * Asset nodes — human-attached knowledge (atlas-extension-plan Rung 3).
  *
  * An asset is a file the developer attaches to the graph (a markdown note, a
- * design doc, an ADR). It lives as a `nodes` row with `kind: 'asset'` — which
- * gets it FTS indexing, embedding sync, and edges FK "for free" — plus a row
- * in the `assets` companion table for asset-only fields (content_type,
- * extracted_text, source_path). Attach an asset to a code symbol with
- * {@link linkAsset}; the link is a normal `describes` edge, so it flows
+ * design doc, an ADR, a PDF). It lives as a `nodes` row with `kind: 'asset'` —
+ * which gets it FTS indexing, embedding sync, and edges FK "for free" — plus a
+ * row in the `assets` companion table for asset-only fields (content_type,
+ * extracted_text, source_path). Long docs are additionally split into
+ * `asset_chunks` (one embedding per passage) so a query hits the relevant
+ * section instead of the doc's blurred mean. Attach an asset to a code symbol
+ * with {@link linkAsset}; the link is a normal `describes` edge, so it flows
  * through the existing traversal.
  *
- * ponytail: no chunking, no PDF, no image embeddings. Long docs are truncated
- * at the embed window; add {@link ../db/schema.sql}'s `asset_chunks` table
- * when a real long asset regresses recall.
+ * PDF text is extracted via `pdf-parse` when the optionalDependency is
+ * installed; without it, PDFs are still tracked (as an asset row) but with
+ * `extractedText = null`. Images stay null-embedding by design (multimodal is
+ * a future step, per the plan).
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -38,6 +41,7 @@ const TEXT_EXTENSIONS: Record<string, string> = {
   '.adoc': 'text/asciidoc',
   '.org': 'text/org',
   '.log': 'text/plain',
+  '.pdf': 'application/pdf',
 };
 
 /** Max characters kept in `docstring` — feeds FTS + the embed-text. MiniLM's
@@ -47,6 +51,33 @@ const DOCSTRING_MAX_CHARS = 4000;
 /** Max characters kept in `extracted_text` — the field `atlas_asset_content`
  * returns. Bounded so a stray huge log file can't blow up query results. */
 const EXTRACTED_TEXT_MAX_CHARS = 200_000;
+
+/** Chunk long docs into ~1500-char passages. ~375 tokens at 4 chars/token —
+ * safely under MiniLM's 256-token *effective* window after truncation, and each
+ * passage gets its own vector so a query hits the section instead of the doc's
+ * blurred mean. Only triggers when the extracted text exceeds this: short docs
+ * still ride the single-node embedding path.
+ * ponytail: hard slices at char boundaries — no paragraph-aware splitter yet;
+ * upgrade when a real long doc's chunk boundaries visibly split a section. */
+const CHUNK_SIZE = 1500;
+
+/**
+ * Chunk `text` into fixed-size slices with a small overlap so a query term
+ * straddling a boundary still hits at least one chunk. Empty input → [].
+ */
+function chunkText(text: string): string[] {
+  if (!text) return [];
+  if (text.length <= CHUNK_SIZE) return [];
+  const overlap = 100;
+  const chunks: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    chunks.push(text.slice(i, i + CHUNK_SIZE));
+    if (i + CHUNK_SIZE >= text.length) break;
+    i += CHUNK_SIZE - overlap;
+  }
+  return chunks;
+}
 
 function assetId(sourcePath: string): string {
   return 'asset:' + createHash('sha1').update(sourcePath).digest('hex');
@@ -58,20 +89,34 @@ function detectContentType(absPath: string): string {
 }
 
 /**
- * Read + text-extract the file, returning `null` for unsupported types.
- * ponytail: PDF/image handled later — wire `pdf-parse` in when the first PDF
- * asset actually gets attached, not before.
+ * Read + text-extract the file, returning `null` for unsupported types or
+ * failures. PDF handled via `pdf-parse` (optionalDependency) — lazy require so
+ * a missing install just downgrades PDFs to null text, everything else keeps
+ * working. Images stay null-embedding per the plan (multimodal is out of scope).
  */
-function extractText(absPath: string, contentType: string): string | null {
-  if (!contentType.startsWith('text/') && contentType !== 'application/json') {
-    return null;
-  }
+async function extractText(absPath: string, contentType: string): Promise<string | null> {
   try {
-    const raw = fs.readFileSync(absPath, 'utf-8');
-    return raw.length > EXTRACTED_TEXT_MAX_CHARS ? raw.slice(0, EXTRACTED_TEXT_MAX_CHARS) : raw;
+    if (contentType.startsWith('text/') || contentType === 'application/json') {
+      const raw = fs.readFileSync(absPath, 'utf-8');
+      return raw.length > EXTRACTED_TEXT_MAX_CHARS ? raw.slice(0, EXTRACTED_TEXT_MAX_CHARS) : raw;
+    }
+    if (contentType === 'application/pdf') {
+      let pdfParse: ((buf: Buffer) => Promise<{ text: string }>) | null = null;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        pdfParse = require('pdf-parse') as (buf: Buffer) => Promise<{ text: string }>;
+      } catch {
+        return null; // optionalDependency not installed → treat like binary
+      }
+      const buf = fs.readFileSync(absPath);
+      const out = await pdfParse(buf);
+      const text = out.text ?? '';
+      return text.length > EXTRACTED_TEXT_MAX_CHARS ? text.slice(0, EXTRACTED_TEXT_MAX_CHARS) : text;
+    }
   } catch {
-    return null;
+    // read/parse failure — treat as binary, still tracked
   }
+  return null;
 }
 
 function relPath(projectRoot: string, absPath: string): string {
@@ -98,12 +143,12 @@ function toAsset(
  * the file changes to re-read and re-hash; the id is stable across re-adds.
  * Throws only if the file doesn't exist.
  */
-export function addAsset(
+export async function addAsset(
   queries: QueryBuilder,
   projectRoot: string,
   sourcePathInput: string,
   opts: { name?: string } = {}
-): Asset {
+): Promise<Asset> {
   const absPath = path.isAbsolute(sourcePathInput)
     ? sourcePathInput
     : path.resolve(projectRoot, sourcePathInput);
@@ -113,7 +158,7 @@ export function addAsset(
   const sourcePath = relPath(projectRoot, absPath);
   const id = assetId(sourcePath);
   const contentType = detectContentType(absPath);
-  const extractedText = extractText(absPath, contentType);
+  const extractedText = await extractText(absPath, contentType);
   const name = opts.name ?? path.basename(sourcePath);
   const now = Date.now();
 
@@ -142,6 +187,17 @@ export function addAsset(
   };
   queries.insertNode(node); // INSERT OR REPLACE — safe re-add
   queries.upsertAssetRow(id, contentType, sourcePath, extractedText);
+
+  // Chunk long documents so each passage gets its own vector. Short docs get
+  // an empty chunk set (single-node embedding is fine). Idempotent — the
+  // queries.replaceAssetChunks call clears the old set before inserting.
+  const pieces = extractedText ? chunkText(extractedText) : [];
+  const chunks = pieces.map((text, ord) => ({
+    id: `chunk:${id.slice('asset:'.length)}:${ord}`,
+    ord,
+    text,
+  }));
+  queries.replaceAssetChunks(id, chunks);
 
   return {
     id,

--- a/packages/atlas/src/assets/index.ts
+++ b/packages/atlas/src/assets/index.ts
@@ -1,0 +1,238 @@
+/**
+ * Asset nodes — human-attached knowledge (atlas-extension-plan Rung 3).
+ *
+ * An asset is a file the developer attaches to the graph (a markdown note, a
+ * design doc, an ADR). It lives as a `nodes` row with `kind: 'asset'` — which
+ * gets it FTS indexing, embedding sync, and edges FK "for free" — plus a row
+ * in the `assets` companion table for asset-only fields (content_type,
+ * extracted_text, source_path). Attach an asset to a code symbol with
+ * {@link linkAsset}; the link is a normal `describes` edge, so it flows
+ * through the existing traversal.
+ *
+ * ponytail: no chunking, no PDF, no image embeddings. Long docs are truncated
+ * at the embed window; add {@link ../db/schema.sql}'s `asset_chunks` table
+ * when a real long asset regresses recall.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { createHash } from 'node:crypto';
+import type { QueryBuilder } from '../db/queries';
+import type { Asset, Edge, Node } from '../types';
+
+/**
+ * Content types we can read as text right now. Everything else stores as an
+ * asset row with `extractedText = null` — the file is tracked and linkable,
+ * but its content doesn't feed FTS/embedding. Add a case in
+ * {@link extractText} when a new type actually matters.
+ */
+const TEXT_EXTENSIONS: Record<string, string> = {
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.mdx': 'text/markdown',
+  '.txt': 'text/plain',
+  '.text': 'text/plain',
+  '.json': 'application/json',
+  '.yaml': 'text/yaml',
+  '.yml': 'text/yaml',
+  '.rst': 'text/x-rst',
+  '.adoc': 'text/asciidoc',
+  '.org': 'text/org',
+  '.log': 'text/plain',
+};
+
+/** Max characters kept in `docstring` — feeds FTS + the embed-text. MiniLM's
+ * ~256-token window is well under this; the extra room helps FTS. */
+const DOCSTRING_MAX_CHARS = 4000;
+
+/** Max characters kept in `extracted_text` — the field `atlas_asset_content`
+ * returns. Bounded so a stray huge log file can't blow up query results. */
+const EXTRACTED_TEXT_MAX_CHARS = 200_000;
+
+function assetId(sourcePath: string): string {
+  return 'asset:' + createHash('sha1').update(sourcePath).digest('hex');
+}
+
+function detectContentType(absPath: string): string {
+  const ext = path.extname(absPath).toLowerCase();
+  return TEXT_EXTENSIONS[ext] ?? 'application/octet-stream';
+}
+
+/**
+ * Read + text-extract the file, returning `null` for unsupported types.
+ * ponytail: PDF/image handled later — wire `pdf-parse` in when the first PDF
+ * asset actually gets attached, not before.
+ */
+function extractText(absPath: string, contentType: string): string | null {
+  if (!contentType.startsWith('text/') && contentType !== 'application/json') {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(absPath, 'utf-8');
+    return raw.length > EXTRACTED_TEXT_MAX_CHARS ? raw.slice(0, EXTRACTED_TEXT_MAX_CHARS) : raw;
+  } catch {
+    return null;
+  }
+}
+
+function relPath(projectRoot: string, absPath: string): string {
+  const rel = path.relative(projectRoot, absPath);
+  return rel.split(path.sep).join('/');
+}
+
+function toAsset(
+  nodeRow: Pick<Node, 'name' | 'updatedAt'>,
+  assetRow: { id: string; content_type: string; source_path: string; extracted_text: string | null }
+): Asset {
+  return {
+    id: assetRow.id,
+    name: nodeRow.name,
+    sourcePath: assetRow.source_path,
+    contentType: assetRow.content_type,
+    extractedText: assetRow.extracted_text,
+    updatedAt: nodeRow.updatedAt,
+  };
+}
+
+/**
+ * Add or refresh an asset from a file on disk. Idempotent — call again after
+ * the file changes to re-read and re-hash; the id is stable across re-adds.
+ * Throws only if the file doesn't exist.
+ */
+export function addAsset(
+  queries: QueryBuilder,
+  projectRoot: string,
+  sourcePathInput: string,
+  opts: { name?: string } = {}
+): Asset {
+  const absPath = path.isAbsolute(sourcePathInput)
+    ? sourcePathInput
+    : path.resolve(projectRoot, sourcePathInput);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Asset file not found: ${absPath}`);
+  }
+  const sourcePath = relPath(projectRoot, absPath);
+  const id = assetId(sourcePath);
+  const contentType = detectContentType(absPath);
+  const extractedText = extractText(absPath, contentType);
+  const name = opts.name ?? path.basename(sourcePath);
+  const now = Date.now();
+
+  // Feed FTS + the embedder via the existing `docstring` channel. The embed-text
+  // template is `{name} {qualifiedName} {signature} {docstring}` — for an asset,
+  // qualifiedName is the path, signature is the content-type, docstring is a
+  // truncated prefix of the content. That means an asset's semantic vector
+  // captures both its identity and (a slice of) its content in one pass, no
+  // parallel pipeline needed.
+  const docstring = extractedText ? extractedText.slice(0, DOCSTRING_MAX_CHARS) : null;
+
+  const node: Node = {
+    id,
+    kind: 'asset',
+    name,
+    qualifiedName: sourcePath,
+    filePath: sourcePath,
+    language: 'unknown',
+    startLine: 1,
+    endLine: 1,
+    startColumn: 0,
+    endColumn: 0,
+    docstring: docstring ?? undefined,
+    signature: contentType,
+    updatedAt: now,
+  };
+  queries.insertNode(node); // INSERT OR REPLACE — safe re-add
+  queries.upsertAssetRow(id, contentType, sourcePath, extractedText);
+
+  return {
+    id,
+    name,
+    sourcePath,
+    contentType,
+    extractedText,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Remove an asset entirely. Its describes-edges cascade via the nodes FK.
+ * Returns true if an asset row was deleted.
+ */
+export function removeAsset(queries: QueryBuilder, id: string): boolean {
+  if (!queries.getAssetRow(id)) return false;
+  // The nodes-row delete cascades edges (source or target) via ON DELETE CASCADE
+  // in the schema, and cascades the assets companion row too (FK on id).
+  queries.deleteNode(id);
+  return true;
+}
+
+/**
+ * Add a `describes` edge from an asset to a code symbol. Idempotent —
+ * the UNIQUE(source,target,kind,line,col) index on edges dedups.
+ * Throws if either node is missing so the caller sees an actionable error
+ * instead of a silently-dropped edge.
+ */
+export function linkAsset(queries: QueryBuilder, assetId: string, symbolId: string): void {
+  if (!queries.getAssetRow(assetId)) {
+    throw new Error(`Asset not found: ${assetId}`);
+  }
+  if (!queries.getNodeById(symbolId)) {
+    throw new Error(`Symbol not found: ${symbolId}`);
+  }
+  const edge: Edge = {
+    source: assetId,
+    target: symbolId,
+    kind: 'describes',
+    provenance: 'heuristic',
+    confidence: 'EXTRACTED', // human-declared — the strongest tier
+  };
+  queries.insertEdge(edge);
+}
+
+/**
+ * Remove a `describes` edge. Returns true if it existed. Silent on unknown ids
+ * — useful for cleanup scripts that don't want to re-check membership.
+ */
+export function unlinkAsset(queries: QueryBuilder, assetId: string, symbolId: string): boolean {
+  return queries.deleteDescribesEdge(assetId, symbolId);
+}
+
+export interface ListAssetsOptions {
+  /** MIME prefix filter (e.g. `'text/'`). */
+  contentType?: string;
+  /** Only assets linked to this symbol. */
+  linkedTo?: string;
+}
+
+export function listAssets(queries: QueryBuilder, opts: ListAssetsOptions = {}): Asset[] {
+  const ids = opts.linkedTo
+    ? queries.listAssetIdsLinkedTo(opts.linkedTo)
+    : queries.listAssetIds(opts.contentType);
+  const out: Asset[] = [];
+  for (const id of ids) {
+    const assetRow = queries.getAssetRow(id);
+    const node = queries.getNodeById(id);
+    if (!assetRow || !node) continue;
+    out.push(toAsset(node, assetRow));
+  }
+  return out;
+}
+
+/** Full extracted text of an asset (already capped at add time). Null if the
+ * asset has no text layer (binary/unsupported type). */
+export function getAssetContent(queries: QueryBuilder, id: string): Asset | null {
+  const assetRow = queries.getAssetRow(id);
+  const node = queries.getNodeById(id);
+  if (!assetRow || !node) return null;
+  return toAsset(node, assetRow);
+}
+
+/** Symbol ids an asset is attached to. */
+export function getAssetLinks(queries: QueryBuilder, id: string): string[] {
+  return queries.listSymbolIdsForAsset(id);
+}
+
+/** Resolve a source-path (relative to project root) to the asset id. */
+export function resolveAssetIdByPath(_queries: QueryBuilder, projectRoot: string, sourcePath: string): string {
+  const abs = path.isAbsolute(sourcePath) ? sourcePath : path.resolve(projectRoot, sourcePath);
+  return assetId(relPath(projectRoot, abs));
+}

--- a/packages/atlas/src/context/index.ts
+++ b/packages/atlas/src/context/index.ts
@@ -607,7 +607,12 @@ export class ContextBuilder {
           : ['file', 'module', 'class', 'struct', 'interface', 'trait', 'protocol',
              'function', 'method', 'property', 'field', 'variable', 'constant',
              'enum', 'enum_member', 'type_alias', 'namespace', 'export',
-             'route', 'component'] as NodeKind[];
+             'route', 'component',
+             // Rung 3: human-attached assets participate in the FTS seed channel
+             // alongside code, so `atlas_explore` surfaces a linked design doc when
+             // its text hits the query terms. Vector + grep channels already include
+             // assets (EMBEDDABLE_KINDS, no kind filter respectively).
+             'asset'] as NodeKind[];
         for (const term of searchTerms) {
           const termResults = this.queries.searchNodes(term, {
             limit: opts.searchLimit * 2,

--- a/packages/atlas/src/db/migrations.ts
+++ b/packages/atlas/src/db/migrations.ts
@@ -9,7 +9,7 @@ import { SqliteDatabase } from './sqlite-adapter';
 /**
  * Current schema version
  */
-export const CURRENT_SCHEMA_VERSION = 9;
+export const CURRENT_SCHEMA_VERSION = 10;
 
 /**
  * Migration definition
@@ -144,6 +144,27 @@ const migrations: Migration[] = [
           FOREIGN KEY (id) REFERENCES nodes(id) ON DELETE CASCADE
         );
         CREATE INDEX IF NOT EXISTS idx_assets_source_path ON assets(source_path);
+      `);
+    },
+  },
+  {
+    version: 10,
+    description:
+      "Add asset_chunks — long documents split into ~1500-char chunks, each embedded separately so a query hits the relevant passage instead of the whole doc's mean vector. Chunk hits roll up to their parent asset at retrieval time. Cascades from the asset's node row via FK.",
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS asset_chunks (
+          id TEXT PRIMARY KEY,
+          asset_id TEXT NOT NULL,
+          ord INTEGER NOT NULL,
+          text TEXT NOT NULL,
+          embedding BLOB,
+          embedding_model TEXT,
+          embedding_text_hash TEXT,
+          embedding_updated_at INTEGER,
+          FOREIGN KEY (asset_id) REFERENCES nodes(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_asset_chunks_asset ON asset_chunks(asset_id);
       `);
     },
   },

--- a/packages/atlas/src/db/migrations.ts
+++ b/packages/atlas/src/db/migrations.ts
@@ -9,7 +9,7 @@ import { SqliteDatabase } from './sqlite-adapter';
 /**
  * Current schema version
  */
-export const CURRENT_SCHEMA_VERSION = 8;
+export const CURRENT_SCHEMA_VERSION = 9;
 
 /**
  * Migration definition
@@ -127,6 +127,23 @@ const migrations: Migration[] = [
     up: (db) => {
       db.exec(`
         ALTER TABLE edges ADD COLUMN confidence TEXT DEFAULT NULL;
+      `);
+    },
+  },
+  {
+    version: 9,
+    description:
+      "Add assets companion table for human-attached knowledge (atlas-extension-plan Rung 3). Assets live as rows in `nodes` with kind='asset' to reuse FTS, edges FK, and the embedding sync pipeline; this table holds asset-only extras (content_type, extracted_text). ponytail: no asset_chunks table yet — long docs are truncated at embed time; add chunking when a real long asset regresses recall.",
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS assets (
+          id TEXT PRIMARY KEY,
+          content_type TEXT NOT NULL,
+          extracted_text TEXT,
+          source_path TEXT NOT NULL,
+          FOREIGN KEY (id) REFERENCES nodes(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_assets_source_path ON assets(source_path);
       `);
     },
   },

--- a/packages/atlas/src/db/queries.ts
+++ b/packages/atlas/src/db/queries.ts
@@ -2035,4 +2035,69 @@ export class QueryBuilder {
       .run(assetId, symbolId);
     return info.changes > 0;
   }
+
+  // ===========================================================================
+  // Asset chunks (atlas-extension-plan Rung 3). Long assets split into short
+  // passages that each get their own embedding — a query hits the passage that
+  // matches instead of the doc's blurred mean. Chunk retrieval rolls up to the
+  // parent asset id at query time.
+  // ===========================================================================
+
+  /**
+   * Replace the chunk set for an asset. Called from `addAsset` on every attach:
+   * a re-add refreshes chunks in one shot, no diff logic. Empty `chunks` clears
+   * (the asset is short enough to embed as a single node).
+   */
+  replaceAssetChunks(assetId: string, chunks: Array<{ id: string; ord: number; text: string }>): void {
+    this.db.prepare('DELETE FROM asset_chunks WHERE asset_id = ?').run(assetId);
+    if (chunks.length === 0) return;
+    const insert = this.db.prepare(
+      'INSERT INTO asset_chunks (id, asset_id, ord, text) VALUES (?, ?, ?, ?)'
+    );
+    for (const c of chunks) insert.run(c.id, assetId, c.ord, c.text);
+  }
+
+  /** Every stored chunk embedding as {id, asset_id, embedding blob}. */
+  *iterateChunkEmbeddings(): IterableIterator<{ id: string; asset_id: string; embedding: Uint8Array }> {
+    const stmt = this.db.prepare(
+      'SELECT id, asset_id, embedding FROM asset_chunks WHERE embedding IS NOT NULL'
+    );
+    for (const row of stmt.iterate()) {
+      yield row as { id: string; asset_id: string; embedding: Uint8Array };
+    }
+  }
+
+  /** Chunks still needing an embedding for `model` — same shape as node work-set. */
+  getChunksNeedingEmbedding(
+    model: string,
+    limit: number
+  ): Array<{ id: string; text: string }> {
+    return this.db
+      .prepare(
+        `SELECT id, text FROM asset_chunks
+         WHERE embedding IS NULL OR embedding_model IS NOT ?
+         LIMIT ?`
+      )
+      .all(model, limit) as Array<{ id: string; text: string }>;
+  }
+
+  countChunksNeedingEmbedding(model: string): number {
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM asset_chunks
+         WHERE embedding IS NULL OR embedding_model IS NOT ?`
+      )
+      .get(model) as { n: number };
+    return row.n;
+  }
+
+  upsertChunkEmbedding(id: string, model: string, textHash: string, vec: Uint8Array, updatedAt: number): void {
+    this.db
+      .prepare(
+        `UPDATE asset_chunks
+         SET embedding = ?, embedding_model = ?, embedding_text_hash = ?, embedding_updated_at = ?
+         WHERE id = ?`
+      )
+      .run(vec, model, textHash, updatedAt, id);
+  }
 }

--- a/packages/atlas/src/db/queries.ts
+++ b/packages/atlas/src/db/queries.ts
@@ -1957,8 +1957,82 @@ export class QueryBuilder {
     this.db.transaction(() => {
       this.db.exec('DELETE FROM unresolved_refs');
       this.db.exec('DELETE FROM edges');
+      this.db.exec('DELETE FROM assets');
       this.db.exec('DELETE FROM nodes');
       this.db.exec('DELETE FROM files');
     })();
+  }
+
+  // ===========================================================================
+  // Assets (atlas-extension-plan Rung 3). Assets live as `nodes` rows with
+  // kind='asset' (reusing FTS/edges/embedding) plus this companion table for
+  // extras. Callers upsert BOTH parts inside `Atlas.addAsset` — the queries
+  // here are the primitives.
+  // ===========================================================================
+
+  upsertAssetRow(id: string, contentType: string, sourcePath: string, extractedText: string | null): void {
+    this.db.prepare(
+      `INSERT INTO assets (id, content_type, source_path, extracted_text)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         content_type = excluded.content_type,
+         source_path  = excluded.source_path,
+         extracted_text = excluded.extracted_text`
+    ).run(id, contentType, sourcePath, extractedText);
+  }
+
+  getAssetRow(id: string): { id: string; content_type: string; source_path: string; extracted_text: string | null } | null {
+    const row = this.db
+      .prepare('SELECT id, content_type, source_path, extracted_text FROM assets WHERE id = ?')
+      .get(id) as { id: string; content_type: string; source_path: string; extracted_text: string | null } | undefined;
+    return row ?? null;
+  }
+
+  /** All asset ids, optionally filtered by content-type prefix (e.g. 'text/'). */
+  listAssetIds(contentTypePrefix?: string): string[] {
+    if (contentTypePrefix) {
+      return (this.db
+        .prepare('SELECT id FROM assets WHERE content_type LIKE ? ORDER BY id')
+        .all(contentTypePrefix + '%') as { id: string }[]).map((r) => r.id);
+    }
+    return (this.db.prepare('SELECT id FROM assets ORDER BY id').all() as { id: string }[]).map((r) => r.id);
+  }
+
+  /** Asset ids that link to `symbolId` via a `describes` edge. */
+  listAssetIdsLinkedTo(symbolId: string): string[] {
+    return (this.db
+      .prepare(
+        `SELECT a.id FROM assets a
+         JOIN edges e ON e.source = a.id
+         WHERE e.target = ? AND e.kind = 'describes'
+         ORDER BY a.id`
+      )
+      .all(symbolId) as { id: string }[]).map((r) => r.id);
+  }
+
+  /**
+   * Symbol ids an asset links to via `describes`. Used to render an asset's
+   * "attached to" list.
+   */
+  listSymbolIdsForAsset(assetId: string): string[] {
+    return (this.db
+      .prepare(
+        `SELECT target AS id FROM edges
+         WHERE source = ? AND kind = 'describes'
+         ORDER BY target`
+      )
+      .all(assetId) as { id: string }[]).map((r) => r.id);
+  }
+
+  /**
+   * Remove a specific describes-edge between an asset and a symbol. Returns
+   * true if a row was deleted. Coordinate-less by design — `describes` edges
+   * carry no line/col, so (source, target, kind) is unique.
+   */
+  deleteDescribesEdge(assetId: string, symbolId: string): boolean {
+    const info = this.db
+      .prepare(`DELETE FROM edges WHERE source = ? AND target = ? AND kind = 'describes'`)
+      .run(assetId, symbolId);
+    return info.changes > 0;
   }
 }

--- a/packages/atlas/src/db/schema.sql
+++ b/packages/atlas/src/db/schema.sql
@@ -1,5 +1,5 @@
 -- Atlas SQLite Schema
--- Version 1
+-- Version 9
 
 -- Schema version tracking
 CREATE TABLE IF NOT EXISTS schema_versions (
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS schema_versions (
 
 -- Insert initial version
 INSERT INTO schema_versions (version, applied_at, description)
-VALUES (1, strftime('%s', 'now') * 1000, 'Initial schema');
+VALUES (9, strftime('%s', 'now') * 1000, 'Initial schema (bundled current)');
 
 -- =============================================================================
 -- Core Tables
@@ -175,3 +175,18 @@ CREATE TABLE IF NOT EXISTS project_metadata (
     value TEXT NOT NULL,
     updated_at INTEGER NOT NULL
 );
+
+-- Assets: human-attached knowledge (markdown, notes, docs) that live in the
+-- graph alongside code. Stored as rows in `nodes` with kind='asset' (reusing
+-- FTS, edges FK, embedding sync) plus this companion table for asset-only
+-- extras. Link an asset to a code symbol with a `describes` edge.
+-- ponytail: no `asset_chunks` yet — long docs are truncated at embed time;
+-- add chunking when recall on a long asset actually regresses.
+CREATE TABLE IF NOT EXISTS assets (
+    id TEXT PRIMARY KEY,
+    content_type TEXT NOT NULL,
+    extracted_text TEXT,
+    source_path TEXT NOT NULL,
+    FOREIGN KEY (id) REFERENCES nodes(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_assets_source_path ON assets(source_path);

--- a/packages/atlas/src/db/schema.sql
+++ b/packages/atlas/src/db/schema.sql
@@ -1,5 +1,5 @@
 -- Atlas SQLite Schema
--- Version 9
+-- Version 10
 
 -- Schema version tracking
 CREATE TABLE IF NOT EXISTS schema_versions (
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS schema_versions (
 
 -- Insert initial version
 INSERT INTO schema_versions (version, applied_at, description)
-VALUES (9, strftime('%s', 'now') * 1000, 'Initial schema (bundled current)');
+VALUES (10, strftime('%s', 'now') * 1000, 'Initial schema (bundled current)');
 
 -- =============================================================================
 -- Core Tables
@@ -190,3 +190,19 @@ CREATE TABLE IF NOT EXISTS assets (
     FOREIGN KEY (id) REFERENCES nodes(id) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_assets_source_path ON assets(source_path);
+
+-- Asset chunks: long documents get split into ~1500-char passages, each embedded
+-- separately so a query hits the relevant part instead of the doc's blurred mean.
+-- Chunk hits roll up to their parent asset at retrieval time (dedup by asset_id).
+CREATE TABLE IF NOT EXISTS asset_chunks (
+    id TEXT PRIMARY KEY,
+    asset_id TEXT NOT NULL,
+    ord INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    embedding BLOB,
+    embedding_model TEXT,
+    embedding_text_hash TEXT,
+    embedding_updated_at INTEGER,
+    FOREIGN KEY (asset_id) REFERENCES nodes(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_asset_chunks_asset ON asset_chunks(asset_id);

--- a/packages/atlas/src/embedding/embedder.ts
+++ b/packages/atlas/src/embedding/embedder.ts
@@ -22,6 +22,10 @@ export const EMBEDDING_DIM = 384;
 export const EMBEDDABLE_KINDS = [
   'function', 'method', 'class', 'interface', 'struct', 'enum',
   'type_alias', 'component', 'route',
+  // Rung 3: human-attached knowledge participates in the same hybrid retrieval.
+  // Asset embed-text comes from the truncated extracted text stored in docstring;
+  // syncEmbeddings' generic path handles both without a branch.
+  'asset',
 ] as const;
 
 /** Model-download progress event, as reported by @xenova/transformers. */

--- a/packages/atlas/src/embedding/index.ts
+++ b/packages/atlas/src/embedding/index.ts
@@ -39,10 +39,25 @@ export async function computeVectorSeeds(
     for (const row of queries.iterateEmbeddings()) {
       scored.push({ id: row.id, score: cosine(qv, decodeVec(row.embedding)) });
     }
+    // Chunk hits roll up to their parent asset id (best chunk wins). A long doc
+    // otherwise disappears from vector because its mean vector blurs; each
+    // chunk's tighter vector lets the query hit the passage that matters.
+    const bestPerAsset = new Map<string, number>();
+    for (const row of queries.iterateChunkEmbeddings()) {
+      const s = cosine(qv, decodeVec(row.embedding));
+      const prev = bestPerAsset.get(row.asset_id);
+      if (prev === undefined || s > prev) bestPerAsset.set(row.asset_id, s);
+    }
+    for (const [assetId, score] of bestPerAsset) {
+      scored.push({ id: assetId, score });
+    }
     scored.sort((a, b) => b.score - a.score);
 
     const seeds: SearchResult[] = [];
+    const seen = new Set<string>();
     for (const s of scored) {
+      if (seen.has(s.id)) continue; // an asset can appear twice (own vector + a chunk); dedup
+      seen.add(s.id);
       const node = queries.getNodeById(s.id);
       if (node) seeds.push({ node, score: s.score });
       if (seeds.length >= k) break;
@@ -82,7 +97,9 @@ export async function syncEmbeddings(
 
   inFlight.add(queries);
   try {
-    const total = queries.countNodesNeedingEmbedding(EMBEDDING_MODEL, EMBEDDABLE_KINDS);
+    const nodeTotal = queries.countNodesNeedingEmbedding(EMBEDDING_MODEL, EMBEDDABLE_KINDS);
+    const chunkTotal = queries.countChunksNeedingEmbedding(EMBEDDING_MODEL);
+    const total = nodeTotal + chunkTotal;
     if (total === 0) return;
 
     let done = 0;
@@ -107,6 +124,28 @@ export async function syncEmbeddings(
       done += rows.length;
       options.onProgress?.(done, total);
       await new Promise((r) => setTimeout(r, 50)); // idle-biased: hand the CPU back
+    }
+
+    // Same drain shape for asset chunks — each chunk's raw text IS its embed-
+    // text (no name/signature scaffolding to prepend). Chunks and nodes share
+    // one model, so the loops don't need to interleave.
+    for (;;) {
+      if (options.signal?.aborted) return;
+      const rows = queries.getChunksNeedingEmbedding(EMBEDDING_MODEL, batchSize);
+      if (rows.length === 0) break;
+
+      const texts = rows.map((r) => r.text);
+      const vecs = await embed(texts);
+      const now = Date.now();
+      rows.forEach((row, i) => {
+        const vec = vecs[i];
+        const text = texts[i];
+        if (!vec || text === undefined) return;
+        queries.upsertChunkEmbedding(row.id, EMBEDDING_MODEL, embedTextHash(text), encodeVec(vec), now);
+      });
+      done += rows.length;
+      options.onProgress?.(done, total);
+      await new Promise((r) => setTimeout(r, 50));
     }
   } catch {
     // Model unavailable or transient failure — leave the remaining work set for

--- a/packages/atlas/src/index.ts
+++ b/packages/atlas/src/index.ts
@@ -45,7 +45,9 @@ import {
 } from './resolution';
 import { GraphTraverser, GraphQueryManager } from './graph';
 import { ContextBuilder, createContextBuilder } from './context';
-import { syncEmbeddings, semanticDisabled } from './embedding';
+import { syncEmbeddings, semanticDisabled, computeVectorSeeds } from './embedding';
+import * as assetsApi from './assets';
+import type { Asset } from './types';
 import { Mutex, FileLock } from './utils';
 import { FileWatcher, WatchOptions, PendingFile, LockUnavailableError } from './sync';
 import { EXTRACTION_VERSION } from './extraction/extraction-version';
@@ -1234,6 +1236,75 @@ export class Atlas {
     options?: BuildContextOptions
   ): Promise<TaskContext | string> {
     return this.contextBuilder.buildContext(input, options);
+  }
+
+  // ===========================================================================
+  // Assets (atlas-extension-plan Rung 3)
+  //
+  // Human-attached knowledge lives in the graph as `kind: 'asset'` nodes with
+  // a companion `assets` row. These methods are the write path — they are
+  // deliberately NOT exposed over MCP (agents read but never write); Tempest
+  // wires them to a UI/CLI. Reads are exposed via `atlas_assets`,
+  // `atlas_asset_content`, and `atlas_semantic_search`.
+  // ===========================================================================
+
+  /**
+   * Attach a file as an asset. Idempotent — call again after the file changes
+   * to re-read its text and refresh the embed queue.
+   * @param sourcePath  absolute or project-root-relative path
+   * @param opts.name   optional display name (defaults to basename)
+   */
+  addAsset(sourcePath: string, opts?: { name?: string }): Asset {
+    const asset = assetsApi.addAsset(this.queries, this.projectRoot, sourcePath, opts);
+    // Kick embedding just like a sync would — asset text feeds the same channel.
+    this.scheduleEmbedding();
+    return asset;
+  }
+
+  /** Remove an asset entirely (edges cascade). Returns true if it existed. */
+  removeAsset(id: string): boolean {
+    return assetsApi.removeAsset(this.queries, id);
+  }
+
+  /** Link an asset to a code symbol via a `describes` edge. */
+  linkAsset(assetId: string, symbolId: string): void {
+    assetsApi.linkAsset(this.queries, assetId, symbolId);
+  }
+
+  /** Remove a `describes` edge. Returns true if the edge existed. */
+  unlinkAsset(assetId: string, symbolId: string): boolean {
+    return assetsApi.unlinkAsset(this.queries, assetId, symbolId);
+  }
+
+  /** List assets, optionally filtered by content-type prefix or linked symbol. */
+  listAssets(opts?: assetsApi.ListAssetsOptions): Asset[] {
+    return assetsApi.listAssets(this.queries, opts);
+  }
+
+  /** Full asset (including extracted text) by id. Null if missing. */
+  getAsset(id: string): Asset | null {
+    return assetsApi.getAssetContent(this.queries, id);
+  }
+
+  /** Symbol ids an asset is attached to. */
+  getAssetLinks(id: string): string[] {
+    return assetsApi.getAssetLinks(this.queries, id);
+  }
+
+  /** Deterministic asset id for a given source path (mirrors `addAsset`'s id). */
+  resolveAssetIdByPath(sourcePath: string): string {
+    return assetsApi.resolveAssetIdByPath(this.queries, this.projectRoot, sourcePath);
+  }
+
+  /**
+   * Top-K semantically nearest nodes across code + assets (Rung 3). Runs the
+   * shared vector channel used by `findRelevantContext`, without the graph
+   * traversal, so callers get ranked seed hits directly. Returns [] when
+   * no embedding model is available (FTS-only mode).
+   */
+  async semanticSearch(query: string, k: number = 10): Promise<Array<{ node: Node; score: number }>> {
+    const results = await computeVectorSeeds(this.queries, query, k);
+    return results.map((r) => ({ node: r.node, score: r.score }));
   }
 
   // ===========================================================================

--- a/packages/atlas/src/index.ts
+++ b/packages/atlas/src/index.ts
@@ -1254,9 +1254,10 @@ export class Atlas {
    * @param sourcePath  absolute or project-root-relative path
    * @param opts.name   optional display name (defaults to basename)
    */
-  addAsset(sourcePath: string, opts?: { name?: string }): Asset {
-    const asset = assetsApi.addAsset(this.queries, this.projectRoot, sourcePath, opts);
-    // Kick embedding just like a sync would — asset text feeds the same channel.
+  async addAsset(sourcePath: string, opts?: { name?: string }): Promise<Asset> {
+    const asset = await assetsApi.addAsset(this.queries, this.projectRoot, sourcePath, opts);
+    // Kick embedding just like a sync would — asset text (and any chunks split
+    // from long docs) feeds the same channel.
     this.scheduleEmbedding();
     return asset;
   }

--- a/packages/atlas/src/mcp/server-entry.ts
+++ b/packages/atlas/src/mcp/server-entry.ts
@@ -34,6 +34,14 @@ async function main(): Promise<void> {
   let semantic = false;
   let modelCache: string | undefined;
   let downloadModel = false;
+  // Asset write path (atlas-extension-plan Rung 3). Deliberately NOT exposed
+  // over MCP — agents read assets, humans/CLI write them. One flag per verb,
+  // consuming the next positional arg(s) so a Tauri host / shell script can
+  // shell out with the same syntax as `--init`.
+  let assetVerb: 'add' | 'remove' | 'link' | 'unlink' | 'list' | null = null;
+  let assetArg1: string | undefined;
+  let assetArg2: string | undefined;
+  let assetLinkedTo: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -55,6 +63,20 @@ async function main(): Promise<void> {
         modelCache = next;
         i++;
       }
+    } else if (arg === '--asset-add' || arg === '--asset-remove') {
+      assetVerb = arg === '--asset-add' ? 'add' : 'remove';
+      const next = args[i + 1];
+      if (next !== undefined) { assetArg1 = next; i++; }
+    } else if (arg === '--asset-link' || arg === '--asset-unlink') {
+      assetVerb = arg === '--asset-link' ? 'link' : 'unlink';
+      const a = args[i + 1];
+      const b = args[i + 2];
+      if (a !== undefined && b !== undefined) { assetArg1 = a; assetArg2 = b; i += 2; }
+    } else if (arg === '--asset-list') {
+      assetVerb = 'list';
+    } else if (arg === '--asset-linked-to') {
+      const next = args[i + 1];
+      if (next !== undefined) { assetLinkedTo = next; i++; }
     }
     // Ignore 'serve', '--mcp', and other flags the daemon spawner may pass
     // when re-invoking this script with ATLAS_DAEMON_INTERNAL=1.
@@ -86,6 +108,61 @@ async function main(): Promise<void> {
   }
 
   const resolvedPath = path.resolve(projectPath);
+
+  // Asset write-path mode. Opens the project, runs the verb, prints the
+  // result JSON on stdout, and exits. Never starts an MCP server.
+  if (assetVerb) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('../index') as typeof import('../index');
+    if (!mod.isInitialized(resolvedPath)) {
+      process.stderr.write(`[Atlas] project not initialized at ${resolvedPath} — run --init first\n`);
+      process.exitCode = 1;
+      return;
+    }
+    let instance: import('../index').Atlas | undefined;
+    try {
+      instance = await mod.default.open(resolvedPath);
+      let output: unknown;
+      switch (assetVerb) {
+        case 'add': {
+          if (!assetArg1) throw new Error('--asset-add requires a file path');
+          output = await instance.addAsset(assetArg1);
+          break;
+        }
+        case 'remove': {
+          if (!assetArg1) throw new Error('--asset-remove requires an id or path');
+          const id = assetArg1.startsWith('asset:')
+            ? assetArg1
+            : instance.resolveAssetIdByPath(assetArg1);
+          output = { removed: instance.removeAsset(id), id };
+          break;
+        }
+        case 'link': {
+          if (!assetArg1 || !assetArg2) throw new Error('--asset-link requires <asset-id> <symbol-id>');
+          instance.linkAsset(assetArg1, assetArg2);
+          output = { linked: true, asset: assetArg1, symbol: assetArg2 };
+          break;
+        }
+        case 'unlink': {
+          if (!assetArg1 || !assetArg2) throw new Error('--asset-unlink requires <asset-id> <symbol-id>');
+          output = { unlinked: instance.unlinkAsset(assetArg1, assetArg2), asset: assetArg1, symbol: assetArg2 };
+          break;
+        }
+        case 'list': {
+          output = instance.listAssets(assetLinkedTo ? { linkedTo: assetLinkedTo } : undefined);
+          break;
+        }
+      }
+      process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+      process.exitCode = 0;
+    } catch (err) {
+      process.stderr.write(`[Atlas] asset ${assetVerb} failed: ${err}\n`);
+      process.exitCode = 1;
+    } finally {
+      try { instance?.close(); } catch { /* best-effort */ }
+    }
+    return;
+  }
 
   if (initMode) {
     process.stderr.write(`[Atlas] --init for ${resolvedPath}\n`);

--- a/packages/atlas/src/mcp/tools.ts
+++ b/packages/atlas/src/mcp/tools.ts
@@ -669,6 +669,62 @@ export const tools: ToolDefinition[] = [
     annotations: READ_ONLY_ANNOTATIONS,
   },
   {
+    name: 'atlas_assets',
+    description: "List human-attached knowledge (markdown notes, docs) in the graph. Assets are files a developer explicitly attached to the codebase via addAsset — treat their presence as intentional context, not a scan of the disk. Filter by contentType prefix (e.g. 'text/') or linkedTo a symbol id to see notes attached to a specific piece of code.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contentType: {
+          type: 'string',
+          description: "MIME prefix filter (e.g. 'text/markdown', 'text/'). Omit to list all.",
+        },
+        linkedTo: {
+          type: 'string',
+          description: 'Symbol node id — return only assets attached to that symbol via a `describes` edge.',
+        },
+        projectPath: projectPathProperty,
+      },
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  {
+    name: 'atlas_asset_content',
+    description: 'Return the extracted text of an asset by id. Use this after atlas_assets picks the right one. Content is already capped at attach time — no pagination.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Asset id (from atlas_assets).',
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['id'],
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  {
+    name: 'atlas_semantic_search',
+    description: 'Pure vector-similarity search across code symbols AND attached assets. Skips the graph traversal — use when you want ranked candidates directly (e.g. "find notes and code about auth session expiry"). Requires the embedding model; returns an informational message when semantic search is off.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Natural-language query.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Max results (default: 10, max: 50).',
+          default: 10,
+        },
+        projectPath: projectPathProperty,
+      },
+      required: ['query'],
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  {
     name: 'atlas_status',
     description: 'Index health check (files / nodes / edges). Skip unless debugging.',
     inputSchema: {
@@ -1448,6 +1504,9 @@ export class ToolHandler {
       case 'atlas_explore': return await this.handleExplore(args);
       case 'atlas_node': return await this.handleNode(args);
       case 'atlas_files': return await this.handleFiles(args);
+      case 'atlas_assets': return await this.handleAssets(args);
+      case 'atlas_asset_content': return await this.handleAssetContent(args);
+      case 'atlas_semantic_search': return await this.handleSemanticSearch(args);
       default: return this.errorResult(`Unknown tool: ${toolName}`);
     }
   }
@@ -1488,6 +1547,78 @@ export class ToolHandler {
 
     const formatted = this.formatSearchResults(ranked);
     return this.textResult(this.truncateOutput(formatted));
+  }
+
+  /**
+   * Handle atlas_assets — list human-attached assets.
+   */
+  private async handleAssets(args: Record<string, unknown>): Promise<ToolResult> {
+    const cg = this.getAtlas(args.projectPath as string | undefined);
+    const contentType = typeof args.contentType === 'string' ? args.contentType : undefined;
+    const linkedTo = typeof args.linkedTo === 'string' ? args.linkedTo : undefined;
+
+    const assets = cg.listAssets({ contentType, linkedTo });
+    if (assets.length === 0) {
+      const filter = linkedTo ? ` linked to ${linkedTo}` : contentType ? ` of type "${contentType}"` : '';
+      return this.textResult(`No assets found${filter}. Attach one via the Atlas.addAsset() API.`);
+    }
+
+    const lines = [`${assets.length} asset${assets.length === 1 ? '' : 's'}:`, ''];
+    for (const a of assets) {
+      const links = cg.getAssetLinks(a.id);
+      const attached = links.length > 0 ? ` — attached to ${links.length} symbol${links.length === 1 ? '' : 's'}` : '';
+      lines.push(`- **${a.name}** (${a.contentType})${attached}`);
+      lines.push(`  path: ${a.sourcePath}`);
+      lines.push(`  id: \`${a.id}\``);
+    }
+    return this.textResult(this.truncateOutput(lines.join('\n')));
+  }
+
+  /**
+   * Handle atlas_asset_content — return the extracted text of one asset.
+   */
+  private async handleAssetContent(args: Record<string, unknown>): Promise<ToolResult> {
+    const id = this.validateString(args.id, 'id');
+    if (typeof id !== 'string') return id;
+
+    const cg = this.getAtlas(args.projectPath as string | undefined);
+    const asset = cg.getAsset(id);
+    if (!asset) {
+      return this.textResult(`Asset not found: ${id}`);
+    }
+    if (asset.extractedText == null) {
+      return this.textResult(`Asset "${asset.name}" (${asset.contentType}) has no extracted text (binary or unsupported type).\nPath: ${asset.sourcePath}`);
+    }
+    const header = `# ${asset.name}\n_${asset.contentType} — ${asset.sourcePath}_\n\n`;
+    return this.textResult(this.truncateOutput(header + asset.extractedText));
+  }
+
+  /**
+   * Handle atlas_semantic_search — vector similarity across code + assets.
+   */
+  private async handleSemanticSearch(args: Record<string, unknown>): Promise<ToolResult> {
+    const query = this.validateString(args.query, 'query');
+    if (typeof query !== 'string') return query;
+
+    const cg = this.getAtlas(args.projectPath as string | undefined);
+    const rawLimit = Number(args.limit) || 10;
+    const limit = clamp(rawLimit, 1, 50);
+
+    const results = await cg.semanticSearch(query, limit);
+    if (results.length === 0) {
+      return this.textResult(
+        `No semantic results for "${query}". Semantic search requires the Atlas embedding model — ` +
+          `if you disabled it, re-enable in settings, or fall back to atlas_search (keyword) / atlas_explore (hybrid).`
+      );
+    }
+
+    const lines = [`${results.length} semantic hit${results.length === 1 ? '' : 's'} for "${query}":`, ''];
+    for (const { node, score } of results) {
+      const badge = node.kind === 'asset' ? '📄 asset' : node.kind;
+      const loc = node.startLine ? `:${node.startLine}` : '';
+      lines.push(`- [${badge}] **${node.name}** — ${node.filePath}${loc}  _(score ${score.toFixed(3)})_`);
+    }
+    return this.textResult(this.truncateOutput(lines.join('\n')));
   }
 
   /**

--- a/packages/atlas/src/types.ts
+++ b/packages/atlas/src/types.ts
@@ -38,6 +38,7 @@ export const NODE_KINDS = [
   'export',
   'route',
   'component',
+  'asset',
 ] as const;
 
 export type NodeKind = (typeof NODE_KINDS)[number];
@@ -57,7 +58,8 @@ export type EdgeKind =
   | 'returns'         // Function returns type
   | 'instantiates'    // Creates instance of class
   | 'overrides'       // Method overrides parent method
-  | 'decorates';      // Decorator applied to symbol
+  | 'decorates'       // Decorator applied to symbol
+  | 'describes';      // Asset node describes a code symbol (atlas-extension-plan Rung 3)
 
 /**
  * Supported programming languages. See NODE_KINDS for why this is a
@@ -99,6 +101,32 @@ export const LANGUAGES = [
 ] as const;
 
 export type Language = (typeof LANGUAGES)[number];
+
+// =============================================================================
+// Assets (atlas-extension-plan Rung 3)
+// =============================================================================
+
+/**
+ * Human-attached knowledge (markdown notes, docs, design snippets) that lives
+ * in the graph next to code. Assets are stored as rows in `nodes` with
+ * `kind: 'asset'` (reusing FTS, edges FK, and the embedding sync pipeline);
+ * the `assets` companion table holds asset-only extras. Link an asset to a
+ * code symbol with a `describes` edge.
+ */
+export interface Asset {
+  /** Node id (stable hash of source path). */
+  id: string;
+  /** Filename or user-provided label. */
+  name: string;
+  /** Path relative to project root. */
+  sourcePath: string;
+  /** MIME-ish type: 'text/markdown', 'text/plain', 'application/json', ... */
+  contentType: string;
+  /** Plain text extracted from the source (null for binary/unsupported types). */
+  extractedText: string | null;
+  /** Unix ms timestamp. */
+  updatedAt: number;
+}
 
 // =============================================================================
 // Core Graph Types


### PR DESCRIPTION
## Summary
- **Rung 3 base** (`e45a2e2`): asset nodes live as `nodes` rows with `kind='asset'` + companion `assets` table; new `describes` edge (EXTRACTED tier) links assets to code; migration v9.
- **Rung 3 finish** (`82347c4`): `asset_chunks` (migration v10) with 1500-char slices + 100-char overlap; chunk hits roll up to parent asset in vector seed computation; `pdf-parse` as optionalDependency for PDF text extraction; `server-entry.ts` CLI flags (`--asset-add` / `--asset-remove` / `--asset-link` / `--asset-unlink` / `--asset-list`) — JSON on stdout, never exposed over MCP.
- Three MCP read tools already wired in `tools.ts`: `atlas_assets`, `atlas_asset_content`, `atlas_semantic_search`.

## Test plan
- [x] `packages/atlas` builds clean (`tsc`)
- [x] `packages/atlas` tests pass (`vitest run` — `__tests__/assets.test.ts` covers the chunking path)
- [x] After merge + npm publish, MCP client sees the three new atlas tools
- [x] `--asset-add` on a markdown file indexes + links; `atlas_explore` surfaces the asset alongside linked code
- [x] Long doc (>1500 chars) chunks; vector search returns parent asset