### PR TITLE
chore: add OpenSSF Scorecard workflow + badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
   <a href="https://github.com/tempestai-dev/tempest/actions/workflows/ci.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/tempestai-dev/tempest/ci.yml?branch=main&label=build" alt="CI" />
   </a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/tempestai-dev/tempest">
+    <img src="https://img.shields.io/ossf-scorecard/github.com/tempestai-dev/tempest?label=openssf%20scorecard" alt="OpenSSF Scorecard" />
+  </a>
   <a href="https://discord.gg/bRQhAKKVa8">
     <img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord" />
   </a>


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/scorecard.yml` — weekly OpenSSF Scorecard scan, results published to scorecard.dev and uploaded to GitHub code-scanning (SARIF)
- Adds Scorecard shields.io badge to README

## Test plan
- [ ] Workflow runs green on merge
- [ ] Score appears at https://scorecard.dev/viewer/?uri=github.com/tempestai-dev/tempest
- [ ] Badge renders in README