### PR TITLE
docs: cover tasks, automations, chat, knowledge base, BYOK, message queue

### DIFF
--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -296,36 +296,51 @@ Broadcasting allows you to send the same message to multiple agent sessions simu
 
 ## Message Queue
 
-The message queue buffers messages for an agent when it is still working on a previous task. Instead of blocking, messages are queued and automatically sent when the agent returns to its prompt.
+The message queue buffers messages for an agent so you can line up follow-ups without waiting for it to idle. The queue is a per-session drawer that pins to the right edge of the workspace canvas — it stays open while you switch panes and closes with `Esc`.
 
 ### Queue Behavior
 
-1. **Agent is working**: When you type a message and press Enter while the agent is still thinking, the message is queued instead of sent immediately.
-2. **Agent finishes**: When the agent's work-done signal fires, the queue is checked. If a message is waiting, it is automatically sent.
-3. **Queue persistence**: Messages remain in the queue until the session closes or you manually clear them.
+1. **Compose ahead**: Type any message in the queue drawer and press `Enter` (or click **Queue**) to add it. `Shift+Enter` inserts a newline.
+2. **Auto-send on idle**: When the agent's work-done signal fires, the head of the queue is written to the PTY automatically. Each subsequent completion drains the next item.
+3. **Send now**: The **Send** button starts the queue immediately — it enqueues the current draft (if any), pops the head, and writes it to the agent without waiting for a done signal. Useful when the agent is already idle or when you want to kick off the sequence explicitly.
+4. **Queue persistence**: Items remain in the queue until they're sent, removed, or the session closes.
 
 ### Accessing the Queue
 
-Press `Ctrl+Shift+Q` (or your configured shortcut) to open the QueuePanel for the active agent session. Here you can:
+Open the drawer from the tab (queue icon on the agent tab), the terminal footer, or the keyboard shortcut (`Ctrl+Shift+Q` by default). Each tab shows a badge with the queue length while items are pending. Inside the drawer you can:
 
-- View all queued messages in order
-- Add new messages to the queue
-- Remove individual messages
-- Clear the entire queue
-- See a badge on the tab indicating queue length
+- View queued messages in order with their position index
+- Add or remove individual messages
+- Click **Clear all** in the header to empty the queue
+- Insert an agent-aware context reset (see below)
+- **Send** to start the queue immediately, or **Queue** to append without sending
+
+### Agent-Aware Clear
+
+The queue's **Add `/clear`** chip enqueues the running agent's context-reset command as its own item, so a long multi-step run can reset between tasks without you switching to the terminal.
+
+The exact command comes from each agent's manifest (`clearCommand`):
+
+| Agent | Reset command |
+|-------|--------------|
+| Claude Code | `/clear` |
+| Codex CLI | `/new` |
+| Goose | `.clear` |
+| Gemini CLI, Aider, Opencode, others | `/clear` (fallback) |
+
+The chip label updates to match the active agent (for example, "Add `/new`" for Codex sessions). Queued clear items render with a distinct style in the list so they're easy to spot among prompts.
 
 ### Example Workflow
 
 1. Agent is analyzing code (working)
-2. You type "Now check the tests" and press Enter
-3. Message is queued (not sent yet, since agent is busy)
-4. Agent finishes analyzing
-5. First queued message "Now check the tests" is automatically sent
-6. Agent responds with test results
-7. Agent finishes (work-done signal fires)
-8. Next queued message (if any) is sent
+2. You open the queue, type "Now check the tests" and press `Enter` → queued
+3. Click **Add `/clear`** → context reset queued right after
+4. Type "Summarise what you found" and press `Enter` → queued
+5. Agent finishes analyzing → first item sent
+6. Agent finishes tests → context reset sent → agent resets
+7. Agent returns to prompt → final summary prompt sent
 
-This allows you to compose multiple instructions while the agent is thinking, ensuring they are delivered in order when the agent is ready.
+This lets you compose multi-turn workflows in one place and have them delivered in order, with clean context breaks in between.
 
 ## Environment and Configuration
 

--- a/docs/agents/supported.mdx
+++ b/docs/agents/supported.mdx
@@ -479,26 +479,37 @@ If Codex CLI doesn't launch:
 | Cline | No | — | `~/.cline` | Yes (Anthropic) |
 | Cursor Agent | No | — | Cursor IDE config | Varies |
 | Goose | No | — | `~/.goose` | Varies |
+| Amp, Hermes, Pi, fx, Grok | Manifest-defined | Per manifest | Per CLI | Per CLI |
+
+## Manifest-Driven Agents
+
+The full agent list ships as [`config/agents.json`](https://github.com/tempestai-dev/tempest/blob/main/config/agents.json). The `AgentConfig` fields on each entry — `hint`, `sessionIdArgs`, `resumeArgs`, `capturePattern`, `captureResumeArgs`, `autoApproveArgs`, `printArgs`, `modelArgs`, `clearCommand` — are what every surface in Tempest reads: the New Session menu, the [Automations](/automations/overview) headless runner, the [Chat pane](/chat/overview) bridges, and the [Message Queue's agent-aware clear](/agents/overview#agent-aware-clear).
+
+Agents added since this table was first written and driven entirely through the manifest: Antigravity, Codex CLI, Cursor Agent, Gemini CLI, Amp, Hermes, Pi, fx, Grok.
+
+Tempest periodically fetches an updated manifest from the tempestai-dev/tempest repository at startup — a new agent added upstream shows up in your workspace without needing to rebuild.
 
 ## Adding a New Agent
 
 To add support for a new agent to Tempest:
 
-1. **Define the agent config** in `src/components/NewSessionMenu.tsx`:
-   ```typescript
+1. **Add an entry to `config/agents.json`**:
+   ```json
    {
-     name: "My Agent",
-     hint: "myagent",           // CLI command
-     iconSrc: myAgentIconSrc,   // Icon SVG
-     sessionIdArgs: ["--session-id", "{UUID}"],    // or null
-     resumeArgs: ["--resume", "{UUID}"],           // or null
-     capturePattern: /pattern/,  // optional
-     captureResumeArgs: ["-s", "{UUID}"],  // optional
-     autoApproveArgs: ["--my-skip-flag"],  // optional — appended when auto-approve is enabled
+     "name": "My Agent",
+     "hint": "myagent",
+     "sessionIdArgs": ["--session-id", "{UUID}"],
+     "resumeArgs": ["--resume", "{UUID}"],
+     "capturePattern": "([0-9a-f-]{36})",
+     "captureResumeArgs": ["-s", "{UUID}"],
+     "autoApproveArgs": ["--my-skip-flag"],
+     "printArgs": ["-p", "{PROMPT}"],
+     "modelArgs": ["--model", "{MODEL}"],
+     "clearCommand": "/clear"
    }
    ```
 
-2. **Provide an icon** as an SVG file in `src/assets/agent-icons/`
+2. **Provide an icon** as an SVG file in `src/assets/agent-icons/` (or reference an existing one).
 
 3. **Implement work-done detection** (if needed):
    - Add title-based classification to `sessionManager.ts` `classifyTitle()` method if your agent sets a title
@@ -509,4 +520,5 @@ To add support for a new agent to Tempest:
    - Verify the command is constructed correctly
    - Confirm work-done detection fires at the right time
    - Test resumption if your agent supports it
+   - Run it as a headless [automation](/automations/overview) if `printArgs` is set
 

--- a/docs/automations/overview.mdx
+++ b/docs/automations/overview.mdx
@@ -1,0 +1,81 @@
+---
+title: "Automations"
+description: "Run AI agents on a schedule. Status reports, release checks, quality scans — dispatched headlessly, results piped into a live terminal."
+icon: "clock"
+---
+
+# Automations
+
+An **automation** is a scheduled, headless run of any Tempest-supported agent. You pick an agent, write a prompt, choose a schedule, and Tempest fires the CLI in the background whenever the schedule ticks. Output streams into a live terminal on the automation's detail page.
+
+Automations live under the **Automations** section in the sidebar.
+
+## What an automation is
+
+Each automation bundles:
+
+- **Agent** — any agent from your manifest that supports non-interactive output (`printArgs` set)
+- **Prompt** — the message sent to the agent on every run
+- **Schedule** — an RRULE-backed rule (Hourly / Daily / Weekly / Monthly + time)
+- **Model** *(optional)* — free-text, only shown when the agent manifest declares `modelArgs`. Accepts aliases (`haiku`, `sonnet`, `opus`, `fable`) or `provider/model` strings.
+- **Scope** — Global (runs from your home directory) or one open project (runs from that project's root). A project-scoped automation whose project isn't open at fire time is marked `dispatch_failed` with a message telling you to open it first.
+
+## Creating an automation
+
+Click **New Automation** in the Automations page. The dialog has two tabs:
+
+- **Compose** — start blank. Name, agent, model, schedule, prompt.
+- **Templates** — pick from 12 built-ins across four categories: **Status reports**, **Release prep**, **Quality & health**, **Growth**. Templates prefill agent, prompt, and a sensible schedule; you can edit any of it before saving.
+
+## The schedule picker
+
+`SchedulePicker` is a shadcn-styled form (not a cron string field). It has:
+
+- **Frequency** — Hourly, Daily, Weekly, Monthly
+- **Interval** — every N units
+- **Day of week / day of month** — shown only for Weekly and Monthly
+- **Time** — with a 12-hour / 24-hour toggle and your local timezone label
+- **Quick presets** — *Every hour*, *Daily 9am*, *Mon 9am*, *Fri 5pm*
+
+Times are stored as UTC hour/minute and rendered in your local zone. A human-readable summary line appears below the picker so you can double-check the rule before saving.
+
+## The detail page
+
+Open any automation to edit it. The page has:
+
+- **Header** — back link, name, **Run now** button
+- **Schedule** — the picker plus the summary line
+- **Prompt** — a textarea that auto-saves 800ms after you stop typing; every save creates a prompt version you can browse
+- **Output** — a live `TerminalPane` bound to the current or most recent run's PTY. Clicking a run in the sidebar swaps the terminal to that run.
+- **Sidebar** — Agent picker, Model input, **Next run** timestamp, and **Recent runs** (last 8, with status)
+
+Each row in the automations list has an enable/disable toggle. Disabled automations skip the scheduler but stay editable.
+
+## How runs are dispatched
+
+A background scheduler thread wakes every 60 seconds. For every automation whose `next_run_at` is due, it emits a `automation:dispatch` event that the frontend catches and hands to the same runner used by **Run now**.
+
+The runner:
+
+1. Resolves the working directory (project path or `$HOME` for Global scope)
+2. Builds the command from the agent manifest:
+   - `hint` — the CLI (`claude`, `gemini`, `opencode`, …)
+   - `printArgs` — the non-interactive form (e.g. Claude's `-p "{PROMPT}"`, opencode's `run … {PROMPT}`). `{PROMPT}` is substituted with the automation's prompt.
+   - `modelArgs` — appended with `{MODEL}` substituted, if a model override is set
+   - `autoApproveArgs` — appended when Settings → **Auto-approve agent tool calls** is on
+3. Spawns a PTY session in the resolved cwd and streams output to the terminal pane
+4. Marks the run `dispatching → dispatched → succeeded` (or `dispatch_failed`)
+
+Agents without a `printArgs` entry in the manifest are hidden from the agent picker — automations refuse to run without one.
+
+## Storage
+
+Automations, runs, and prompt versions live in the Tempest SQLite database, in three tables: `automations`, `automation_runs`, `automation_prompt_versions`. Deleting an automation cascades to its runs and versions.
+
+## Related Tauri commands
+
+The Rust backend exposes: `list_automations`, `get_automation`, `create_automation`, `update_automation`, `delete_automation`, `list_automation_runs`, `upsert_automation_run`, `list_prompt_versions`, `save_prompt_version`. The frontend store (`src/store/automations.ts`) wraps them.
+
+## Global settings that apply
+
+- **Auto-approve agent tool calls** (Settings → Security) — if on and the agent's manifest has `autoApproveArgs`, those flags are appended to headless runs, matching the behaviour of interactive sessions.

--- a/docs/chat/overview.mdx
+++ b/docs/chat/overview.mdx
@@ -1,0 +1,74 @@
+---
+title: "Chat Pane"
+description: "Headless chat with hosted LLMs or CLI agents from inside the workspace canvas. No terminal, no TUI."
+icon: "message-square"
+---
+
+# Chat Pane
+
+The chat pane is a canvas node that renders a headless conversation with an LLM or an agent CLI — no terminal, no TUI. It sits alongside terminal-based agent sessions on the workspace canvas and is meant for quick asks, planning, and one-shot generations without the ceremony of a full agent tab.
+
+Add one from the canvas node picker (**+ → Chat**), or convert a selection into a chat via the canvas context menu.
+
+## Three backends, one UI
+
+Every chat node picks one of three backends via the model dropdown. The choice is per-node:
+
+| Backend | What it uses | Auth |
+|---------|--------------|------|
+| **API** (BYOK) | Provider SDK called from the Rust backend | [OS credential manager](/settings/api-keys) |
+| **CLI Agent** | The vendor CLI, driven headlessly by a per-turn Node bridge | Whatever the CLI itself is logged into |
+| **Warp** (experimental) | The `warpllm` Rust gateway, single-round-trip | BYOK slot or provider env var |
+
+Streaming, message rendering, tool-call display, and copy-to-clipboard behave the same regardless of backend.
+
+## Model picker
+
+Clicking the model chip opens a portal picker with two sections:
+
+- **CLI Agents** — grouped by agent (Claude Code, Codex, Gemini CLI, Opencode). Each agent has a shortlist of its own models. When the experimental Warp toggle is on, Warp shows up here too with a `provider/model` list (OpenAI, DeepSeek, Kimi, OpenRouter).
+- **BYOK providers** — Anthropic, OpenAI, Google Gemini, Mistral, DeepSeek, xAI, Groq, OpenRouter, Ollama, LM Studio — each with a shortlist. The active provider is remembered across sessions.
+
+A search box across the picker filters both sections at once.
+
+## CLI agent bridges
+
+The four CLI-agent backends (Claude Code, Codex, Gemini CLI, Opencode) all run through per-turn Node sidecars shipped inside the app under `src-tauri/resources/{agent}-bridge/bridge.mjs`. The Rust backend spawns the sidecar on `claude_stream_start`, streams NDJSON back over a `claude://{streamId}` Tauri channel, and the frontend maps it to typed chat events.
+
+Under the hood each bridge shells the vendor CLI in a specific non-interactive mode:
+
+- **Claude Code** — Anthropic's Claude Code CLI in stream mode
+- **Codex** — `codex exec --json --sandbox workspace-write` (no per-tool approvals)
+- **Gemini** — `gemini --experimental-acp` speaking JSON-RPC ACP (per-tool permission prompts surface as chat UI)
+- **Opencode** — `opencode serve` on a free local port, consuming its SSE stream and permission POSTs
+
+**Auth for CLI bridges is whatever the CLI already has on your machine.** Tempest does not hand a BYOK key to the CLI bridges — if you can `claude` in your terminal, you can chat with Claude Code in the pane.
+
+## Warp (experimental)
+
+Warp is an opt-in, single-round-trip gateway that routes any `provider/model` string through a Rust `warp_chat` command. Enable it in **Settings → Experimental → warpllm**. The Agents section of the model picker then shows Warp with its own model list.
+
+Warp reads the API key for the selected provider from either:
+
+1. The matching [BYOK slot](/settings/api-keys), or
+2. An environment variable — `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY` (for Kimi), or `OPENROUTER_API_KEY`
+
+Warp responses are not streamed; you'll see the whole reply arrive at once.
+
+## Chat pane vs terminal sessions
+
+| | Chat pane | Terminal session |
+|--|-----------|-----------------|
+| Interface | Headless message stream | Full PTY / TUI |
+| Backend | API / CLI bridge / Warp | Vendor CLI in a real shell |
+| Persistence | Canvas node state | Session store + PTY resume |
+| Tool calls | Rendered inline as event cards | Whatever the CLI's UI shows |
+| Best for | Planning, quick asks, embedding into a larger canvas | Long agent runs, file edits, tool-heavy tasks |
+| Isolation | Same process as the app | Hephaestus sandbox (see [Agents](/agents/overview)) |
+
+Both surfaces are first-class. A common workflow is to plan and iterate in a chat node, then hand the final prompt off to a terminal agent session in a fresh worktree.
+
+## Related settings
+
+- **Settings → API Keys** — BYOK slots consumed by both the API backend and Warp. See [API Keys](/settings/api-keys).
+- **Settings → Experimental → warpllm** — reveals the Warp backend in the picker.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,6 +52,18 @@
         "pages": ["agents/overview", "agents/supported"]
       },
       {
+        "group": "Chat",
+        "pages": ["chat/overview"]
+      },
+      {
+        "group": "Tasks",
+        "pages": ["tasks/overview"]
+      },
+      {
+        "group": "Automations",
+        "pages": ["automations/overview"]
+      },
+      {
         "group": "Git",
         "pages": ["git/overview", "git/worktrees", "git/staging-commits", "git/push-pr"]
       },
@@ -62,6 +74,14 @@
       {
         "group": "Token Intelligence",
         "pages": ["token-intelligence/overview", "token-intelligence/mcp"]
+      },
+      {
+        "group": "Knowledge Base",
+        "pages": ["knowledge-base/overview"]
+      },
+      {
+        "group": "Settings",
+        "pages": ["settings/api-keys"]
       },
       {
         "group": "Themes",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -55,13 +55,17 @@ Review your changes, stage files, write commits, and open pull requests without 
 Tempest works with any CLI-based AI coding agent. Built-in support for:
 
 - Claude Code
-- Aider
-- OpenCode
+- Codex CLI
+- Gemini CLI
+- Opencode
 - Copilot CLI
 - Cline
+- Cursor Agent
+- Antigravity
 - Goose
+- Amp, Hermes, Pi, fx, Grok
 
-More agents can be added to the platform.
+The agent list ships in [`config/agents.json`](https://github.com/tempestai-dev/tempest/blob/main/config/agents.json) and can be extended or updated in place — see [Supported Agents](/agents/supported).
 
 ## What's Coming
 

--- a/docs/knowledge-base/overview.mdx
+++ b/docs/knowledge-base/overview.mdx
@@ -1,0 +1,115 @@
+---
+title: "Knowledge Base"
+description: "The visual side of Token Intelligence — an interactive graph of your codebase plus a docs library you drop into it."
+icon: "network"
+---
+
+# Knowledge Base
+
+The Knowledge Base tab is the visual companion to [Token Intelligence (Atlas)](/token-intelligence/overview). Where Atlas gives your agents a machine-readable code graph, the Knowledge Base gives *you* a way to see the same graph, drop your own docs into it, and explore how symbols connect.
+
+Open it from the sidebar's **Knowledge Base** entry. Only projects with an existing `.atlas/` database show up in the project picker.
+
+## Layout
+
+The tab renders a full-bleed, Obsidian-style force-directed graph on an HTML canvas.
+
+**Top toolbar (`KbToolbar`):**
+
+- Project picker — every project with an Atlas index on disk
+- Zoom in / out / fit-to-view / reset
+- **Docs** toggle — reveals the floating documents panel
+
+**Main canvas (`.kb-canvas-wrap`):**
+
+- D3 force simulation of the Atlas node/edge graph fetched via the `get_atlas_graph` Tauri command
+- Pan by dragging the background, drag any node, mouse-wheel or pinch to zoom
+- A minimap in the corner for jump-to-region navigation
+- Clicking a node opens `NodeDetailPanel`; clicking blank space deselects
+- Selection highlights the node's neighborhood (nodes + edges) so multi-hop context stays visible
+
+## The Docs panel (floating)
+
+Toggling **Docs** in the toolbar floats the `AssetsPanel` over the graph — the canvas keeps its bounds, the panel is an overlay. It's the surface for anything that isn't source code: markdown notes, plain text, PDFs, YAML, JSON.
+
+**Header:** *Documents* title, **Add**, close (X).
+
+**Rows** show:
+
+- Filename
+- MIME subtype (`markdown`, `pdf`, `text`, …)
+- **N linked** badge when the asset has `describes` edges to code symbols
+- Trash icon to remove
+
+**Empty state:** *"Add markdown notes, text files, or PDFs to index them in the knowledge graph."*
+
+Click **Add** to open a file dialog and pick one or more files. Each becomes an `asset` node in the graph and can be linked to code symbols via `describes` edges — the same edge kind Atlas uses for imports and calls, so search and traversal treat docs as first-class citizens.
+
+### Supported asset types
+
+- **Markdown / text** — `.md`, `.mdx`, `.markdown`, `.txt`, `.text`, `.log`, `.json`, `.yaml`, `.yml`, `.rst`, `.adoc`, `.org` (extracted verbatim)
+- **PDF** — parsed with `pdf-parse` (an optional dependency; if not installed, the PDF is tracked but with no extracted text)
+- **Anything else** — stored as a tracked, null-text asset
+
+### Chunking behaviour
+
+The extracted text is capped and split for semantic search:
+
+- Extracted text capped at **200,000 characters** per asset
+- FTS docstring capped at **4,000 characters**
+- Documents longer than **1,500 characters** are split into ~1,500-char chunks with **100-char overlap**, stored in an `asset_chunks` table so semantic hits land on the relevant passage instead of the whole doc's mean embedding
+- Short documents ride the single-node embedding path
+
+## Semantic search
+
+Semantic search is **opt-in**. Enable it in **Settings → Token Intelligence → Semantic search**; the first toggle downloads a one-time ~25 MB MiniLM model with a progress bar, then flips the `atlasSemantic` flag.
+
+Once enabled, semantic ranking runs across both code symbols and asset chunks — a natural-language query like *"how does token bucket rate limiting work"* returns matching passages regardless of whether they live in code comments, a design doc PDF, or a class method.
+
+Agents invoke it through the MCP tool `atlas_semantic_search`. If a client asks for it while semantic is off, it responds with a graceful "semantic search is off" note instead of an error.
+
+## Rationale nodes (WHY / NOTE / HACK / TODO)
+
+Comments in your source code become first-class graph nodes when they carry a rationale tag. Just write the comment — no config, no tooling. Atlas picks them up on the next index or sync pass.
+
+Recognised patterns (language-agnostic, matches any of `//`, `/*`, `*`, `#`, `--`, `;`, `%` openers):
+
+```ts
+// WHY: this cache stays global — per-account locks turned out to blow up under fan-out
+// NOTE: assumes the caller has already resolved the tenant
+// HACK: bypass Google's OAuth loop when the refresh token is < 60 s from expiring
+// TODO: replace this with a proper priority queue once the throughput matters
+```
+
+Each match becomes a `kind: 'rationale'` node with an **explains** edge to the smallest enclosing symbol at that line — usually the method or function containing it, so a query like *"why does X do Y"* becomes a real graph hop rather than a full-text search.
+
+Multi-line continuation comments aren't folded yet — one rationale per opener line. A guard blocks false hits like `URL:` or `someWHY:`.
+
+## MCP tools exposed to agents
+
+The default MCP tool surface for agents is small on purpose — every tool is a strict subset of `atlas_explore`, and each extra listed name was steering wrong picks:
+
+| Tool | What it does |
+|------|-------------|
+| `atlas_explore` | Primary read-equivalent — natural-language question in, verbatim source + call paths + blast radius out |
+| `atlas_assets` | List human-attached knowledge, optional `contentType` / `linkedTo` filters |
+| `atlas_asset_content` | Return the extracted text for one asset id |
+| `atlas_semantic_search` | Vector-similarity ranking across code + assets |
+
+The legacy tools `node`, `search`, `callers`, `callees`, `impact`, `files`, `status` are still implemented and callable — just not listed to agents by default. Re-enable any via the `ATLAS_MCP_TOOLS` env var:
+
+```bash
+ATLAS_MCP_TOOLS=explore,node,search,semantic_search
+```
+
+The **Add** and trash actions in the Docs panel additionally call the mutating tools `atlas_asset_add` and `atlas_asset_remove` — these live on the handler surface but are not part of the read-only default MCP list.
+
+## Settings that apply
+
+| Setting | Location | Effect |
+|---------|----------|--------|
+| **Token Intelligence** | Settings → Token Intelligence | Master switch. Off → no `.atlas/` database, no graph, no tools. |
+| **Semantic search** | Settings → Token Intelligence → Semantic | Downloads the MiniLM model and enables `atlas_semantic_search`. Requires Token Intelligence on. |
+| `ATLAS_MCP_TOOLS` (env) | Per-agent | Re-includes hidden tools in the MCP list. |
+
+The Atlas indexing modal (`AtlasIndexModal`) surfaces on first index, polls for `.atlas/atlas.db` every 2 s, and auto-dismisses ~1.5 s after completion. It streams `atlas:log` events from the indexing process into the modal so you see progress in real time.

--- a/docs/settings/api-keys.mdx
+++ b/docs/settings/api-keys.mdx
@@ -1,0 +1,64 @@
+---
+title: "API Keys (BYOK)"
+description: "Bring your own keys for chat models, external agents, and integrations. Keys are stored in your OS credential manager."
+icon: "key"
+---
+
+# API Keys
+
+Tempest is bring-your-own-key. You enter each provider's API key once, and Tempest hands it to the local model calls, chat bridges, and integrations that need it — never to a Tempest server. **There is no Tempest cloud account, no login, no proxy.**
+
+## Where keys live
+
+Keys are stored in your operating system's credential manager under the service name `tempest-byok`, one entry per provider:
+
+| Platform | Store |
+|----------|-------|
+| Windows | Credential Manager |
+| macOS | Keychain |
+| Linux | Secret Service (GNOME Keyring, KWallet) via D-Bus |
+
+They are never written to `localStorage`, config files, or logs. Only the model selection and the currently-active provider live in `localStorage` — the secret itself sits in the keychain.
+
+Earlier releases stored keys in `localStorage`. On first read after upgrading, Tempest silently promotes any legacy key into the keychain and wipes the plaintext copy.
+
+## Adding a key
+
+Two entry points:
+
+1. **Onboarding** — the first-run flow includes a **Bring your own key** step where you can enter one or more provider keys before reaching the workspace.
+2. **Settings → API Keys** — one row per provider with an input, an eye toggle to reveal the masked value, an edit button, and a trash icon. The masked preview keeps the first four and last four characters (`abcd••••••••wxyz`).
+
+Save writes the key to the OS credential manager. Delete removes it from the store.
+
+## Supported providers
+
+The Settings panel exposes ten provider slots:
+
+- **Anthropic** — Claude (Fable, Opus, Sonnet, Haiku)
+- **OpenAI** — GPT models via the OpenAI API
+- **Google Gemini**
+- **Mistral**
+- **DeepSeek**
+- **xAI** — Grok
+- **Groq**
+- **OpenRouter** — access to many models with one key
+- **Ollama** — local, no key required
+- **Linear** — non-LLM; powers the [Tasks tab](/tasks/overview) Linear integration
+
+Onboarding also lets you point Tempest at a local **LM Studio** base URL.
+
+Keys are stored per provider, not per agent. If you use, for example, OpenCode with an Anthropic model and Claude Code side by side, both draw from the same Anthropic slot.
+
+## Which features use which keys
+
+| Feature | Key needed |
+|---------|-----------|
+| [Chat pane](/chat/overview) with a hosted model | The provider hosting that model |
+| Codex / Gemini / Opencode bridges | The provider they call (usually OpenAI or Anthropic; see agent docs) |
+| warpLLM opt-in agent | Provider chosen in its settings |
+| Local agents (Ollama, LM Studio) | None — a base URL is enough |
+| Tasks tab (Linear sync) | Linear |
+| Tasks tab (GitHub sync) | GitHub personal access token (managed separately in the Tasks tab) |
+
+Agents that ship their own auth (Claude Code CLI, Gemini CLI, and similar) continue to use whatever the CLI is already logged into on your machine. Tempest doesn't touch those.

--- a/docs/tasks/overview.mdx
+++ b/docs/tasks/overview.mdx
@@ -1,0 +1,101 @@
+---
+title: "Tasks"
+description: "A unified inbox for GitHub issues and PRs and Linear issues. Launch agents into fresh worktrees straight from a ticket."
+icon: "list-checks"
+---
+
+# Tasks
+
+The **Tasks** tab is a unified inbox for the work waiting on you across GitHub and Linear. From any row you can inspect the ticket, read its comments and activity, and launch an agent into a fresh worktree preconfigured with the ticket's context.
+
+Open it from the sidebar's **Tasks** entry.
+
+## Layout
+
+Three source tabs sit across the top, each with a live count:
+
+- **Unified** — everything merged
+- **GitHub** — issues and pull requests
+- **Linear** — issues
+
+Below the tabs, a context bar holds source-specific filters and a title search (`/` focuses it). Selecting a row expands an in-place accordion with:
+
+- **Description** — the ticket body
+- **Comments** — pulled live from the source
+- **Activity** — timeline events (commits, state changes, label edits). GitHub "commented" events are filtered out here to avoid duplicating the Comments tab.
+- **Files** and **Checks** on PRs (stub tabs — not wired up yet)
+
+A right rail on the accordion shows Details and Labels. Row buttons: **Launch agent**, open in browser, copy link, close.
+
+Filter state (source, filter chips, search) persists to `localStorage` under `tempest:tasks-page:v1` and survives restarts. Selection and expansion are ephemeral.
+
+## GitHub
+
+**Auth.** Tempest shells out to your local [`gh` CLI](https://cli.github.com/) — there is no in-app OAuth. If `gh` is missing or unauthenticated, the list shows the exact message from `gh auth status` and points at `gh auth login`.
+
+**Context bar:**
+
+- Repo picker — **All repos** or one from `gh repo list`
+- Kind toggle — **Both / Issues / Pull requests**
+- Preset chips — **All, Assigned to me, Created by me, Mentioned, Review requested, Open, Closed**
+
+Sort is fixed to Updated for now.
+
+**Row fields:** `owner/repo#N`, title, state, draft flag, author, assignees, labels (colored), comment count, relative "updated".
+
+## Linear
+
+**Auth.** Personal API key, stored in your OS credential manager. Add it in **[Settings → API Keys](/settings/api-keys)** under the **Linear** slot.
+
+**Context bar:**
+
+- Workspace name (from Linear's viewer; picker disabled — one workspace per key)
+- Scope picker with **Views / Teams / Projects** optgroups. The active view (`v-active`) is the default.
+- Group-by-status toggle
+- **Order by** dropdown — **Priority / Updated / Status / Title**
+
+Sorting is client-side.
+
+**Row fields:** `TEAM-N` id, title, status (backlog/todo/in progress/review/done/cancelled), priority (urgent/high/med/low/none), assignee, labels, project, cycle, team.
+
+## Launching an agent from a task
+
+Click **Launch agent** on any row to open the **Launch Agent** modal:
+
+- **Project** — a fresh worktree will be cut from this project's default branch
+- **Branch** — prefilled: `pr-<n>` or `fix-<n>` for GitHub, the lowercased slugged id for Linear
+- **Agent** — any enabled agent from your manifest
+- **Prompt** — prefilled with the ticket header, body, and a "implement, add a test, open a PR" instruction
+
+Launch is fire-and-forget: the modal closes immediately and the worktree plus agent boot in the background. The row's button flips to **View agent**, which jumps to the live session.
+
+At least one project must be open. If none is, the modal blocks with *"Open a project first — tasks launch into a fresh worktree of a project."*
+
+## Bulk launch
+
+Row checkboxes reveal a floating **BulkBar** with the selected count, a **Launch N** button, and **Clear**. `Ctrl+Enter` / `Cmd+Enter` is a shortcut for **Launch N**.
+
+The modal opens in multi-mode with one tab per selected task. Each tab has its own project, branch, agent, and prompt — you can mix agents across a batch. The footer shows *"N agents ready"* and **Launch N**. Validation runs across every form before firing; the first tab missing a project or branch gets focused.
+
+Each spawn is independent — a failure on one task doesn't block the others.
+
+## Refresh & cache
+
+Task lists are cached in-process for 60 seconds to keep list navigation snappy. The **Refresh** button invalidates the cache and re-fetches.
+
+## Required setup
+
+- **GitHub:** install `gh` and run `gh auth login`. Nothing to configure inside Tempest.
+- **Linear:** paste a personal API key at [Settings → API Keys](/settings/api-keys).
+- **Agents:** at least one agent enabled (not hidden) in Settings.
+- **Projects:** at least one project open in the workspace.
+
+## Under the hood
+
+The Rust backend exposes these Tauri commands (in `src-tauri/src/tasks.rs`):
+
+- `tasks_github_auth`, `tasks_github_repos`, `tasks_github_list`, `tasks_github_thread`
+- `tasks_linear_bootstrap`, `tasks_linear_list`, `tasks_linear_thread`
+- `tasks_cache_invalidate`
+
+GitHub commands wrap `gh` subcommands (`gh search issues|prs`, `gh api …`). Linear commands hit Linear's GraphQL endpoint with the stored key. Agent launches route through the workspace's existing launch pipeline, not a Tasks-specific command.

--- a/docs/token-intelligence/overview.mdx
+++ b/docs/token-intelligence/overview.mdx
@@ -413,39 +413,34 @@ Both fields accept gitignore patterns: `vendor/`, `**/*.min.js`, `src/generated/
 
 ## Graph Operations
 
-Once indexed, agents can query the graph via MCP tools:
-
-**Search:**
-```
-atlas_search "authentication middleware"
-```
-Returns FTS-ranked results: matching symbols, sorted by relevance.
+Once indexed, agents query the graph through a small default MCP surface. The full set is intentionally trimmed — every other tool is a strict subset of `atlas_explore`, and listing them was steering wrong picks:
 
 **Explore:**
 ```
 atlas_explore "How does user login work?" --maxFiles 6
 ```
-Returns relevant subgraph: entry points + related code + relationships.
+The primary read-equivalent. Natural language in; verbatim source grouped by file plus the call paths among them plus a blast-radius summary out. This is usually the only tool you need.
 
-**Node details:**
+**Assets:**
 ```
-atlas_node "src/auth.ts::authenticate" --includeCode
+atlas_assets --contentType application/pdf
+atlas_asset_content <asset-id>
 ```
-Returns symbol metadata + code snippet + callers/callees.
+List and read human-attached knowledge (markdown notes, PDFs, YAML). Assets and their chunks are indexed alongside code — see [Knowledge Base](/knowledge-base/overview) for how to add them.
 
-**Graph traversal:**
+**Semantic search:**
 ```
-atlas_graph "find_callers authenticate"
-atlas_graph "find_usages UserService"
-atlas_graph "type_hierarchy BaseController"
+atlas_semantic_search "how does token bucket rate limiting work"
 ```
-Returns call graphs, usages, type hierarchies.
+Vector-similarity ranking across code symbols and asset chunks. Requires the semantic setting to be on (a one-time ~25 MB MiniLM model download).
 
-**Project structure:**
+**Re-enabling legacy tools:**
+
+`node`, `search`, `callers`, `callees`, `impact`, `files`, and `status` are still implemented and callable. Add them back to the MCP list per-agent with:
+
+```bash
+ATLAS_MCP_TOOLS=explore,node,search,callers,semantic_search
 ```
-atlas_status
-```
-Returns graph statistics, index freshness, database size.
 
 ## Performance Considerations
 
@@ -504,14 +499,10 @@ Returns graph statistics, index freshness, database size.
 - Check `.atlas/daemon.log` for errors
 - Ensure no stale daemon lock at `.atlas/daemon.lock`
 
-## What's Next: Nexus
+## The Knowledge Base tab
 
-Tempest includes a **Nexus page** (code graph visualization interface) that is currently a placeholder for future functionality. Planned features include:
+The visual companion to Atlas ships as the [**Knowledge Base**](/knowledge-base/overview) tab: an interactive force-directed graph of the same node/edge data agents query, a floating **Docs** panel for attaching your own markdown / text / PDF notes, and a minimap. Assets you drop into the Docs panel become real graph nodes with `describes` edges to the code symbols they cover, and (with semantic search on) they're ranked alongside code in `atlas_semantic_search` results.
 
-- Interactive visualization of the code graph
-- Node/edge filtering and search
-- Call graph exploration UI
-- Data flow visualization
-- Type hierarchy browser
+Rationale comments in your source — `// WHY:`, `// NOTE:`, `// HACK:`, `// TODO:` — automatically promote to `rationale` graph nodes with `explains` edges to the smallest enclosing symbol, so *"why does X do Y"* is a real graph hop rather than a full-text search.
 
-This will provide a visual complement to the agent-facing MCP tools, letting developers understand their codebase structure at a glance.
+See [Knowledge Base](/knowledge-base/overview) for the full tour.


### PR DESCRIPTION
## Summary

Refreshes docs to match what actually shipped since the last docs pass. Five new pages, five updates, and the Mintlify nav.

**New pages**
- `tasks/overview` — unified GitHub + Linear inbox, Launch Agent modal, bulk launch, `Ctrl+Enter`
- `automations/overview` — scheduled headless agent runs, `SchedulePicker`, templates, manifest `printArgs` runner
- `chat/overview` — `ChatNode` with three backends (API / CLI-bridge / Warp), model picker, warpLLM opt-in
- `knowledge-base/overview` — force-directed graph, floating Docs panel, asset chunking, PDF extraction, WHY/NOTE/HACK/TODO rationale nodes
- `settings/api-keys` — BYOK stored in the OS credential manager, 10 provider slots

**Updated**
- `agents/overview` — Message Queue rewritten: workspace drawer, Send button, agent-aware clear with per-manifest `clearCommand` table
- `agents/supported` — manifest-driven agents row (Amp, Hermes, Pi, fx, Grok); "Adding a New Agent" rewritten around `config/agents.json`
- `index` — supported-agents list refreshed
- `token-intelligence/overview` — default MCP surface trimmed to `explore`/`assets`/`asset_content`/`semantic_search`; `ATLAS_MCP_TOOLS` env var; "Nexus placeholder" section replaced with pointer to the shipped Knowledge Base tab
- `docs.json` — adds Chat, Tasks, Automations, Knowledge Base, Settings groups

## Test plan
- [x] Preview Mintlify build locally (`mintlify dev` in `docs/`) — every new page renders without warnings
- [x] Sidebar shows the five new groups in the expected order
- [x] Cross-page links resolve: KB ↔ Token Intelligence, Chat ↔ API Keys, Tasks ↔ API Keys, Automations ↔ Agents
- [x] Comparison table in `agents/supported` still renders