### PR TITLE
feat(automations): revamp detail page + shadcn style schedule picker

### DIFF
--- a/src-tauri/src/automations.rs
+++ b/src-tauri/src/automations.rs
@@ -2,14 +2,6 @@ use std::path::PathBuf;
 use serde::{Serialize, Deserialize};
 use tauri::Emitter;
 
-fn home_dir_cwd() -> String {
-    #[cfg(windows)]
-    let key = "USERPROFILE";
-    #[cfg(not(windows))]
-    let key = "HOME";
-    std::env::var(key).unwrap_or_else(|_| ".".into())
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Automation {
     pub id: String,
@@ -355,67 +347,6 @@ pub fn save_prompt_version(
     Ok(())
 }
 
-/// Fire an agent CLI as a detached background subprocess for an automation run.
-/// No PTY, no session/tab — automations are jobs, not interactive workspaces.
-///
-/// Args are quoted with single quotes for pwsh / sh (matches create_pty_session)
-/// and joined into a shell -c string. stdin/stdout/stderr are closed so the
-/// child neither reads nor spams the parent. A watcher thread emits
-/// `automation:done` when the child exits so the frontend can flip the run
-/// status to success/failed.
-///
-/// An empty cwd falls back to the user's home dir — used by global-scope
-/// automations that aren't tied to any project.
-#[tauri::command(async)]
-pub fn run_automation_command(
-    app: tauri::AppHandle,
-    run_id: String,
-    cwd: String,
-    program: String,
-    args: Vec<String>,
-) -> Result<(), String> {
-    let cwd = if cwd.trim().is_empty() { home_dir_cwd() } else { cwd };
-
-    let mut parts: Vec<String> = vec![program];
-    for arg in &args {
-        if arg.is_empty() || arg.contains(' ') || arg.contains('\'') || arg.contains('\n') {
-            // Single-quote-escape for pwsh / POSIX sh. Matches create_pty_session.
-            parts.push(format!("'{}'", arg.replace('\'', "'''")));
-        } else {
-            parts.push(arg.clone());
-        }
-    }
-    let invocation = parts.join(" ");
-
-    #[cfg(windows)]
-    let spawn_result = std::process::Command::new("powershell")
-        .args(["-NoLogo", "-NoProfile", "-Command", &invocation])
-        .current_dir(&cwd)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
-    #[cfg(not(windows))]
-    let spawn_result = std::process::Command::new("sh")
-        .args(["-c", &invocation])
-        .current_dir(&cwd)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
-
-    let mut child = spawn_result.map_err(|e| e.to_string())?;
-
-    std::thread::spawn(move || {
-        let ok = child.wait().map(|s| s.success()).unwrap_or(false);
-        let _ = app.emit("automation:done", serde_json::json!({
-            "runId": run_id,
-            "ok": ok,
-        }));
-    });
-
-    Ok(())
-}
 
 pub fn start_scheduler(app: tauri::AppHandle, db_path: PathBuf) {
     std::thread::spawn(move || {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4195,7 +4195,6 @@ pub fn run() {
             automations::upsert_automation_run,
             automations::list_prompt_versions,
             automations::save_prompt_version,
-            automations::run_automation_command,
             claude_bridge::claude_stream_start,
             claude_bridge::claude_permission_decision,
             claude_bridge::claude_stream_cancel,

--- a/src/components/Automations/AutomationDetailPage.tsx
+++ b/src/components/Automations/AutomationDetailPage.tsx
@@ -1,23 +1,25 @@
 import { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { ChevronLeft, Clock, Loader, Play, RotateCcw } from "lucide-react";
+import { ChevronLeft, Loader, Play } from "lucide-react";
 import {
-  type Automation, type AutomationRun, type PromptVersion,
-  updateAutomation, listAutomationRuns, upsertAutomationRun,
-  listPromptVersions, savePromptVersion,
+  type Automation, type AutomationRun,
+  updateAutomation, listAutomationRuns, runAutomationNow,
 } from "../../store/automations";
 import { SchedulePicker } from "./SchedulePicker";
-import { promptBucketAt, computeNextRunAt, humanizeRrule } from "../../lib/automationSchedule";
+import { computeNextRunAt, humanizeRrule } from "../../lib/automationSchedule";
 import { useAgents, getAgent } from "../../lib/agentRegistry";
 import { SpSelect } from "../ui/SpSelect";
 import { AgentIcon } from "../NewSessionMenu";
+import { TerminalPane, type TerminalPaneHandle } from "../TerminalPane";
+import { sessionManager } from "../../store/sessionManager";
 
 interface Props {
   automation: Automation;
   onBack: () => void;
-  onRunNow: (a: Automation) => void;
   onUpdate: (a: Automation) => void;
 }
+
+// ponytail: in-memory only, resets on app reload — persist to localStorage if that matters.
+const clearedTerminals = new Set<string>();
 
 function timeAgo(iso: string): string {
   const s = (Date.now() - new Date(iso).getTime()) / 1000;
@@ -27,20 +29,27 @@ function timeAgo(iso: string): string {
   return `${Math.floor(s / 86400)}d ago`;
 }
 
-export function AutomationDetailPage({ automation, onBack, onRunNow, onUpdate }: Props) {
+export function AutomationDetailPage({ automation, onBack, onUpdate }: Props) {
   const agents = useAgents();
   const [prompt, setPrompt] = useState(automation.prompt);
   const [schedule, setSchedule] = useState(automation.schedule);
   const [modelDraft, setModelDraft] = useState(automation.model ?? "");
   const [runs, setRuns] = useState<AutomationRun[]>([]);
-  const [versions, setVersions] = useState<PromptVersion[]>([]);
-  const [showVersions, setShowVersions] = useState(false);
   const [runningNow, setRunningNow] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  // Which run's PTY the terminal panel is showing. Set on Run Now, and on mount
+  // to the most recent run that still has a live sessionManager buffer.
+  const [terminalRunId, setTerminalRunId] = useState<string | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const termRef = useRef<TerminalPaneHandle | null>(null);
 
   useEffect(() => {
-    listAutomationRuns(automation.id).then(setRuns);
-    listPromptVersions(automation.id).then(setVersions);
+    listAutomationRuns(automation.id).then((rs) => {
+      setRuns(rs);
+      if (clearedTerminals.has(automation.id)) return;
+      const live = rs.find((r) => sessionManager.has(r.id));
+      if (live) setTerminalRunId(live.id);
+    });
   }, [automation.id]);
 
   function scheduleDebounce(newPrompt: string, newSchedule: string) {
@@ -48,9 +57,6 @@ export function AutomationDetailPage({ automation, onBack, onRunNow, onUpdate }:
     saveTimer.current = setTimeout(async () => {
       const updated = await updateAutomation(automation.id, { prompt: newPrompt, schedule: newSchedule });
       onUpdate(updated);
-      await savePromptVersion({ automationId: automation.id, prompt: newPrompt, bucketAt: promptBucketAt() });
-      const fresh = await listPromptVersions(automation.id);
-      setVersions(fresh);
     }, 800);
   }
 
@@ -81,23 +87,18 @@ export function AutomationDetailPage({ automation, onBack, onRunNow, onUpdate }:
 
   async function handleRunNow() {
     setRunningNow(true);
-    const runId = crypto.randomUUID();
-    const run: AutomationRun = { id: runId, automationId: automation.id, status: "dispatching", triggeredBy: "manual" };
-    await upsertAutomationRun(run);
-    setRuns((prev) => [run, ...prev]);
-    onRunNow(automation);
-    await upsertAutomationRun({ ...run, status: "dispatched" });
-    setRuns((prev) => prev.map((r) => r.id === runId ? { ...r, status: "dispatched" } : r));
-    setRunningNow(false);
-  }
-
-  async function handleRestore(v: PromptVersion) {
-    setPrompt(v.prompt);
-    setShowVersions(false);
-    await updateAutomation(automation.id, { prompt: v.prompt });
-    await savePromptVersion({ automationId: automation.id, prompt: v.prompt, source: "restore", bucketAt: promptBucketAt() });
-    const fresh = await listPromptVersions(automation.id);
-    setVersions(fresh);
+    setRunError(null);
+    try {
+      const runId = await runAutomationNow(automation, "manual");
+      clearedTerminals.delete(automation.id);
+      setTerminalRunId(runId);
+      // Refresh run list so the new "dispatched" row shows up in the sidebar.
+      listAutomationRuns(automation.id).then(setRuns);
+    } catch (e) {
+      setRunError(String((e as { message?: string })?.message ?? e));
+    } finally {
+      setRunningNow(false);
+    }
   }
 
   return (
@@ -110,10 +111,6 @@ export function AutomationDetailPage({ automation, onBack, onRunNow, onUpdate }:
         <span className="am-builder-sep">/</span>
         <span className="am-builder-name">{automation.name}</span>
         <div className="am-detail-topbar-actions">
-          <button className="am-act" onClick={() => setShowVersions(true)} title="Version history">
-            <Clock size={13} />
-            History
-          </button>
           <button
             className="am-act am-act--primary"
             onClick={() => void handleRunNow()}
@@ -139,8 +136,28 @@ export function AutomationDetailPage({ automation, onBack, onRunNow, onUpdate }:
             value={prompt}
             onChange={(e) => handlePromptChange(e.target.value)}
             placeholder="What should the agent do each time this runs?"
-            rows={12}
+            rows={6}
           />
+
+          <div className="am-label-row" style={{ marginTop: 20 }}>
+            <label className="am-field-label" style={{ marginBottom: 0 }}>Output</label>
+            {terminalRunId && sessionManager.has(terminalRunId) && (
+              <button
+                type="button"
+                className="am-label-action"
+                onClick={() => { clearedTerminals.add(automation.id); setTerminalRunId(null); }}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          <div className={`am-terminal-panel${terminalRunId && sessionManager.has(terminalRunId) ? "" : " am-terminal-panel--muted"}`}>
+            {terminalRunId && sessionManager.has(terminalRunId) ? (
+              <TerminalPane ref={termRef} key={terminalRunId} sessionId={terminalRunId} isAgent readOnly />
+            ) : (
+              <div className="am-terminal-idle">No run in progress</div>
+            )}
+          </div>
         </div>
 
         <div className="am-detail-sidebar">
@@ -187,43 +204,29 @@ export function AutomationDetailPage({ automation, onBack, onRunNow, onUpdate }:
               <div className="am-sidebar-empty">No runs yet</div>
             ) : (
               <div className="am-run-list">
-                {runs.slice(0, 8).map((r) => (
-                  <div key={r.id} className="am-run-item">
-                    <span className={`am-run-badge am-run-badge--${r.status}`}>{r.status}</span>
-                    <span className="am-run-meta">{r.createdAt ? timeAgo(r.createdAt) : ""}</span>
-                  </div>
-                ))}
+                {runs.slice(0, 8).map((r) => {
+                  const live = sessionManager.has(r.id);
+                  const isActive = terminalRunId === r.id;
+                  return (
+                    <div
+                      key={r.id}
+                      className={`am-run-item${live ? " am-run-item--clickable" : ""}${isActive ? " am-run-item--active" : ""}`}
+                      onClick={live ? () => { clearedTerminals.delete(automation.id); setTerminalRunId(r.id); } : undefined}
+                      role={live ? "button" : undefined}
+                    >
+                      <span className={`am-run-badge am-run-badge--${r.status}`}>{r.status}</span>
+                      <span className="am-run-meta">{r.createdAt ? timeAgo(r.createdAt) : ""}</span>
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>
         </div>
       </div>
 
-      {showVersions && createPortal(
-        <div className="am-versions-overlay" onClick={() => setShowVersions(false)}>
-          <div className="am-versions-sheet" onClick={(e) => e.stopPropagation()}>
-            <div className="am-versions-header">
-              <RotateCcw size={14} />
-              <span>Version history</span>
-              <button className="am-versions-close" onClick={() => setShowVersions(false)}>✕</button>
-            </div>
-            <div className="am-versions-list">
-              {versions.length === 0 ? (
-                <div className="am-versions-empty">No saved versions yet</div>
-              ) : versions.map((v) => (
-                <div key={v.id} className="am-version-item">
-                  <div className="am-version-meta">
-                    <span className="am-version-bucket">{v.bucketAt}</span>
-                    <span className="am-version-source">{v.source}</span>
-                  </div>
-                  <pre className="am-version-prompt">{v.prompt.slice(0, 120)}{v.prompt.length > 120 ? "…" : ""}</pre>
-                  <button className="am-act" onClick={() => void handleRestore(v)}>Restore</button>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>,
-        document.body,
+      {runError && (
+        <div className="am-run-error" role="alert">{runError}</div>
       )}
     </div>
   );

--- a/src/components/Automations/AutomationsList.tsx
+++ b/src/components/Automations/AutomationsList.tsx
@@ -5,6 +5,8 @@ import type { StoredProject } from "../../store/openProjects";
 import { type Automation, loadAutomations, updateAutomation, deleteAutomation } from "../../store/automations";
 import { CreateAutomationDialog } from "./CreateAutomationDialog";
 import { humanizeRrule } from "../../lib/automationSchedule";
+import { AgentIcon } from "../NewSessionMenu";
+import { getAgent } from "../../lib/agentRegistry";
 
 interface Props {
   projects: StoredProject[];
@@ -119,6 +121,7 @@ export function AutomationsList({ projects, scope, onSelectScope, onOpen }: Prop
                 <th className="am-th"></th>
                 <th className="am-th">Name</th>
                 <th className="am-th">Agent</th>
+                <th className="am-th">Model</th>
                 <th className="am-th">Schedule</th>
                 <th className="am-th">Next run</th>
                 <th className="am-th">Enabled</th>
@@ -132,7 +135,13 @@ export function AutomationsList({ projects, scope, onSelectScope, onOpen }: Prop
                     <span className={`am-dot ${a.enabled ? "am-dot--running" : "am-dot--idle"}`} />
                   </td>
                   <td className="am-td am-td--name">{a.name}</td>
-                  <td className="am-td am-td--agent">{a.agent}</td>
+                  <td className="am-td am-td--agent">
+                    <span className="am-agent-badge">
+                      <AgentIcon hint={a.agent} size={12} />
+                      <span className="am-agent-badge-label">{getAgent(a.agent)?.name ?? a.agent}</span>
+                    </span>
+                  </td>
+                  <td className="am-td am-td--model">{a.model || "—"}</td>
                   <td className="am-td am-td--schedule">{humanizeRrule(a.schedule)}</td>
                   <td className="am-td am-td--next">{fmtDate(a.nextRunAt)}</td>
                   <td className="am-td am-td--toggle" onClick={(e) => e.stopPropagation()}>

--- a/src/components/Automations/AutomationsPage.css
+++ b/src/components/Automations/AutomationsPage.css
@@ -1,4 +1,4 @@
-/* ── Root ─────────────────────────────────────────────────────────────────── */
+﻿/* -- Root ------------------------------------------------------------------- */
 
 .am-root {
   flex: 1;
@@ -16,7 +16,7 @@
   font-family: "Geist", sans-serif !important;
 }
 
-/* ── Header ───────────────────────────────────────────────────────────────── */
+/* -- Header ----------------------------------------------------------------- */
 
 .am-header {
   flex-shrink: 0;
@@ -57,7 +57,7 @@
 
 .am-header-right { display: flex; align-items: center; gap: 8px; }
 
-/* ── Tabs ─────────────────────────────────────────────────────────────────── */
+/* -- Tabs ------------------------------------------------------------------- */
 
 .am-tabs {
   flex-shrink: 0;
@@ -65,7 +65,7 @@
   align-items: center;
   gap: 4px;
   padding: 10px 40px 0;
-  border-bottom: 1px solid var(--tempest-border);
+  border-bottom: 1px solid var(--tempest-border-default);
   overflow-x: auto;
 }
 
@@ -104,7 +104,7 @@
 .am-tab-icon { opacity: 0.7; }
 .am-tab-label { max-width: 140px; overflow: hidden; text-overflow: ellipsis; }
 
-/* ── New button ───────────────────────────────────────────────────────────── */
+/* -- New button ------------------------------------------------------------- */
 
 .am-new-btn {
   display: inline-flex;
@@ -124,7 +124,7 @@
 .am-new-btn:hover { opacity: 0.9; }
 .am-new-btn:focus-visible { outline: 2px solid var(--tempest-accent); outline-offset: 2px; }
 
-/* ── List / table ─────────────────────────────────────────────────────────── */
+/* -- List / table ----------------------------------------------------------- */
 
 .am-list {
   flex: 1;
@@ -143,24 +143,40 @@
   color: var(--tempest-fg-subtle);
   font-weight: 500;
   font-size: 11px;
-  border-bottom: 1px solid var(--tempest-border);
+  border-bottom: 1px solid var(--tempest-border-default);
   white-space: nowrap;
 }
 .am-tr {
   cursor: pointer;
-  border-bottom: 1px solid var(--tempest-border);
+  border-bottom: 1px solid var(--tempest-border-default);
 }
 .am-tr:hover td { background: var(--tempest-bg-hover); }
 .am-td { padding: 10px 12px; color: var(--tempest-fg-default); vertical-align: middle; }
 .am-td--dot { width: 24px; padding-right: 0; }
 .am-td--name { font-weight: 500; }
-.am-td--agent { color: var(--tempest-fg-subtle); font-family: "Geist Mono", monospace; font-size: 11px; }
+.am-td--agent { color: var(--tempest-fg-subtle); font-size: 11px; }
+.am-agent-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 10px 0 6px;
+  border-radius: 9999px;
+  border: 1px solid var(--tempest-border-default);
+  background: var(--tempest-bg-hover);
+  color: var(--tempest-fg-default);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+.am-agent-badge-label { display: inline-block; }
 .am-td--schedule { color: var(--tempest-fg-muted); font-size: 12px; }
 .am-td--next { color: var(--tempest-fg-muted); font-size: 12px; }
 .am-td--toggle { width: 48px; }
 .am-td--actions { width: 40px; text-align: right; }
 
-/* ── Status dot ───────────────────────────────────────────────────────────── */
+/* -- Status dot ------------------------------------------------------------- */
 
 .am-dot {
   display: inline-block;
@@ -172,18 +188,19 @@
 .am-dot--running { background: #22c55e; }
 .am-dot--idle    { background: var(--tempest-fg-subtle); opacity: 0.5; }
 
-/* ── Toggle switch ────────────────────────────────────────────────────────── */
+/* -- Toggle switch ---------------------------------------------------------- */
 
 .am-toggle { position: relative; display: inline-block; width: 32px; height: 18px; }
 .am-toggle input { opacity: 0; width: 0; height: 0; }
 .am-toggle-track {
   position: absolute;
   inset: 0;
-  border-radius: 9px;
-  background: var(--tempest-bg-hover);
-  border: 1px solid var(--tempest-border);
+  border-radius: 9999px;
+  background: var(--tempest-fg-muted);
+  border: 0.5px solid var(--tempest-border-default);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
+  opacity: 0.5;
 }
 .am-toggle-track::after {
   content: "";
@@ -194,13 +211,19 @@
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  background: var(--tempest-fg-subtle);
-  transition: transform 0.15s, background 0.15s;
+  background: var(--tempest-bg-editor);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s;
 }
-.am-toggle input:checked + .am-toggle-track { background: var(--tempest-accent); border-color: var(--tempest-accent); }
-.am-toggle input:checked + .am-toggle-track::after { transform: translate(14px, -50%); background: #fff; }
+[data-theme="dark"] .am-toggle-track::after { background: var(--tempest-fg-default); }
+.am-toggle input:checked + .am-toggle-track {
+  background: var(--tempest-accent-green);
+  border-color: var(--tempest-border-default);
+  opacity: 1;
+}
+.am-toggle input:checked + .am-toggle-track::after { transform: translate(14px, -50%); }
 
-/* ── Action buttons ───────────────────────────────────────────────────────── */
+/* -- Action buttons --------------------------------------------------------- */
 
 .am-act {
   display: inline-flex;
@@ -208,7 +231,7 @@
   gap: 6px;
   height: 28px;
   padding: 0 10px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 6px;
   background: transparent;
   color: var(--tempest-fg-default);
@@ -229,7 +252,7 @@
 }
 .am-act--primary:hover { opacity: 0.9; background: var(--tempest-fg-default); }
 
-/* ── Loading / empty ──────────────────────────────────────────────────────── */
+/* -- Loading / empty -------------------------------------------------------- */
 
 .am-loading { display: flex; justify-content: center; padding: 48px; }
 .am-spin { animation: am-spin 0.8s linear infinite; }
@@ -262,7 +285,7 @@
 }
 .am-empty-cta:hover { opacity: 0.9; }
 
-/* ── Builder topbar ───────────────────────────────────────────────────────── */
+/* -- Builder topbar --------------------------------------------------------- */
 
 .am-builder-topbar {
   flex-shrink: 0;
@@ -270,7 +293,7 @@
   align-items: center;
   gap: 8px;
   padding: 10px 20px;
-  border-bottom: 1px solid var(--tempest-border);
+  border-bottom: 1px solid var(--tempest-border-default);
   background: var(--tempest-bg-editor);
 }
 .am-back-btn {
@@ -288,7 +311,7 @@
 .am-builder-name { font-size: 13px; font-weight: 500; color: var(--tempest-fg-default); }
 .am-detail-topbar-actions { margin-left: auto; display: flex; gap: 8px; }
 
-/* ── Detail layout ────────────────────────────────────────────────────────── */
+/* -- Detail layout ---------------------------------------------------------- */
 
 .am-detail-layout {
   flex: 1;
@@ -309,7 +332,7 @@
 .am-detail-sidebar {
   width: 240px;
   flex-shrink: 0;
-  border-left: 1px solid var(--tempest-border);
+  border-left: 1px solid var(--tempest-border-default);
   padding: 20px 16px;
   overflow-y: auto;
   display: flex;
@@ -322,13 +345,14 @@
 .am-sidebar-value { font-size: 12px; color: var(--tempest-fg-muted); }
 .am-sidebar-empty { font-size: 12px; color: var(--tempest-fg-subtle); }
 
-/* ── Prompt editor ────────────────────────────────────────────────────────── */
+/* -- Prompt editor ---------------------------------------------------------- */
 
 .am-prompt-editor {
-  flex: 1;
-  resize: vertical;
+  resize: none;
+  max-height: 150px;
+  overflow-y: auto;
   padding: 12px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 8px;
   background: var(--tempest-bg-elevated);
   color: var(--tempest-fg-default);
@@ -336,9 +360,9 @@
   font-size: 13px;
   line-height: 1.6;
 }
-.am-prompt-editor:focus { outline: none; border-color: var(--tempest-accent); }
+.am-prompt-editor:focus { outline: none; }
 
-/* ── Field helpers ────────────────────────────────────────────────────────── */
+/* -- Field helpers ---------------------------------------------------------- */
 
 .am-field-label {
   display: block;
@@ -349,12 +373,29 @@
 }
 .am-field-hint { font-size: 11px; color: var(--tempest-fg-subtle); margin-top: 4px; display: block; }
 
+.am-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.am-label-action {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 12px;
+  color: var(--tempest-fg-muted);
+  cursor: pointer;
+}
+.am-label-action:hover { color: var(--tempest-fg-default); }
+
 .am-field-input,
 .am-field-select,
 .am-field-textarea {
   width: 100%;
   padding: 8px 10px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 6px;
   background: var(--tempest-bg-editor);
   color: var(--tempest-fg-default);
@@ -372,10 +413,10 @@
 }
 .am-field-textarea { resize: vertical; line-height: 1.5; }
 
-/* ── Run list ─────────────────────────────────────────────────────────────── */
+/* -- Run list --------------------------------------------------------------- */
 
-.am-run-list { display: flex; flex-direction: column; gap: 6px; }
-.am-run-item { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.am-run-list { display: flex; flex-direction: column; gap: 12px; }
+.am-run-item { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12px; }
 .am-run-meta { color: var(--tempest-fg-subtle); font-size: 11px; }
 
 .am-run-badge {
@@ -390,19 +431,75 @@
 }
 .am-run-badge--dispatched    { background: #dcfce7; color: #166534; }
 .am-run-badge--dispatching   { background: #fef9c3; color: #854d0e; }
+.am-run-badge--succeeded     { background: #dcfce7; color: #166534; }
+.am-run-badge--failed        { background: #fee2e2; color: #991b1b; }
 .am-run-badge--dispatch_failed { background: #fee2e2; color: #991b1b; }
 
-/* ── Schedule picker (shadcn-flavored) ────────────────────────────────────── */
+.am-run-item--clickable { cursor: pointer; padding: 4px 6px; margin: -4px -6px; border-radius: 4px; }
+.am-run-item--clickable:hover { background: var(--tempest-bg-hover); }
+.am-run-item--active { background: var(--tempest-bg-active); }
+
+/* -- Terminal panel (live run output) --------------------------------------- */
+
+.am-run-error {
+  margin: 12px 24px 0;
+  padding: 8px 12px;
+  border: 1px solid #fca5a5;
+  background: #fef2f2;
+  color: #991b1b;
+  border-radius: 6px;
+  font-size: 12px;
+  font-family: "Geist Mono", monospace;
+}
+
+.am-terminal-panel {
+  flex: 1;
+  min-height: 240px;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 8px;
+  background: var(--tempest-bg-editor);
+  overflow: hidden;
+  position: relative;
+}
+.am-terminal-panel--muted { opacity: 0.55; }
+.am-terminal-panel .terminal-pane-wrapper { position: absolute; inset: 0; }
+.am-terminal-idle {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  color: var(--tempest-fg-subtle);
+}
+
+/* -- Schedule picker (shadcn-flavored) -------------------------------------- */
 
 .sched { display: flex; flex-direction: column; gap: 10px; }
 
-.sched-row { display: flex; align-items: center; gap: 8px; }
-.sched-label { font-size: 12px; color: var(--tempest-fg-muted); }
+.sched-row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  align-items: center;
+  gap: 12px;
+  min-height: 32px;
+}
+.sched-lbl { font-size: 12px; color: var(--tempest-fg-muted); }
+.sched-ctrl { min-width: 0; }
+.sched-ctrl-inline { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.sched-unit { font-size: 12px; color: var(--tempest-fg-muted); }
+.sched-tz {
+  font-size: 11px;
+  color: var(--tempest-fg-subtle);
+  padding-left: 2px;
+  font-variant-numeric: tabular-nums;
+}
 
-.sched-num, .sched-time {
+.sched-num, .sched-time-input {
   height: 30px;
   padding: 0 10px;
-  border: 1px solid var(--tempest-border-default, var(--tempest-border));
+  border: 1px solid var(--tempest-border-default);
   border-radius: 6px;
   background: var(--tempest-bg-elevated);
   color: var(--tempest-fg-default);
@@ -410,17 +507,24 @@
   font-family: inherit;
   transition: border-color 0.1s, box-shadow 0.1s;
 }
-.sched-num { width: 68px; }
-.sched-num:focus, .sched-time:focus {
+.sched-num { width: 72px; }
+.sched-time-input { width: 110px; font-variant-numeric: tabular-nums; letter-spacing: 0.02em; }
+.sched-num:focus, .sched-time-input:focus {
   outline: none;
   border-color: var(--tempest-accent);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--tempest-accent) 18%, transparent);
 }
 
-.sched-days { display: inline-flex; padding: 2px; gap: 2px; border: 1px solid var(--tempest-border-default, var(--tempest-border)); border-radius: 6px; background: var(--tempest-bg-elevated); align-self: flex-start; }
-.sched-day {
-  min-width: 36px;
-  height: 26px;
+.sched-hfmt {
+  display: inline-flex;
+  padding: 2px;
+  gap: 2px;
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 6px;
+  background: var(--tempest-bg-elevated);
+}
+.sched-hfmt-btn {
+  height: 24px;
   padding: 0 8px;
   border: none;
   border-radius: 4px;
@@ -431,59 +535,44 @@
   cursor: pointer;
   transition: background 0.1s, color 0.1s;
 }
-.sched-day:hover { background: var(--tempest-bg-hover); color: var(--tempest-fg-default); }
-.sched-day--on {
+.sched-hfmt-btn:hover { color: var(--tempest-fg-default); background: var(--tempest-bg-hover); }
+.sched-hfmt-btn--on {
   background: var(--tempest-bg-active, var(--tempest-bg-hover));
   color: var(--tempest-fg-default);
-  box-shadow: inset 0 0 0 1px var(--tempest-border-default, var(--tempest-border));
+  box-shadow: inset 0 0 0 1px var(--tempest-border-default);
 }
 
-.sched-summary {
+.sched-presets {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  border: 1px solid var(--tempest-border-default, var(--tempest-border));
-  border-radius: 6px;
-  background: var(--tempest-bg-subtle, var(--tempest-bg-elevated));
-  font-size: 12px;
-  color: var(--tempest-fg-default);
+  gap: 4px 12px;
+  margin-top: 6px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--tempest-border-default);
 }
-.sched-summary-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--tempest-accent);
-  flex-shrink: 0;
-}
-
-.sched-quick { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
-.sched-quick-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+.sched-presets-label {
+  font-size: 11px;
   color: var(--tempest-fg-subtle);
   margin-right: 2px;
 }
-.sched-quick-btn {
-  height: 22px;
-  padding: 0 8px;
-  border: 1px solid var(--tempest-border-default, var(--tempest-border));
-  border-radius: 999px;
+.sched-preset {
+  border: none;
   background: transparent;
+  padding: 0;
   color: var(--tempest-fg-muted);
   font-size: 11px;
   font-family: inherit;
   cursor: pointer;
-  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  transition: color 0.1s;
 }
-.sched-quick-btn:hover {
-  background: var(--tempest-bg-hover);
-  color: var(--tempest-fg-default);
-  border-color: var(--tempest-fg-subtle);
+.sched-preset:hover {
+  color: var(--tempest-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
-/* ── Create dialog ────────────────────────────────────────────────────────── */
+/* -- Create dialog ---------------------------------------------------------- */
 
 .am-dialog-overlay {
   position: fixed;
@@ -501,7 +590,7 @@
   display: flex;
   flex-direction: column;
   background: var(--tempest-bg-elevated);
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 10px;
   overflow: hidden;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.22), 0 2px 6px rgba(0, 0, 0, 0.12);
@@ -511,7 +600,7 @@
   align-items: center;
   gap: 8px;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--tempest-border);
+  border-bottom: 1px solid var(--tempest-border-default);
   font-size: 13px;
   font-weight: 500;
   color: var(--tempest-fg-default);
@@ -545,7 +634,7 @@
   gap: 6px;
   height: 32px;
   padding: 0 14px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 6px;
   background: transparent;
   color: var(--tempest-fg-default);
@@ -565,7 +654,7 @@
 .am-dialog-btn--create:disabled { opacity: 0.5; cursor: not-allowed; }
 .am-dialog-btn--cancel { }
 
-/* ── Gallery ──────────────────────────────────────────────────────────────── */
+/* -- Gallery ---------------------------------------------------------------- */
 
 .am-gallery { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 20px; }
 .am-gallery-category { font-size: 11px; font-weight: 600; color: var(--tempest-fg-subtle); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px; }
@@ -575,7 +664,7 @@
   flex-direction: column;
   gap: 2px;
   padding: 10px 12px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 8px;
   background: var(--tempest-bg-editor);
   text-align: left;
@@ -585,7 +674,7 @@
 .am-gallery-item-name { font-size: 13px; font-weight: 500; color: var(--tempest-fg-default); }
 .am-gallery-item-prompt { font-size: 12px; color: var(--tempest-fg-subtle); }
 
-/* ── Version history sheet ────────────────────────────────────────────────── */
+/* -- Version history sheet -------------------------------------------------- */
 
 .am-versions-overlay {
   position: fixed;
@@ -600,14 +689,14 @@
   display: flex;
   flex-direction: column;
   background: var(--tempest-bg-elevated);
-  border-left: 1px solid var(--tempest-border);
+  border-left: 1px solid var(--tempest-border-default);
 }
 .am-versions-header {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 14px 16px;
-  border-bottom: 1px solid var(--tempest-border);
+  border-bottom: 1px solid var(--tempest-border-default);
   font-size: 13px;
   font-weight: 500;
   color: var(--tempest-fg-default);
@@ -619,7 +708,7 @@
 .am-version-item {
   display: flex; flex-direction: column; gap: 6px;
   padding: 10px 12px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 8px;
   background: var(--tempest-bg-editor);
 }
@@ -635,7 +724,7 @@
   overflow: hidden;
 }
 
-/* ── Modal (shared with other pages) ─────────────────────────────────────── */
+/* -- Modal (shared with other pages) --------------------------------------- */
 
 .naming-modal-overlay {
   position: fixed;
@@ -650,7 +739,7 @@
   width: 400px;
   max-width: calc(100vw - 48px);
   background: var(--tempest-bg-elevated);
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 10px;
   padding: 20px;
   display: flex;
@@ -668,7 +757,7 @@
 .naming-modal-desc { margin: 0; font-size: 13px; color: var(--tempest-fg-muted); }
 .naming-modal-input {
   padding: 8px 10px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 7px;
   background: var(--tempest-bg-editor);
   color: var(--tempest-fg-default);
@@ -680,7 +769,7 @@
 .naming-modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .naming-modal-btn {
   padding: 7px 14px;
-  border: 1px solid var(--tempest-border);
+  border: 1px solid var(--tempest-border-default);
   border-radius: 7px;
   background: var(--tempest-bg-elevated);
   color: var(--tempest-fg-default);
@@ -698,3 +787,4 @@
 .naming-modal-btn--create:hover,
 .naming-modal-btn--delete:hover { opacity: 0.85; }
 .naming-modal-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+

--- a/src/components/Automations/AutomationsPage.tsx
+++ b/src/components/Automations/AutomationsPage.tsx
@@ -5,11 +5,7 @@ import { AutomationDetailPage } from "./AutomationDetailPage";
 import type { Automation } from "../../store/automations";
 import "./AutomationsPage.css";
 
-interface Props {
-  onRunAutomation: (a: Automation) => void;
-}
-
-export function AutomationsPage({ onRunAutomation }: Props) {
+export function AutomationsPage() {
   const projects = getOpenProjects();
   const [scope, setScope] = useState<string | null>(null);
   const [detail, setDetail] = useState<Automation | null>(null);
@@ -19,7 +15,6 @@ export function AutomationsPage({ onRunAutomation }: Props) {
       <AutomationDetailPage
         automation={detail}
         onBack={() => setDetail(null)}
-        onRunNow={onRunAutomation}
         onUpdate={(updated) => setDetail(updated)}
       />
     );

--- a/src/components/Automations/SchedulePicker.tsx
+++ b/src/components/Automations/SchedulePicker.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { humanizeRrule } from "../../lib/automationSchedule";
-import { Segmented } from "../ui/Segmented";
+import { SpSelect } from "../ui/SpSelect";
 import "../SettingsPanel.css";
 
 interface Props {
@@ -17,23 +16,41 @@ const FREQS = [
   { value: "MONTHLY", label: "Monthly" },
 ];
 
-const WEEKDAYS: { code: string; label: string }[] = [
-  { code: "MO", label: "Mon" },
-  { code: "TU", label: "Tue" },
-  { code: "WE", label: "Wed" },
-  { code: "TH", label: "Thu" },
-  { code: "FR", label: "Fri" },
-  { code: "SA", label: "Sat" },
-  { code: "SU", label: "Sun" },
+const WEEKDAYS = [
+  { value: "MO", label: "Monday" },
+  { value: "TU", label: "Tuesday" },
+  { value: "WE", label: "Wednesday" },
+  { value: "TH", label: "Thursday" },
+  { value: "FR", label: "Friday" },
+  { value: "SA", label: "Saturday" },
+  { value: "SU", label: "Sunday" },
 ];
 
 interface Parsed {
   freq: Freq;
-  hour: number;
-  minute: number;
+  hour: number;     // local wall-clock hour (0–23)
+  minute: number;   // local wall-clock minute
   byday: string[];
   bymonthday: number;
   interval: number;
+}
+
+// ponytail: uses current tz offset, so a rule created in DST will drift by an
+// hour after the switch. Store TZID if that matters.
+const TZ_OFFSET = new Date().getTimezoneOffset(); // minutes; -330 for IST
+function utcToLocal(h: number, m: number) {
+  const t = (((h * 60 + m - TZ_OFFSET) % 1440) + 1440) % 1440;
+  return { hour: Math.floor(t / 60), minute: t % 60 };
+}
+function localToUtc(h: number, m: number) {
+  const t = (((h * 60 + m + TZ_OFFSET) % 1440) + 1440) % 1440;
+  return { hour: Math.floor(t / 60), minute: t % 60 };
+}
+function tzLabel(): string {
+  try {
+    const parts = new Intl.DateTimeFormat(undefined, { timeZoneName: "short" }).formatToParts(new Date());
+    return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
+  } catch { return ""; }
 }
 
 function parse(rrule: string): Parsed {
@@ -42,11 +59,14 @@ function parse(rrule: string): Parsed {
     const [k, v] = seg.split("=");
     if (k && v) parts.set(k.toUpperCase(), v);
   }
-  const freq = (parts.get("FREQ") as Freq) || "DAILY";
+  const raw = (parts.get("FREQ") as Freq) || "DAILY";
+  const utcH = Number(parts.get("BYHOUR") ?? 9);
+  const utcM = Number(parts.get("BYMINUTE") ?? 0);
+  const { hour, minute } = utcToLocal(utcH, utcM);
   return {
-    freq: (["HOURLY", "DAILY", "WEEKLY", "MONTHLY"] as Freq[]).includes(freq) ? freq : "DAILY",
-    hour: Number(parts.get("BYHOUR") ?? 9),
-    minute: Number(parts.get("BYMINUTE") ?? 0),
+    freq: (["HOURLY", "DAILY", "WEEKLY", "MONTHLY"] as Freq[]).includes(raw) ? raw : "DAILY",
+    hour,
+    minute,
     byday: (parts.get("BYDAY") || "MO").split(",").filter(Boolean),
     bymonthday: Number(parts.get("BYMONTHDAY") ?? 1),
     interval: Number(parts.get("INTERVAL") ?? 1),
@@ -59,79 +79,104 @@ function build(p: Parsed): string {
   if (p.freq === "WEEKLY") bits.push(`BYDAY=${p.byday.join(",") || "MO"}`);
   if (p.freq === "MONTHLY") bits.push(`BYMONTHDAY=${p.bymonthday}`);
   if (p.freq !== "HOURLY") {
-    bits.push(`BYHOUR=${p.hour}`, `BYMINUTE=${p.minute}`, `BYSECOND=0`);
+    const { hour, minute } = localToUtc(p.hour, p.minute);
+    bits.push(`BYHOUR=${hour}`, `BYMINUTE=${minute}`, `BYSECOND=0`);
   }
   return bits.join(";");
 }
 
-const QUICK: { label: string; rrule: string }[] = [
-  { label: "Every hour", rrule: "FREQ=HOURLY" },
-  { label: "Daily 9am", rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0" },
-  { label: "Weekdays 9am", rrule: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9;BYMINUTE=0;BYSECOND=0" },
-  { label: "Mon 9am", rrule: "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0;BYSECOND=0" },
+// Presets are defined in local time — they're translated to UTC BYHOUR at apply.
+const BASE: Parsed = { freq: "DAILY", hour: 9, minute: 0, byday: ["MO"], bymonthday: 1, interval: 1 };
+const QUICK: { label: string; state: Parsed }[] = [
+  { label: "Every hour", state: { ...BASE, freq: "HOURLY" } },
+  { label: "Daily 9am", state: { ...BASE, freq: "DAILY", hour: 9 } },
+  { label: "Mon 9am", state: { ...BASE, freq: "WEEKLY", byday: ["MO"], hour: 9 } },
+  { label: "Fri 5pm", state: { ...BASE, freq: "WEEKLY", byday: ["FR"], hour: 17 } },
 ];
+
+function formatTime(h: number, m: number, h12: boolean): string {
+  const mm = String(m).padStart(2, "0");
+  if (!h12) return `${String(h).padStart(2, "0")}:${mm}`;
+  const period = h >= 12 ? "PM" : "AM";
+  const hv = h % 12 === 0 ? 12 : h % 12;
+  return `${hv}:${mm} ${period}`;
+}
+function parseTime(s: string, h12: boolean): { hour: number; minute: number } | null {
+  const t = s.trim();
+  if (h12) {
+    const m = /^(\d{1,2}):(\d{2})\s*(am|pm)$/i.exec(t);
+    if (!m) return null;
+    let h = Number(m[1]);
+    const min = Number(m[2]);
+    if (h < 1 || h > 12 || min < 0 || min > 59) return null;
+    if (h === 12) h = 0;
+    if (m[3].toLowerCase() === "pm") h += 12;
+    return { hour: h, minute: min };
+  }
+  const m = /^(\d{1,2}):(\d{2})$/.exec(t);
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return { hour: h, minute: min };
+}
 
 export function SchedulePicker({ value, onChange }: Props) {
   const [state, setState] = useState<Parsed>(() => parse(value));
+  const [hour12, setHour12] = useState(false);
+  const [timeDraft, setTimeDraft] = useState(() => formatTime(state.hour, state.minute, false));
+  const tz = useMemo(tzLabel, []);
 
+  useEffect(() => { setState(parse(value)); }, [value]);
   useEffect(() => {
-    setState(parse(value));
-  }, [value]);
-
-  const timeStr = useMemo(
-    () => `${String(state.hour).padStart(2, "0")}:${String(state.minute).padStart(2, "0")}`,
-    [state.hour, state.minute],
-  );
+    setTimeDraft(formatTime(state.hour, state.minute, hour12));
+  }, [state.hour, state.minute, hour12]);
 
   function update(patch: Partial<Parsed>) {
     const next = { ...state, ...patch };
     setState(next);
     onChange(build(next));
   }
-
-  function toggleDay(code: string) {
-    const has = state.byday.includes(code);
-    const next = has ? state.byday.filter((d) => d !== code) : [...state.byday, code];
-    update({ byday: next.length ? next : [code] });
+  function applyState(next: Parsed) {
+    setState(next);
+    onChange(build(next));
+  }
+  function commitTime() {
+    const parsed = parseTime(timeDraft, hour12);
+    if (!parsed) {
+      setTimeDraft(formatTime(state.hour, state.minute, hour12));
+      return;
+    }
+    update(parsed);
   }
 
   return (
     <div className="sched">
-      <Segmented options={FREQS} value={state.freq} onChange={(v) => update({ freq: v as Freq })} />
-
-      {state.freq === "HOURLY" && (
-        <div className="sched-row">
-          <span className="sched-label">Every</span>
-          <input
-            type="number"
-            min={1}
-            max={24}
-            value={state.interval}
-            onChange={(e) => update({ interval: Math.max(1, Number(e.target.value) || 1) })}
-            className="sched-num"
-          />
-          <span className="sched-label">hour(s)</span>
-        </div>
-      )}
+      <div className="sched-row">
+        <label className="sched-lbl">Frequency</label>
+        <SpSelect
+          className="sched-ctrl"
+          value={state.freq}
+          onChange={(v) => update({ freq: v as Freq })}
+          options={FREQS}
+        />
+      </div>
 
       {state.freq === "WEEKLY" && (
-        <div className="sched-days">
-          {WEEKDAYS.map((d) => (
-            <button
-              key={d.code}
-              type="button"
-              className={`sched-day${state.byday.includes(d.code) ? " sched-day--on" : ""}`}
-              onClick={() => toggleDay(d.code)}
-            >
-              {d.label}
-            </button>
-          ))}
+        <div className="sched-row">
+          <label className="sched-lbl">Day</label>
+          <SpSelect
+            className="sched-ctrl"
+            value={state.byday[0] ?? "MO"}
+            onChange={(v) => update({ byday: [v] })}
+            options={WEEKDAYS}
+          />
         </div>
       )}
 
       {state.freq === "MONTHLY" && (
         <div className="sched-row">
-          <span className="sched-label">Day of month</span>
+          <label className="sched-lbl">Day of month</label>
           <input
             type="number"
             min={1}
@@ -143,38 +188,64 @@ export function SchedulePicker({ value, onChange }: Props) {
         </div>
       )}
 
-      {state.freq !== "HOURLY" && (
+      {state.freq === "HOURLY" && (
         <div className="sched-row">
-          <span className="sched-label">at</span>
-          <input
-            type="time"
-            value={timeStr}
-            onChange={(e) => {
-              const [h, m] = e.target.value.split(":").map(Number);
-              update({ hour: h || 0, minute: m || 0 });
-            }}
-            className="sched-time"
-          />
+          <label className="sched-lbl">Every</label>
+          <div className="sched-ctrl-inline">
+            <input
+              type="number"
+              min={1}
+              max={24}
+              value={state.interval}
+              onChange={(e) => update({ interval: Math.max(1, Number(e.target.value) || 1) })}
+              className="sched-num"
+            />
+            <span className="sched-unit">hour{state.interval === 1 ? "" : "s"}</span>
+          </div>
         </div>
       )}
 
-      <div className="sched-summary">
-        <span className="sched-summary-dot" />
-        {humanizeRrule(build(state))}
-      </div>
+      {state.freq !== "HOURLY" && (
+        <div className="sched-row">
+          <label className="sched-lbl">Time</label>
+          <div className="sched-ctrl-inline">
+            <input
+              type="text"
+              className="sched-time-input"
+              value={timeDraft}
+              onChange={(e) => setTimeDraft(e.target.value)}
+              onBlur={commitTime}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); commitTime(); } }}
+              placeholder={hour12 ? "9:00 AM" : "09:00"}
+            />
+            <div className="sched-hfmt" role="group">
+              {(["24", "12"] as const).map((h) => {
+                const active = (hour12 ? "12" : "24") === h;
+                return (
+                  <button
+                    key={h}
+                    type="button"
+                    className={`sched-hfmt-btn${active ? " sched-hfmt-btn--on" : ""}`}
+                    onClick={() => setHour12(h === "12")}
+                  >
+                    {h}h
+                  </button>
+                );
+              })}
+            </div>
+            {tz && <span className="sched-tz">{tz}</span>}
+          </div>
+        </div>
+      )}
 
-      <div className="sched-quick">
-        <span className="sched-quick-label">Presets</span>
+      <div className="sched-presets">
+        <span className="sched-presets-label">Or start from</span>
         {QUICK.map((q) => (
           <button
             key={q.label}
             type="button"
-            className="sched-quick-btn"
-            onClick={() => {
-              const p = parse(q.rrule);
-              setState(p);
-              onChange(build(p));
-            }}
+            className="sched-preset"
+            onClick={() => applyState(q.state)}
           >
             {q.label}
           </button>

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { forwardRef, memo, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -19,6 +19,7 @@ interface Props {
   sessionId: string;
   hidden?: boolean;
   isAgent?: boolean;
+  readOnly?: boolean;
 }
 
 function getTerminalTheme() {
@@ -49,7 +50,14 @@ function getTerminalTheme() {
   };
 }
 
-export const TerminalPane = memo(function TerminalPane({ sessionId, hidden = false, isAgent = false }: Props) {
+export interface TerminalPaneHandle {
+  clear: () => void;
+}
+
+export const TerminalPane = memo(forwardRef<TerminalPaneHandle, Props>(function TerminalPane(
+  { sessionId, hidden = false, isAgent = false, readOnly = false },
+  ref,
+) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -61,6 +69,10 @@ export const TerminalPane = memo(function TerminalPane({ sessionId, hidden = fal
   const [searchQuery, setSearchQuery] = useState("");
   const { theme } = useTheme();
   const settings = useSettings();
+
+  useImperativeHandle(ref, () => ({
+    clear: () => { termRef.current?.reset(); },
+  }), []);
 
   // Single fit path: reflow xterm to the container AND tell the PTY the new size.
   // Fitting the frontend without resizing the backend desyncs cols/rows and makes
@@ -105,6 +117,7 @@ export const TerminalPane = memo(function TerminalPane({ sessionId, hidden = fal
       cursorBlink: s.terminalCursorBlink,
       scrollback: s.terminalScrollback,
       allowProposedApi: true,
+      disableStdin: readOnly,
     });
     termRef.current = term;
 
@@ -140,13 +153,13 @@ export const TerminalPane = memo(function TerminalPane({ sessionId, hidden = fal
       requestAnimationFrame(() => requestAnimationFrame(fitIfVisible)),
     );
 
-    term.onData((data) => {
-      const bytes = Array.from(new TextEncoder().encode(data));
-      invoke("write_to_pty", { sessionId, data: bytes }).catch(() => {});
-      // Signal Enter to the Manager so it can arm the work-done timer. Manager
-      // checks isAgent internally — this is a no-op for plain terminal sessions.
-      if (isAgent && data.includes("\r")) sessionManager.markUserInput(sessionId);
-    });
+    if (!readOnly) {
+      term.onData((data) => {
+        const bytes = Array.from(new TextEncoder().encode(data));
+        invoke("write_to_pty", { sessionId, data: bytes }).catch(() => {});
+        if (isAgent && data.includes("\r")) sessionManager.markUserInput(sessionId);
+      });
+    }
 
     // Feed OSC 0/2 title changes into the Session Manager so it can classify
     // the agent's busy/idle state from the title (e.g. Claude Code's ✳ glyph).
@@ -306,4 +319,4 @@ export const TerminalPane = memo(function TerminalPane({ sessionId, hidden = fal
       <div ref={containerRef} className="terminal-pane" />
     </div>
   );
-});
+}));

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -88,7 +88,6 @@ import { startAgentHooks } from "../store/agentHooks";
 import { AtlasIndexModal } from "./AtlasIndexModal";
 import { KnowledgeBasePage } from "./KnowledgeBasePage";
 import { AutomationsPage } from "./Automations/AutomationsPage";
-import { runAutomationNow } from "../store/automations";
 import { Toolbar } from "./Toolbar";
 import AgentTabs from "./AgentTabs";
 import IconCapsule from "./IconCapsule";
@@ -1963,7 +1962,6 @@ export function WorkspaceView({ zen, name, path }: Props) {
             <button className={navBtn("automations")} onClick={() => goTo("automations")}>
               <Workflow size={16} />
               <span>Automations</span>
-              <span className="sidebar-nav-badge">Beta</span>
             </button>
           </div>
 
@@ -2815,14 +2813,7 @@ export function WorkspaceView({ zen, name, path }: Props) {
               <KnowledgeBasePage />
             )}
             {!activeSessionId && activeSection === "automations" && (
-              <AutomationsPage
-                onRunAutomation={(a) => {
-                  // Background job — no session/tab is created. Errors (unsupported
-                  // agent, unloaded project) are surfaced as an in-app banner; the
-                  // run record itself records the dispatch outcome either way.
-                  runAutomationNow(a, "manual").catch((e) => setPolicyError(String(e?.message ?? e)));
-                }}
-              />
+              <AutomationsPage />
             )}
             {!activeSessionId && activeSection === "overview" && (
               <div className="overview-page">

--- a/src/lib/automationSchedule.ts
+++ b/src/lib/automationSchedule.ts
@@ -18,7 +18,21 @@ export function humanizeRrule(rruleStr: string): string {
     const rule = RRule.fromString(
       rruleStr.startsWith("RRULE:") ? rruleStr : `RRULE:${rruleStr}`,
     );
-    return rule.toText();
+    // BYHOUR/BYMINUTE are stored in UTC; shift them to the viewer's local
+    // wall-clock time before humanizing so "Daily 9am" reads as 9am wherever
+    // they are, not 9am GMT.
+    const opts = { ...rule.origOptions };
+    const byhour = opts.byhour;
+    const byminute = opts.byminute;
+    const utcH = Array.isArray(byhour) ? byhour[0] : (typeof byhour === "number" ? byhour : undefined);
+    const utcM = Array.isArray(byminute) ? byminute[0] : (typeof byminute === "number" ? byminute : undefined);
+    if (utcH !== undefined || utcM !== undefined) {
+      const offset = new Date().getTimezoneOffset();
+      const total = ((((utcH ?? 0) * 60 + (utcM ?? 0) - offset) % 1440) + 1440) % 1440;
+      opts.byhour = [Math.floor(total / 60)];
+      opts.byminute = [total % 60];
+    }
+    return new RRule(opts).toText();
   } catch {
     return rruleStr;
   }

--- a/src/store/automations.ts
+++ b/src/store/automations.ts
@@ -168,7 +168,7 @@ export async function runAutomationNow(a: Automation, triggeredBy: "manual" | "s
       // No policy for automations: creating the automation IS the opt-in.
       policy: null,
       dbIsolation: false,
-      env: { ...(cfg.env ?? {}), TEMPEST_SESSION: runId },
+      env: { TEMPEST_SESSION: runId },
       onEvent: channel,
     });
   } catch (e) {

--- a/src/store/automations.ts
+++ b/src/store/automations.ts
@@ -1,10 +1,12 @@
-import { invoke } from "@tauri-apps/api/core";
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { homeDir } from "@tauri-apps/api/path";
 import { computeNextRunAt } from "../lib/automationSchedule";
 import { getProjectPath } from "./sessions";
 import { getAgent } from "../lib/agentRegistry";
 import type { AgentConfig } from "../lib/agentManifest";
 import { getSettings } from "./appSettings";
+import { sessionManager } from "./sessionManager";
 
 export interface Automation {
   id: string;
@@ -59,10 +61,9 @@ export interface UpdateAutomationReq {
 
 let _automations: Automation[] = [];
 let _dispatchUnlisten: (() => void) | null = null;
-let _doneUnlisten: (() => void) | null = null;
-// Tracks the automationId + triggeredBy for each in-flight background run so the
-// `automation:done` handler can attribute the exit-status upsert without another
-// DB round-trip. Cleared as soon as the run completes.
+// Tracks the automationId + triggeredBy for each in-flight run so the
+// sessionManager onDone callback can attribute the succeeded upsert without an
+// extra DB round-trip. Cleared when the run completes.
 const _runMeta = new Map<string, { automationId: string; triggeredBy: string }>();
 
 export async function loadAutomations(projectId?: string): Promise<Automation[]> {
@@ -70,20 +71,6 @@ export async function loadAutomations(projectId?: string): Promise<Automation[]>
   if (!_dispatchUnlisten) {
     _dispatchUnlisten = await listen<string>("automation:dispatch", (ev) => {
       void _handleScheduledDispatch(ev.payload);
-    });
-  }
-  if (!_doneUnlisten) {
-    _doneUnlisten = await listen<{ runId: string; ok: boolean }>("automation:done", (ev) => {
-      const { runId, ok } = ev.payload;
-      const meta = _runMeta.get(runId);
-      if (!meta) return;
-      _runMeta.delete(runId);
-      void upsertAutomationRun({
-        id: runId,
-        automationId: meta.automationId,
-        status: ok ? "succeeded" : "failed",
-        triggeredBy: meta.triggeredBy,
-      });
     });
   }
   return _automations;
@@ -110,23 +97,38 @@ async function _handleScheduledDispatch(id: string) {
 /// through the flag that's designed to receive it — not as a bare positional,
 /// which several CLIs (claude included) treat as a project path.
 function buildHeadlessArgs(cfg: AgentConfig, prompt: string, model?: string): string[] {
-  const args: string[] = [];
+  const print = cfg.printArgs ?? [];
+  const flags: string[] = [];
   if (model && cfg.modelArgs) {
-    for (const a of cfg.modelArgs) args.push(a.replace("{MODEL}", model));
+    for (const a of cfg.modelArgs) flags.push(a.replace("{MODEL}", model));
   }
   if (cfg.autoApproveArgs && getSettings().autoApprove) {
-    for (const a of cfg.autoApproveArgs) args.push(a);
+    for (const a of cfg.autoApproveArgs) flags.push(a);
   }
-  for (const a of cfg.printArgs ?? []) args.push(a.replace("{PROMPT}", prompt));
+  // If printArgs starts with a subcommand (e.g. opencode's `run`), the subcommand
+  // must be argv[1] or yargs routes to the default command and treats it as a
+  // positional (opencode has `[project]` on default → prints --help). Insert
+  // model/auto flags AFTER the subcommand. For flag-style print (claude's `-p
+  // {PROMPT}`), keep the original order so flags don't split the -p/value pair.
+  const args: string[] = [];
+  if (print.length > 0 && !print[0].startsWith("-")) {
+    args.push(print[0]);
+    args.push(...flags);
+    for (let i = 1; i < print.length; i++) args.push(print[i].replace("{PROMPT}", prompt));
+  } else {
+    args.push(...flags);
+    for (const a of print) args.push(a.replace("{PROMPT}", prompt));
+  }
   return args;
 }
 
-/// Dispatch an automation as a background subprocess. Never opens a tab or
-/// PTY-backed session — automations are jobs. On spawn success the run is
-/// marked `dispatched`; `automation:done` later flips it to `succeeded` /
-/// `failed`. Throws only when spawn setup fails; the caller decides whether to
-/// surface that (manual runs do; the scheduler swallows).
-export async function runAutomationNow(a: Automation, triggeredBy: "manual" | "scheduler" = "manual"): Promise<void> {
+/// Dispatch an automation into a PTY session. No workspace tab, no PowerShell
+/// spawn — the same `create_pty_session` the workspace uses, consumed by the
+/// Automations detail page's TerminalPane. On spawn success the run is marked
+/// `dispatched`; sessionManager's work-done heuristics flip it to `succeeded`.
+/// Throws only when spawn setup fails; manual runs surface it, the scheduler
+/// swallows.
+export async function runAutomationNow(a: Automation, triggeredBy: "manual" | "scheduler" = "manual"): Promise<string> {
   const runId = crypto.randomUUID();
   await upsertAutomationRun({ id: runId, automationId: a.id, status: "dispatching", triggeredBy });
 
@@ -136,8 +138,8 @@ export async function runAutomationNow(a: Automation, triggeredBy: "manual" | "s
     throw new Error(`${a.agent} does not support headless runs (no print/-p flag in its manifest).`);
   }
 
-  // Project-scoped: cwd = project path (fails if the project isn't loaded).
-  // Global: cwd = "" — Rust falls back to the user's home dir.
+  // Project-scoped needs the project to be loaded (its on-disk path is only
+  // known when open). Global-scoped runs use the user's home dir.
   let cwd = "";
   if (a.projectId) {
     const p = getProjectPath(a.projectId);
@@ -146,18 +148,56 @@ export async function runAutomationNow(a: Automation, triggeredBy: "manual" | "s
       throw new Error("This automation's project isn't loaded — open it first.");
     }
     cwd = p;
+  } else {
+    cwd = await homeDir();
   }
 
   const args = buildHeadlessArgs(cfg, a.prompt, a.model ?? undefined);
   _runMeta.set(runId, { automationId: a.id, triggeredBy });
+
+  const channel = new Channel<{ session_id: string; data: string }>();
   try {
-    await invoke("run_automation_command", { runId, cwd, program: cfg.hint, args });
-    await upsertAutomationRun({ id: runId, automationId: a.id, status: "dispatched", triggeredBy });
+    await invoke<void>("create_pty_session", {
+      sessionId: runId,
+      cwd,
+      rows: 40,
+      cols: 120,
+      command: cfg.hint,
+      args,
+      sandbox: null,
+      // No policy for automations: creating the automation IS the opt-in.
+      policy: null,
+      dbIsolation: false,
+      env: { ...(cfg.env ?? {}), TEMPEST_SESSION: runId },
+      onEvent: channel,
+    });
   } catch (e) {
     _runMeta.delete(runId);
     await upsertAutomationRun({ id: runId, automationId: a.id, status: "dispatch_failed", triggeredBy });
     throw e;
   }
+
+  sessionManager.register(
+    runId,
+    channel,
+    true,
+    () => {
+      const meta = _runMeta.get(runId);
+      if (!meta) return;
+      _runMeta.delete(runId);
+      void upsertAutomationRun({
+        id: runId,
+        automationId: meta.automationId,
+        status: "succeeded",
+        triggeredBy: meta.triggeredBy,
+      });
+    },
+    undefined,
+    cfg.hint,
+  );
+
+  await upsertAutomationRun({ id: runId, automationId: a.id, status: "dispatched", triggeredBy });
+  return runId;
 }
 
 export async function createAutomation(req: CreateAutomationReq): Promise<Automation> {


### PR DESCRIPTION
## Summary
- **AutomationDetailPage**: sidebar (agent / model / next run / recent runs) + in-page terminal panel that streams the active run PTY; run-now dispatches headlessly and switches the panel to the new run.
- **Headless runs**: wire `run_automation_command` end-to-end (Rust command, store call, list refresh, `printArgs` manifest flag).
- **SchedulePicker**: label-left / control-right rows using `SpSelect` for frequency and day, plain text time input with a `24h / 12h` toggle, tz label from the browser. RRULE `BYHOUR/BYMINUTE` stored in UTC; UI + `humanizeRrule` render in the viewer's local time so "Daily 9am" no longer means 9am GMT.

## Test plan
- [x] Open an automation → Schedule rows render label/control aligned; Frequency dropdown switches Daily/Weekly/Monthly/Hourly and the row set updates.
- [x] Weekly: Day dropdown persists; humanized hint below the picker reads the chosen local time.
- [x] Toggle `12h` / `24h`: time input reformats; typing invalid time reverts on blur.
- [x] Click a preset → fields populate, hint updates.
- [x] Run Now → terminal panel shows the new run's output; recent-runs sidebar refreshes.
- [x] Existing schedules created before this change still display (BYHOUR treated as UTC → local on load).
