### PR TITLE
fix: allow window dragging

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "core:window:allow-unmaximize",
     "core:window:allow-is-maximized",
     "core:window:allow-set-fullscreen",
+    "core:window:allow-start-dragging",
     "updater:default",
     "process:allow-restart",
     "notification:default"


### PR DESCRIPTION
## What changed

Added the missing `core:window:allow-start-dragging` permission to the main Tauri capability.

This allows the existing custom title-bar drag regions to invoke Tauri's window-drag command instead of failing with an ACL error.

## Related issue

N/A

## How was this tested

- `cargo check`
- Built and launched the arm64 macOS `.app`
- Confirmed the custom title bar can drag the window without an ACL error
- Tested on macOS Apple Silicon

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes (if backend changed)
- [x] I've tested this on my OS — noted which: macOS Apple Silicon
- [x] Docs updated if user-facing behaviour changed — N/A, bug fix only
- [x] No secrets, tokens, or personal paths in the diff
