### PR TITLE
Message queue: workspace drawer, Send button, agent aware clear (#34)

### DIFF
--- a/config/agents.json
+++ b/config/agents.json
@@ -10,6 +10,7 @@
       "icon": "agy",
       "mono": true,
       "downloadUrl": "https://antigravity.google",
+      "clearCommand": "/clear",
       "flags": {
         "resume": ["--continue"],
         "model": ["--model", "{MODEL}"],
@@ -23,6 +24,7 @@
       "adapter": "cli",
       "icon": "claude",
       "downloadUrl": "https://code.claude.com/docs",
+      "clearCommand": "/clear",
       "flags": {
         "session": ["--session-id", "{UUID}"],
         "resume": ["--resume", "{UUID}"],
@@ -48,6 +50,7 @@
       "icon": "codex",
       "mono": true,
       "downloadUrl": "https://github.com/openai/codex",
+      "clearCommand": "/new",
       "flags": {
         "resume": ["resume", "--last"],
         "model": ["--model", "{MODEL}"],
@@ -70,6 +73,7 @@
       "icon": "cursor",
       "mono": true,
       "downloadUrl": "https://cursor.com/cli",
+      "clearCommand": "/new",
       "flags": {
         "model": ["--model", "{MODEL}"]
       }
@@ -81,6 +85,7 @@
       "adapter": "cli",
       "icon": "gemini",
       "downloadUrl": "https://github.com/google-gemini/gemini-cli",
+      "clearCommand": "/clear",
       "flags": {
         "session": ["--session-id", "{UUID}"],
         "resume": ["--resume", "{UUID}"],
@@ -96,6 +101,7 @@
       "icon": "goose",
       "mono": true,
       "downloadUrl": "https://block.github.io/goose",
+      "clearCommand": ".clear",
       "flags": {
         "model": ["--model", "{MODEL}"]
       }
@@ -108,6 +114,7 @@
       "icon": "opencode",
       "mono": true,
       "downloadUrl": "https://opencode.ai",
+      "clearCommand": "/new",
       "flags": {
         "model": ["--model", "{MODEL}"],
         "autoApprove": ["--auto"],
@@ -127,6 +134,7 @@
       "icon": "hermes.svg",
       "mono": true,
       "downloadUrl": "https://hermes-agent.nousresearch.com",
+      "clearCommand": "/clear",
       "flags": {
         "resume": ["--continue"],
         "model": ["--model", "{MODEL}"],
@@ -141,6 +149,7 @@
       "icon": "pi.svg",
       "mono": true,
       "downloadUrl": "https://pi.dev",
+      "clearCommand": "/clear",
       "flags": {
         "session": ["--session-id", "{UUID}"],
         "resume": ["--session-id", "{UUID}"],
@@ -156,6 +165,7 @@
       "icon": "amp.svg",
       "mono": true,
       "downloadUrl": "https://ampcode.com",
+      "clearCommand": "/clear",
       "flags": {
         "print": ["-x", "{PROMPT}"]
       }
@@ -168,6 +178,7 @@
       "icon": "fx.svg",
       "mono": true,
       "downloadUrl": "https://fx.sh",
+      "clearCommand": "/clear",
       "flags": {
         "session": ["--id", "{UUID}"],
         "resume": ["--continue"],
@@ -182,6 +193,7 @@
       "icon": "grok.svg",
       "mono": true,
       "downloadUrl": "https://github.com/xai-org/grok-build",
+      "clearCommand": "/clear",
       "flags": {
         "session": ["--session-id", "{UUID}"],
         "resume": ["--resume", "{UUID}"],

--- a/src/components/QueuePanel.css
+++ b/src/components/QueuePanel.css
@@ -1,63 +1,81 @@
 .qp-panel {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 50;
-  background: var(--tempest-bg-panel);
-  border-top: 1px solid var(--tempest-border-default);
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  max-height: 55%;
+  max-height: 340px;
+  background: var(--tempest-bg-canvas-wrap);
+  animation: qp-slide-in 0.22s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+  overflow: hidden;
+}
+
+@keyframes qp-slide-in {
+  from { max-height: 0;     opacity: 0; }
+  to   { max-height: 340px; opacity: 1; }
 }
 
 /* ── Header ── */
 .qp-header {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 7px 10px 6px;
-  border-bottom: 1px solid var(--tempest-border-subtle);
+  gap: 8px;
+  padding: 10px 12px 6px;
   flex-shrink: 0;
 }
 
 .qp-header-icon {
-  color: var(--tempest-accent-blue);
+  color: var(--tempest-fg-subtle);
   flex-shrink: 0;
 }
 
 .qp-title {
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 600;
-  color: var(--tempest-fg-default);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tempest-fg-subtle);
+  font-family: var(--font-sans);
+}
+
+.qp-count {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--tempest-fg-muted);
+  padding: 1px 6px;
+  border-radius: 99px;
+  background: var(--tempest-bg-active);
+  line-height: 1.4;
+}
+
+.qp-header-spacer {
   flex: 1;
 }
 
 .qp-clear {
-  background: none;
-  border: none;
+  background: transparent;
+  border: 1px solid var(--tempest-border-default);
   cursor: pointer;
+  font-family: var(--font-sans);
   font-size: 11px;
   color: var(--tempest-fg-muted);
-  padding: 2px 6px;
-  border-radius: 3px;
-  transition: color 100ms, background 100ms;
+  padding: 3px 8px;
+  border-radius: 5px;
+  transition: color 0.1s, background 0.1s, border-color 0.1s;
 }
 .qp-clear:hover {
-  color: var(--tempest-accent-red);
+  color: var(--tempest-fg-default);
   background: var(--tempest-bg-hover);
 }
 
 .qp-close {
-  background: none;
-  border: none;
+  background: transparent;
+  border: 1px solid var(--tempest-border-default);
   cursor: pointer;
   color: var(--tempest-fg-muted);
-  padding: 2px;
+  padding: 3px;
   display: flex;
   align-items: center;
-  border-radius: 3px;
-  transition: color 100ms, background 100ms;
+  border-radius: 5px;
+  transition: color 0.1s, background 0.1s, border-color 0.1s;
 }
 .qp-close:hover {
   color: var(--tempest-fg-default);
@@ -68,65 +86,83 @@
 .qp-list {
   list-style: none;
   margin: 0;
-  padding: 4px 0;
+  padding: 4px 10px 8px;
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: var(--tempest-border-subtle) transparent;
+  scrollbar-color: var(--tempest-border-default) transparent;
   flex-shrink: 1;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .qp-item {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  padding: 5px 10px;
-  transition: background 80ms;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--tempest-border-subtle);
+  background: var(--tempest-bg-base);
+  transition: border-color 0.1s, background 0.1s;
+  animation: qp-item-in 0.16s ease-out both;
 }
 .qp-item:hover {
-  background: var(--tempest-bg-hover);
+  border-color: var(--tempest-border-default);
+}
+
+.qp-item--clear .qp-item-text {
+  color: var(--tempest-fg-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.qp-item--clear .qp-item-index {
+  color: var(--tempest-accent-yellow);
+}
+
+@keyframes qp-item-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .qp-item-index {
-  font-size: 10px;
-  font-family: "Geist Mono", monospace;
-  color: var(--tempest-fg-muted);
-  background: var(--tempest-bg-active);
-  border-radius: 10px;
-  min-width: 18px;
-  height: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  font-size: 10.5px;
+  font-family: var(--font-mono);
+  color: var(--tempest-fg-subtle);
   flex-shrink: 0;
-  margin-top: 1px;
+  min-width: 14px;
+  padding-top: 2px;
+  text-align: right;
+  user-select: none;
 }
 
 .qp-item-text {
-  font-size: 12px;
+  font-size: 12.5px;
   color: var(--tempest-fg-default);
   flex: 1;
-  font-family: "Geist Mono", monospace;
+  min-width: 0;
+  font-family: var(--font-sans);
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 .qp-item-remove {
-  background: none;
-  border: none;
+  background: transparent;
+  border: 1px solid var(--tempest-border-subtle);
   cursor: pointer;
   color: var(--tempest-fg-muted);
   padding: 2px;
   display: flex;
   align-items: center;
-  border-radius: 3px;
+  border-radius: 4px;
   flex-shrink: 0;
-  margin-top: 2px;
   opacity: 0;
-  transition: opacity 80ms, color 80ms, background 80ms;
+  transition: opacity 0.1s, color 0.1s, background 0.1s, border-color 0.1s;
 }
-.qp-item:hover .qp-item-remove {
+.qp-item:hover .qp-item-remove,
+.qp-item:focus-within .qp-item-remove {
   opacity: 1;
 }
 .qp-item-remove:hover {
@@ -136,70 +172,153 @@
 
 /* ── Empty state ── */
 .qp-empty {
-  font-size: 11.5px;
-  color: var(--tempest-fg-muted);
-  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--tempest-fg-subtle);
+  padding: 2px 14px 10px;
   margin: 0;
-  line-height: 1.5;
+  line-height: 1.55;
+  max-width: 520px;
 }
 
 /* ── Compose ── */
 .qp-compose {
-  border-top: 1px solid var(--tempest-border-subtle);
-  padding: 8px 10px;
+  padding: 6px 10px 10px;
   flex-shrink: 0;
 }
 
 .qp-input {
   width: 100%;
   box-sizing: border-box;
-  background: var(--tempest-bg-editor);
-  border: 1px solid var(--tempest-border-subtle);
-  border-radius: 4px;
+  background: var(--tempest-bg-base);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 8px;
   color: var(--tempest-fg-default);
-  font-size: 12px;
-  font-family: inherit;
-  padding: 6px 8px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  padding: 9px 11px;
+  line-height: 1.5;
   resize: none;
   outline: none;
-  transition: border-color 120ms;
+  transition: border-color 0.15s;
   scrollbar-width: thin;
-  scrollbar-color: var(--tempest-border-subtle) transparent;
+  scrollbar-color: var(--tempest-border-default) transparent;
 }
 .qp-input:focus {
-  border-color: var(--tempest-accent-blue);
+  border-color: color-mix(in srgb, var(--tempest-fg-muted) 50%, transparent);
 }
 .qp-input::placeholder {
-  color: var(--tempest-fg-muted);
+  color: var(--tempest-fg-subtle);
 }
 
 .qp-compose-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 6px;
+  margin-top: 8px;
+  gap: 8px;
 }
 
 .qp-hint {
-  font-size: 10.5px;
+  font-size: 11px;
+  color: var(--tempest-fg-subtle);
+  font-family: var(--font-sans);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.qp-kbd {
+  font-family: var(--font-mono);
+  font-size: 10px;
   color: var(--tempest-fg-muted);
+  background: var(--tempest-bg-active);
+  border: 1px solid var(--tempest-border-subtle);
+  padding: 0 5px;
+  border-radius: 3px;
+  line-height: 1.5;
+}
+.qp-hint-sep {
+  opacity: 0.5;
+  padding: 0 2px;
+}
+
+.qp-compose-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.qp-compose-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.qp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  color: var(--tempest-fg-muted);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  padding: 3px 10px 3px 8px;
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s, border-color 0.1s;
+}
+.qp-chip:hover {
+  color: var(--tempest-fg-default);
+  background: var(--tempest-bg-hover);
+}
+
+.qp-send-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  color: var(--tempest-fg-default);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  padding: 4px 12px 4px 10px;
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s, border-color 0.1s, opacity 0.15s;
+}
+.qp-send-btn:hover:not(:disabled) {
+  background: var(--tempest-bg-hover);
+  border-color: color-mix(in srgb, var(--tempest-fg-muted) 50%, transparent);
+}
+.qp-send-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .qp-queue-btn {
-  background: var(--tempest-accent-blue);
-  color: #fff;
-  border: none;
-  border-radius: 4px;
+  background: var(--tempest-fg-default);
+  color: var(--tempest-bg-base);
+  border: 1px solid var(--tempest-fg-default);
+  border-radius: 6px;
   font-size: 12px;
   font-weight: 500;
-  padding: 4px 12px;
+  font-family: var(--font-sans);
+  padding: 5px 14px;
   cursor: pointer;
-  transition: filter 120ms, opacity 120ms;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
 }
 .qp-queue-btn:hover:not(:disabled) {
-  filter: brightness(1.12);
+  opacity: 0.85;
 }
 .qp-queue-btn:disabled {
-  opacity: 0.35;
+  opacity: 0.3;
   cursor: not-allowed;
 }

--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -1,14 +1,24 @@
 import { useRef, useState, useEffect } from "react";
-import { X, ListOrdered } from "lucide-react";
-import { useQueue, enqueue, removeFromQueue, clearQueue } from "../store/messageQueue";
+import { X, ListOrdered, Eraser, Send } from "lucide-react";
+import { useQueue, enqueue, dequeue, removeFromQueue, clearQueue } from "../store/messageQueue";
 import "./QueuePanel.css";
 
 interface Props {
   sessionId: string;
   onClose: () => void;
+  // Writes text directly to the PTY (used by the Send button, bypassing the
+  // work-done dequeue hook). Kept as a prop so QueuePanel doesn't need to know
+  // about invoke / sessionManager — the parent owns that wiring.
+  onSend: (text: string) => void;
+  // The active agent's context-reset REPL command (e.g. "/clear", "/new",
+  // ".clear"), from the agent manifest. Undefined for user-added agents that
+  // haven't set one — we fall back to "/clear" since it's the near-universal
+  // convention for modern coding-agent TUIs.
+  clearCommand?: string;
 }
 
-export function QueuePanel({ sessionId, onClose }: Props) {
+export function QueuePanel({ sessionId, onClose, onSend, clearCommand }: Props) {
+  const clearCmd = clearCommand || "/clear";
   const queue = useQueue(sessionId);
   const [draft, setDraft] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -25,7 +35,7 @@ export function QueuePanel({ sessionId, onClose }: Props) {
     return () => window.removeEventListener("keydown", onKey, true);
   }, [onClose]);
 
-  function submit() {
+  function queueDraft() {
     const text = draft.trim();
     if (!text) return;
     enqueue(sessionId, text);
@@ -33,11 +43,35 @@ export function QueuePanel({ sessionId, onClose }: Props) {
     inputRef.current?.focus();
   }
 
+  // Start the queue right now: enqueue the draft (if any), then pop the head
+  // and write it to the PTY. Subsequent items flow through the existing
+  // work-done dequeue hook in WorkspaceView, so one click kicks off the whole
+  // sequence — no waiting for the agent to idle first.
+  function startQueue() {
+    const text = draft.trim();
+    if (text) enqueue(sessionId, text);
+    setDraft("");
+    const item = dequeue(sessionId);
+    if (item) onSend(item.text);
+    inputRef.current?.focus();
+  }
+
+  // Explicit clear injection — enqueues the agent's context-reset command as
+  // its own item so the running agent resets between queued tasks (issue #34).
+  // Opt-in: user clicks to insert. The command varies per agent (Claude Code
+  // /clear, Codex /new, Goose .clear, …) and comes from the agent manifest.
+  function addClear() {
+    enqueue(sessionId, clearCmd);
+    inputRef.current?.focus();
+  }
+
   return (
     <div className="qp-panel">
       <div className="qp-header">
-        <ListOrdered size={13} className="qp-header-icon" />
+        <ListOrdered size={12} className="qp-header-icon" />
         <span className="qp-title">Message Queue</span>
+        {queue.length > 0 && <span className="qp-count">{queue.length}</span>}
+        <span className="qp-header-spacer" />
         {queue.length > 0 && (
           <button className="qp-clear" onClick={() => clearQueue(sessionId)}>
             Clear all
@@ -51,7 +85,10 @@ export function QueuePanel({ sessionId, onClose }: Props) {
       {queue.length > 0 && (
         <ol className="qp-list">
           {queue.map((item, i) => (
-            <li key={item.id} className="qp-item">
+            <li
+              key={item.id}
+              className={`qp-item${item.text.trim() === clearCmd ? " qp-item--clear" : ""}`}
+            >
               <span className="qp-item-index">{i + 1}</span>
               <span className="qp-item-text">{item.text}</span>
               <button
@@ -67,7 +104,7 @@ export function QueuePanel({ sessionId, onClose }: Props) {
       )}
 
       {queue.length === 0 && (
-        <p className="qp-empty">No messages queued. The next message you add will be sent automatically when the agent finishes.</p>
+        <p className="qp-empty">Nothing queued. The next message you add will be sent automatically when the agent finishes.</p>
       )}
 
       <div className="qp-compose">
@@ -79,15 +116,47 @@ export function QueuePanel({ sessionId, onClose }: Props) {
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submit(); }
+            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); queueDraft(); }
             e.stopPropagation();
           }}
         />
         <div className="qp-compose-footer">
-          <span className="qp-hint">Enter to queue · Shift+Enter for newline · Esc to close</span>
-          <button className="qp-queue-btn" disabled={!draft.trim()} onClick={submit}>
-            Queue
-          </button>
+          <div className="qp-compose-left">
+            <button
+              className="qp-chip"
+              onClick={addClear}
+              title={`Enqueue ${clearCmd} so the agent resets context between tasks`}
+            >
+              <Eraser size={12} />
+              <span>Add {clearCmd}</span>
+            </button>
+            <span className="qp-hint">
+              <kbd className="qp-kbd">Enter</kbd> queue
+              <span className="qp-hint-sep">·</span>
+              <kbd className="qp-kbd">Shift</kbd>+<kbd className="qp-kbd">Enter</kbd> newline
+              <span className="qp-hint-sep">·</span>
+              <kbd className="qp-kbd">Esc</kbd> close
+            </span>
+          </div>
+          <div className="qp-compose-actions">
+            <button
+              className="qp-send-btn"
+              disabled={!draft.trim() && queue.length === 0}
+              onClick={startQueue}
+              title="Start the queue now — sends the first item to the agent immediately"
+            >
+              <Send size={12} />
+              <span>Send</span>
+            </button>
+            <button
+              className="qp-queue-btn"
+              disabled={!draft.trim()}
+              onClick={queueDraft}
+              title="Add this message to the queue"
+            >
+              Queue
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/SessionBadges.tsx
+++ b/src/components/SessionBadges.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Loader, Bell } from "lucide-react";
+import { Loader, Bell, CheckCircle2 } from "lucide-react";
 import {
   useWorkState,
   useAttention,
@@ -14,9 +14,9 @@ import { useQueue } from "../store/messageQueue";
 export const WorkStateBadge = memo(function WorkStateBadge({ sessionId }: { sessionId: string }) {
   const state = useWorkState(sessionId);
   const attention = useAttention(sessionId);
-  if (attention) return <Bell size={11} className="work-attention-bell" aria-label="Agent waiting for input" />;
-  if (state === "working") return <Loader size={11} className="spin work-spinner" />;
-  if (state === "done") return <span className="work-done-dot" aria-label="Agent finished" />;
+  if (attention) return <Bell size={12} className="work-attention-bell" aria-label="Agent waiting for input" />;
+  if (state === "working") return <Loader size={12} className="spin work-spinner" />;
+  if (state === "done") return <CheckCircle2 size={12} className="work-done-check" aria-label="Agent finished" />;
   return null;
 });
 
@@ -43,9 +43,9 @@ export const QueueBadge = memo(function QueueBadge({
 export const SidebarWorkBadge = memo(function SidebarWorkBadge({ sessionId }: { sessionId: string }) {
   const state = useWorkState(sessionId);
   const attention = useAttention(sessionId);
-  if (attention) return <Bell size={11} className="work-attention-bell" aria-label="Agent waiting for input" />;
-  if (state === "working") return <Loader size={11} className="spin work-spinner" />;
-  if (state === "done") return <span className="work-done-dot" aria-label="Agent finished" />;
+  if (attention) return <Bell size={12} className="work-attention-bell" aria-label="Agent waiting for input" />;
+  if (state === "working") return <Loader size={12} className="spin work-spinner" />;
+  if (state === "done") return <CheckCircle2 size={12} className="work-done-check" aria-label="Agent finished" />;
   return null;
 });
 
@@ -88,6 +88,6 @@ export const ProjectWorkBadge = memo(function ProjectWorkBadge({ sessionIds }: {
   }
   if (anyAttention) return <Bell size={10} className="work-attention-bell" aria-label="Agent waiting for input" />;
   if (anyWorking) return <Loader size={10} className="spin work-spinner" />;
-  if (anyDone) return <span className="work-done-dot" aria-label="Agent finished" />;
+  if (anyDone) return <CheckCircle2 size={12} className="work-done-check" aria-label="Agent finished" />;
   return null;
 });

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -133,7 +133,7 @@ export const TerminalPane = memo(forwardRef<TerminalPaneHandle, Props>(function 
     searchAddonRef.current = searchAddon;
     term.loadAddon(searchAddon);
 
-    term.loadAddon(new WebLinksAddon((_, url) => openUrl(url).catch(() => {})));
+    term.loadAddon(new WebLinksAddon((ev, url) => { if (ev.ctrlKey || ev.metaKey) openUrl(url).catch(() => {}); }));
 
     term.open(el);
 

--- a/src/components/Toolbar.css
+++ b/src/components/Toolbar.css
@@ -46,6 +46,13 @@
   transition: color 0.15s;
 }
 
+.bar .work-done-check,
+.bar .work-spinner,
+.bar .work-attention-bell {
+  width: 12px;
+  height: 12px;
+}
+
 .bar button {
   display: flex;
   align-items: center;
@@ -455,6 +462,9 @@
 
 .bar.tabs-designer .tab-close svg          { width: 12px; height: 12px; stroke-width: 2.2; }
 .bar.tabs-designer .agent-box:hover .tab-close { opacity: 1; pointer-events: auto; }
+.bar.tabs-designer .agent-box:hover .work-done-check,
+.bar.tabs-designer .agent-box:hover .work-spinner,
+.bar.tabs-designer .agent-box:hover .work-attention-bell { opacity: 0; }
 .bar.tabs-designer .tab-close:hover        { background: transparent; }
 .bar.tabs-designer .tab-close:hover svg    { opacity: 0.6; }
 .bar.tabs-designer .agent-box:hover        { background: rgba(0,0,0,.05); opacity: 0.6; }

--- a/src/components/WorkspaceView.css
+++ b/src/components/WorkspaceView.css
@@ -1718,16 +1718,16 @@
 /* Work-done detection indicators (agent sessions) */
 .work-spinner {
   flex-shrink: 0;
+  margin-left: auto;
+  margin-right: -4px;
   color: var(--tempest-accent-blue);
 }
 
-.work-done-dot {
+.work-done-check {
   flex-shrink: 0;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--tempest-terminal-green, var(--tempest-accent-blue));
-  box-shadow: 0 0 4px var(--tempest-terminal-green, var(--tempest-accent-blue));
+  margin-left: auto;
+  margin-right: -4px;
+  color: var(--tempest-terminal-green, var(--tempest-accent-blue));
 }
 
 .work-attention-dot {
@@ -1741,6 +1741,8 @@
 
 .work-attention-bell {
   flex-shrink: 0;
+  margin-left: auto;
+  margin-right: -4px;
   color: var(--tempest-accent-orange, #f5a130);
 }
 

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -129,6 +129,7 @@ import { folderName, timeAgo } from "../lib/format";
 import { getHookCommands, runHook, type HookKind } from "../lib/worktreeHooks";
 import { portForWorkspace, hostSlug, proxyUrl } from "../lib/servicePort";
 import { buildAgentArgs } from "../lib/agentArgs";
+import { getAgent } from "../lib/agentRegistry";
 import { getAgentConfig } from "../lib/runtimeState";
 import {
   type SplitDir,
@@ -2773,12 +2774,6 @@ export function WorkspaceView({ zen, name, path }: Props) {
                       <X size={10} />
                     </button>
                   )}
-                  {!s.kind && s.agent && !hidden && queueOpenSessionId === s.id && (
-                    <QueuePanel
-                      sessionId={s.id}
-                      onClose={() => setQueueOpenSessionId(null)}
-                    />
-                  )}
                   {s.kind === "diff" ? (
                     <DiffPane
                       sessionId={s.id}
@@ -3022,6 +3017,23 @@ export function WorkspaceView({ zen, name, path }: Props) {
             );
           })()}
             </div>{/* canvas */}
+            {(() => {
+              const s = queueOpenSessionId
+                ? sessions.find((x) => x.id === queueOpenSessionId && !x.kind && x.agent)
+                : null;
+              return s ? (
+                <QueuePanel
+                  sessionId={s.id}
+                  onClose={() => setQueueOpenSessionId(null)}
+                  clearCommand={(s.agent ? getAgent(s.agent) : undefined)?.clearCommand}
+                  onSend={(text) => {
+                    const bytes = Array.from(new TextEncoder().encode(text + "\r"));
+                    invoke("write_to_pty", { sessionId: s.id, data: bytes }).catch(() => {});
+                    sessionManager.markUserInput(s.id);
+                  }}
+                />
+              ) : null;
+            })()}
             {/* Overview has no footer of its own, so one drops in to carry the
                 notice. Only here — inside a session the status bar cycle takes
                 over rather than shifting the canvas out from under the user. */}

--- a/src/lib/agentManifest.ts
+++ b/src/lib/agentManifest.ts
@@ -62,6 +62,12 @@ export interface AgentConfig {
   // Informational: id of the agent this one was cloned from. No behavior; just
   // shown in the settings header so the lineage is visible.
   extends?: string;
+  // Text sent to the agent's PTY to reset its conversation context (e.g.
+  // "/clear" for Claude Code, "/new" for agents that start a fresh chat). Used
+  // by the Message Queue's Add-clear button to be agent-aware. Omit to hide the
+  // button. Sourced from each agent's documented slash-command set — the REPL
+  // commands the binary's own `--help` describes, or the /help output.
+  clearCommand?: string;
 }
 
 /// A validated manifest entry. It PATCHES an agent of the same id (so an override
@@ -142,8 +148,21 @@ function sanitizeEntry(a: unknown): RemotePatch | null {
   if (dl) patch.downloadUrl = dl;
   const capture = captureSpec(e.capture);
   if (capture) patch.capture = capture;
+  const clear = clearCmd(e.clearCommand);
+  if (clear) patch.clearCommand = clear;
   return patch;
 }
+
+// A clear command reaches the agent's PTY verbatim followed by a carriage
+// return. Bounded and printable so a stray manifest value can't smuggle
+// control sequences.
+const clearCmd = (v: unknown): string | undefined => {
+  if (typeof v !== "string") return undefined;
+  const s = v.trim();
+  if (!s || s.length > 64) return undefined;
+  // Printable ASCII only — no controls, no newlines.
+  return /^[\x20-\x7E]+$/.test(s) ? s : undefined;
+};
 
 export function sanitizeManifestAgents(list: unknown): RemotePatch[] {
   if (!Array.isArray(list)) return [];
@@ -196,6 +215,8 @@ export function sanitizeCustomAgent(a: unknown): RemotePatch | null {
   if (capture) patch.capture = capture;
   if (e.disabled === true) patch.disabled = true;
   if (typeof e.extends === "string" && e.extends) patch.extends = e.extends;
+  const clear = clearCmd(e.clearCommand);
+  if (clear) patch.clearCommand = clear;
   return patch;
 }
 

--- a/src/store/messageQueue.ts
+++ b/src/store/messageQueue.ts
@@ -24,18 +24,20 @@ function subscribe(sessionId: string, fn: () => void): () => void {
   };
 }
 
+// All mutations replace the array reference — useSyncExternalStore uses
+// Object.is on the snapshot, so in-place splice/push would go undetected.
 export function enqueue(sessionId: string, text: string): void {
-  const q = queues.get(sessionId) ?? [];
-  q.push({ id: crypto.randomUUID(), text });
-  queues.set(sessionId, q);
+  const prev = queues.get(sessionId) ?? [];
+  queues.set(sessionId, [...prev, { id: crypto.randomUUID(), text }]);
   emit(sessionId);
 }
 
 export function dequeue(sessionId: string): QueueItem | undefined {
   const q = queues.get(sessionId);
   if (!q?.length) return undefined;
-  const item = q.shift()!;
-  if (q.length === 0) queues.delete(sessionId);
+  const [item, ...rest] = q;
+  if (rest.length === 0) queues.delete(sessionId);
+  else queues.set(sessionId, rest);
   emit(sessionId);
   return item;
 }
@@ -43,8 +45,11 @@ export function dequeue(sessionId: string): QueueItem | undefined {
 export function removeFromQueue(sessionId: string, itemId: string): void {
   const q = queues.get(sessionId);
   if (!q) return;
-  const idx = q.findIndex((i) => i.id === itemId);
-  if (idx !== -1) { q.splice(idx, 1); emit(sessionId); }
+  const next = q.filter((i) => i.id !== itemId);
+  if (next.length === q.length) return;
+  if (next.length === 0) queues.delete(sessionId);
+  else queues.set(sessionId, next);
+  emit(sessionId);
 }
 
 export function clearQueue(sessionId: string): void {


### PR DESCRIPTION
## Summary

- Queue panel docks as a drawer under the workspace. The terminal stays in view when the queue opens, and panes shrink into the remaining space through flex flow.
- New Send button starts the queue immediately. It enqueues the current draft if any, pops the head, and writes it to the PTY. The work done hook then dequeues the rest.
- New Add /clear chip is opt in. Clicking it enqueues the agent context reset command as its own item, which addresses the sequential slash command flow in issue #34.
- Clear command is agent aware. Each entry in config/agents.json declares its own reset string. Claude uses /clear, Codex uses /new, Goose uses .clear. QueuePanel reads the value through a prop, and defaults to /clear for user added agents that have not set one.
- Fixed a store bug in messageQueue.ts. In place mutations reused the array reference, so useSyncExternalStore missed updates and the per item remove buttons did nothing. Every mutation now replaces the array reference.
- Small UI polish sitting in the tree also lands: a check icon for the work done state, and ctrl click on links inside the terminal.

Closes #34.

## Test plan

- [x] Open the queue on an agent session. Queue two messages. Hit Send. Confirm the first fires immediately, and the second fires after work done.
- [x] Click Add /clear on Claude Code. Confirm the enqueued text is /clear. Switch to Codex and repeat. Confirm the text is /new.
- [x] Remove a queued item through the per item X button. Confirm the list updates.
- [x] Open the queue and watch the panes shrink. Close the queue and watch them grow back.
- [x] Ctrl click a link inside the terminal, and confirm it opens.