### PR TITLE
fix: preserve Codex TOML table newlines

### DIFF
--- a/src/lib/agentHooks/codexTrust.ts
+++ b/src/lib/agentHooks/codexTrust.ts
@@ -85,7 +85,7 @@ export function upsertTrustBlocks(content: string, entries: CodexTrustEntry[]): 
     const block = [`[hooks.state."${escapeTomlBasic(key)}"]`, "enabled = true", `trusted_hash = "${hash}"`].join("\n");
     const range = findBlockRange(out, key);
     if (range) {
-      out = out.slice(0, range.start) + block + out.slice(range.end);
+      out = out.slice(0, range.start) + block + "\n" + out.slice(range.end);
     } else {
       const sep = out.length === 0 ? "" : out.endsWith("\n\n") ? "" : out.endsWith("\n") ? "\n" : "\n\n";
       out = `${out}${sep}${block}\n`;

--- a/src/lib/agentHooks/installer.check.ts
+++ b/src/lib/agentHooks/installer.check.ts
@@ -17,7 +17,7 @@ import { antigravityAdapter } from "./adapters/antigravity.ts";
 import { codexAdapter } from "./adapters/codex.ts";
 import { hermesAdapter } from "./adapters/hermes.ts";
 import { opencodeAdapter } from "./adapters/opencode.ts";
-import { sha256Hex, computeTrustedHash } from "./codexTrust.ts";
+import { sha256Hex, computeTrustedHash, upsertTrustBlocks } from "./codexTrust.ts";
 import type { HookAdapter, HookPaths, JsonObject } from "./types.ts";
 
 const SCRIPT = "tempest-claude-hook.cmd";
@@ -248,6 +248,14 @@ checkPlan(cursorAdapter, "cursor", "/home/u/.cursor/hooks.json", "tempest-cursor
   const trusted = computeTrustedHash({ sourcePath: "/h/.codex/hooks.json", eventLabel: "stop", groupIndex: 0, handlerIndex: 0, command: "x", timeoutSec: 10 });
   assert.ok(/^sha256:[0-9a-f]{64}$/.test(trusted), "trusted hash is sha256:<64 hex>");
   assert.strictEqual(trusted, computeTrustedHash({ sourcePath: "/other", eventLabel: "stop", groupIndex: 5, handlerIndex: 9, command: "x", timeoutSec: 10 }), "hash ignores path/position (Codex hashes only the handler identity)");
+}
+
+// Replacing one trust block must preserve a newline before the next table.
+{
+  const entry = { sourcePath: "/h/.codex/hooks.json", eventLabel: "stop", groupIndex: 0, handlerIndex: 0, command: "new", timeoutSec: 10 };
+  const before = '[hooks.state."/h/.codex/hooks.json:stop:0:0"]\nenabled = true\ntrusted_hash = "old"\n[other]\nvalue = true\n';
+  const after = upsertTrustBlocks(before, [entry]);
+  assert.ok(after.includes(`trusted_hash = "${computeTrustedHash(entry)}"\n[other]`), "replacement keeps next TOML table on a new line");
 }
 
 // ── Codex: hooks.json + config.toml trust, positions shared across both ───────


### PR DESCRIPTION
## What changed

Fixed Codex hook trust updates corrupting `~/.codex/config.toml` when an existing trust block was followed by another TOML table.

Tempest now preserves the required newline after a replaced trust block, preventing Codex startup failures such as `unexpected key or value, expected newline`.

Added a regression test covering replacement next to another TOML table.

## Related issue

Closes #87

## How was this tested

- `npm test` — 9/9 checks passed
- `npx tsc --noEmit`
- Verified the regression test fails before the fix and passes after it
- Parsed the repaired `~/.codex/config.toml` successfully
- Tested on macOS Apple Silicon

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes (if backend changed) — N/A, frontend TypeScript only
- [x] I've tested this on my OS — noted which: macOS Apple Silicon
- [x] Docs updated if user-facing behaviour changed — N/A, bug fix only
- [x] No secrets, tokens, or personal paths in the diff
