### PR TITLE
feat(tasks): wire Files and Checks tabs on the PR drawer

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,9 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-maximize",
+    "core:window:allow-unmaximize",
+    "core:window:allow-is-maximized",
+    "core:window:allow-set-fullscreen",
     "updater:default",
     "process:allow-restart",
     "notification:default"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4192,6 +4192,8 @@ pub fn run() {
             tasks::tasks_github_repos,
             tasks::tasks_github_list,
             tasks::tasks_github_thread,
+            tasks::tasks_github_pr_files,
+            tasks::tasks_github_pr_checks,
             tasks::tasks_linear_bootstrap,
             tasks::tasks_linear_list,
             tasks::tasks_linear_thread,

--- a/src-tauri/src/tasks.rs
+++ b/src-tauri/src/tasks.rs
@@ -144,6 +144,23 @@ pub struct TaskThread {
     pub activity: Vec<TaskActivity>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PrFile {
+    pub filename: String,
+    pub status: String,
+    pub additions: i64,
+    pub deletions: i64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PrCheck {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}
+
 #[derive(Serialize, Clone, Debug)]
 pub struct GhAuthState {
     pub available: bool,      // `gh` binary on PATH
@@ -598,6 +615,71 @@ fn gh_event_from(v: Value) -> Option<TaskActivity> {
         _ => event.replace('_', " "),
     };
     Some(TaskActivity { id, author, kind: event, detail, created })
+}
+
+/// Files changed by a PR. Paginated to completion so the drawer shows the full
+/// list, not the first 100 rows.
+#[tauri::command(async)]
+pub fn tasks_github_pr_files(repo: String, number: i64) -> Result<Vec<PrFile>, String> {
+    let key = format!("gh:pr-files:{repo}:{number}");
+    if let Some(v) = cache_get(&key) {
+        return serde_json::from_value(v).map_err(|e| e.to_string());
+    }
+    let path = format!("/repos/{repo}/pulls/{number}/files?per_page=100");
+    let raw = run_gh_paginated_array(&path)?;
+    let files: Vec<PrFile> = raw
+        .into_iter()
+        .map(|v| PrFile {
+            filename: v.get("filename").and_then(|s| s.as_str()).unwrap_or("").to_string(),
+            status: v.get("status").and_then(|s| s.as_str()).unwrap_or("").to_string(),
+            additions: v.get("additions").and_then(|n| n.as_i64()).unwrap_or(0),
+            deletions: v.get("deletions").and_then(|n| n.as_i64()).unwrap_or(0),
+        })
+        .collect();
+    cache_put(key, serde_json::to_value(&files).unwrap_or(Value::Null));
+    Ok(files)
+}
+
+/// Check-runs for a PR's head commit. Two REST calls: `/pulls/{n}` for the
+/// head SHA, then `/commits/{sha}/check-runs` paginated. GitHub wraps
+/// check-runs in `{ check_runs: [...] }` per page, so we unwrap before
+/// flattening.
+#[tauri::command(async)]
+pub fn tasks_github_pr_checks(repo: String, number: i64) -> Result<Vec<PrCheck>, String> {
+    let key = format!("gh:pr-checks:{repo}:{number}");
+    if let Some(v) = cache_get(&key) {
+        return serde_json::from_value(v).map_err(|e| e.to_string());
+    }
+    let pr_raw = run_gh(&["api", &format!("/repos/{repo}/pulls/{number}")])?;
+    let pr: Value = serde_json::from_str(&pr_raw).map_err(|e| e.to_string())?;
+    let sha = pr
+        .get("head")
+        .and_then(|h| h.get("sha"))
+        .and_then(|s| s.as_str())
+        .ok_or_else(|| "gh: PR head.sha missing".to_string())?
+        .to_string();
+
+    let path = format!("/repos/{repo}/commits/{sha}/check-runs?per_page=100");
+    let pages_raw = run_gh(&["api", &path, "--paginate", "--slurp"])?;
+    let pages: Vec<Value> = serde_json::from_str(&pages_raw).map_err(|e| e.to_string())?;
+    let runs: Vec<PrCheck> = pages
+        .into_iter()
+        .flat_map(|p| {
+            p.get("check_runs")
+                .and_then(|a| a.as_array())
+                .cloned()
+                .unwrap_or_default()
+        })
+        .map(|v| PrCheck {
+            name: v.get("name").and_then(|s| s.as_str()).unwrap_or("").to_string(),
+            status: v.get("status").and_then(|s| s.as_str()).unwrap_or("").to_string(),
+            conclusion: v.get("conclusion").and_then(|s| s.as_str()).map(String::from),
+            started_at: v.get("started_at").and_then(|s| s.as_str()).map(String::from),
+            completed_at: v.get("completed_at").and_then(|s| s.as_str()).map(String::from),
+        })
+        .collect();
+    cache_put(key, serde_json::to_value(&runs).unwrap_or(Value::Null));
+    Ok(runs)
 }
 
 // ────────────────────────────────────────────────────────────────────────

--- a/src/components/tasks/RowAccordion.tsx
+++ b/src/components/tasks/RowAccordion.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, type MouseEvent } from "react";
-import { fetchGhThread, fetchLinearThread, relativeTime } from "./api";
+import { fetchGhPrChecks, fetchGhPrFiles, fetchGhThread, fetchLinearThread, relativeTime } from "./api";
 import { Icon, priGlyph, statusGlyph } from "./icons";
 import { Markdown } from "../Markdown";
-import type { GhItem, LinearItem, LinearProject, LinearTeam, TaskThread, UnifiedItem } from "./types";
+import type { GhItem, LinearItem, LinearProject, LinearTeam, PrCheck, PrFile, TaskThread, UnifiedItem } from "./types";
 import { isGh } from "./types";
 
 const cap = (s: string) => (s ? s[0].toUpperCase() + s.slice(1) : s);
@@ -55,6 +55,64 @@ function ThreadActivity({ thread, err, loading }: ThreadPaneProps) {
   );
 }
 
+type LazyState<T> = { data: T | null; err: string | null; loading: boolean };
+
+function PrFiles({ state }: { state: LazyState<PrFile[]> }) {
+  if (state.loading) return <p style={{ color: "var(--fg-subtle)" }}>Loading files…</p>;
+  if (state.err) return <p style={{ color: "var(--tempest-semantic-error, tomato)" }}>{state.err}</p>;
+  const items = state.data ?? [];
+  if (!items.length) return <p style={{ color: "var(--fg-subtle)", fontStyle: "italic" }}>No files changed.</p>;
+  return (
+    <ul className="thread-list pr-files">
+      {items.map((f) => (
+        <li key={f.filename} className="pr-file">
+          <span className={`pr-file-status ${f.status}`}>{f.status}</span>
+          <span className="pr-file-name mono">{f.filename}</span>
+          <span className="pr-file-diff">
+            <span className="add">+{f.additions}</span>{" "}
+            <span className="del">−{f.deletions}</span>
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// Duration between started_at and completed_at, in the same compact shape
+// (`3s`, `1m`, `2h`) relativeTime uses so both tables read as one system.
+function checkDuration(c: PrCheck): string {
+  if (!c.started_at || !c.completed_at) return "";
+  const a = Date.parse(c.started_at);
+  const b = Date.parse(c.completed_at);
+  if (Number.isNaN(a) || Number.isNaN(b) || b < a) return "";
+  const s = Math.floor((b - a) / 1000);
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  return `${Math.floor(s / 3600)}h`;
+}
+
+function PrChecks({ state }: { state: LazyState<PrCheck[]> }) {
+  if (state.loading) return <p style={{ color: "var(--fg-subtle)" }}>Loading checks…</p>;
+  if (state.err) return <p style={{ color: "var(--tempest-semantic-error, tomato)" }}>{state.err}</p>;
+  const items = state.data ?? [];
+  if (!items.length) return <p style={{ color: "var(--fg-subtle)", fontStyle: "italic" }}>No checks reported.</p>;
+  return (
+    <ul className="thread-list pr-checks">
+      {items.map((c, i) => {
+        const outcome = c.conclusion ?? c.status;
+        const dur = checkDuration(c);
+        return (
+          <li key={`${c.name}-${i}`} className="pr-check">
+            <span className={`pr-check-outcome ${outcome}`}>{outcome}</span>
+            <span className="pr-check-name">{c.name}</span>
+            {dur && <span className="pr-check-dur">{dur}</span>}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
 export function RowAccordion({
   it,
   teams,
@@ -101,9 +159,43 @@ export function RowAccordion({
     return () => { cancelled = true; };
   }, [it.key, gh]);
 
-  const activityLabel = tabs[tab] === "Activity";
-  const commentsLabel = tabs[tab] === "Comments";
-  const stubLabel = tabs[tab] === "Files" || tabs[tab] === "Checks";
+  // PR-only Files/Checks tabs. Fetched lazily when their tab is first opened,
+  // then kept in state so switching back is instant. Backend already caches
+  // for 60s, so a stale row re-fetches on Refresh (cache_invalidate).
+  const isPr = gh && (it as GhItem).kind === "pr";
+  const [files, setFiles] = useState<LazyState<PrFile[]>>({ data: null, err: null, loading: false });
+  const [checks, setChecks] = useState<LazyState<PrCheck[]>>({ data: null, err: null, loading: false });
+
+  useEffect(() => {
+    setFiles({ data: null, err: null, loading: false });
+    setChecks({ data: null, err: null, loading: false });
+  }, [it.key]);
+
+  const activeTab = tabs[tab];
+  useEffect(() => {
+    if (!isPr) return;
+    const repo = (it as GhItem).repo;
+    const number = (it as GhItem).number;
+    let cancelled = false;
+    if (activeTab === "Files" && !files.data && !files.loading && !files.err) {
+      setFiles({ data: null, err: null, loading: true });
+      fetchGhPrFiles(repo, number)
+        .then((d) => { if (!cancelled) setFiles({ data: d, err: null, loading: false }); })
+        .catch((e) => { if (!cancelled) setFiles({ data: null, err: String(e?.message ?? e), loading: false }); });
+    }
+    if (activeTab === "Checks" && !checks.data && !checks.loading && !checks.err) {
+      setChecks({ data: null, err: null, loading: true });
+      fetchGhPrChecks(repo, number)
+        .then((d) => { if (!cancelled) setChecks({ data: d, err: null, loading: false }); })
+        .catch((e) => { if (!cancelled) setChecks({ data: null, err: String(e?.message ?? e), loading: false }); });
+    }
+    return () => { cancelled = true; };
+  }, [activeTab, isPr, it, files.data, files.loading, files.err, checks.data, checks.loading, checks.err]);
+
+  const activityLabel = activeTab === "Activity";
+  const commentsLabel = activeTab === "Comments";
+  const filesLabel = activeTab === "Files";
+  const checksLabel = activeTab === "Checks";
 
   const openBrowser = async () => {
     if (!it.url) return;
@@ -188,7 +280,8 @@ export function RowAccordion({
           {tab === 0 && <div className="prose"><BodyText text={it.body} /></div>}
           {commentsLabel && <ThreadComments thread={thread} err={threadErr} loading={threadLoading} />}
           {activityLabel && <ThreadActivity thread={thread} err={threadErr} loading={threadLoading} />}
-          {stubLabel && <p style={{ color: "var(--fg-subtle)" }}>Loads from the provider on demand — not wired yet.</p>}
+          {filesLabel && <PrFiles state={files} />}
+          {checksLabel && <PrChecks state={checks} />}
         </div>
 
         <aside className="side">

--- a/src/components/tasks/api.ts
+++ b/src/components/tasks/api.ts
@@ -8,6 +8,8 @@ import type {
   LinearBootstrap,
   LinearListPage,
   LinearScope,
+  PrCheck,
+  PrFile,
   TaskThread,
 } from "./types";
 
@@ -51,6 +53,14 @@ export async function fetchGhThread(repo: string, number: number): Promise<TaskT
 
 export async function fetchLinearThread(id: string): Promise<TaskThread> {
   return invoke<TaskThread>("tasks_linear_thread", { id });
+}
+
+export async function fetchGhPrFiles(repo: string, number: number): Promise<PrFile[]> {
+  return invoke<PrFile[]>("tasks_github_pr_files", { repo, number });
+}
+
+export async function fetchGhPrChecks(repo: string, number: number): Promise<PrCheck[]> {
+  return invoke<PrCheck[]>("tasks_github_pr_checks", { repo, number });
 }
 
 export async function invalidateTasksCache(): Promise<void> {

--- a/src/components/tasks/types.ts
+++ b/src/components/tasks/types.ts
@@ -100,6 +100,21 @@ export type TaskThread = {
   activity: TaskActivity[];
 };
 
+export type PrFile = {
+  filename: string;
+  status: string;   // "added" | "modified" | "removed" | "renamed" | ...
+  additions: number;
+  deletions: number;
+};
+
+export type PrCheck = {
+  name: string;
+  status: string;      // "queued" | "in_progress" | "completed"
+  conclusion: string | null; // "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required" | null
+  started_at: string | null;
+  completed_at: string | null;
+};
+
 export type UnifiedItem = (GhItem | LinearItem) & { key: string };
 
 export type Source = "unified" | "github" | "linear";


### PR DESCRIPTION
## Summary
- Files pane: `GET /repos/{repo}/pulls/{n}/files` paginated → filename, add/del counts, status chip.
- Checks pane: `GET /pulls/{n}` for `head.sha`, then paginated `GET /commits/{sha}/check-runs` → name, conclusion (or status), duration.
- Both go through the existing 60s task cache and lazy-load on first tab open, so opening a PR row costs no extra requests until you click into Files or Checks.

Also folds in three window-capability permissions (`unmaximize`, `is-maximized`, `set-fullscreen`) needed by the custom titlebar's maximize/fullscreen path — the existing `allow-maximize` alone can't restore a maximized window.

Closes #51

## Test plan
- [x] Open a PR row in Tasks, click **Files** — list renders with `+add / −del` counts; empty PR shows "No files changed."
- [x] Click **Checks** — runs render with conclusion + duration; PR with no checks shows "No checks reported."
- [x] Switch tabs back and forth — no re-fetch (in-memory cache).
- [x] Refresh from the header — cache invalidates, next open re-fetches.
- [x] Issue row (not a PR) still shows only Description / Comments / Activity.
- [x] Titlebar maximize toggle restores from maximized state.