### PR TITLE
fix: detect CLIs from user shell

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2477,11 +2477,21 @@ fn login_shell_program_available(program: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(not(windows))]
+fn interactive_login_shell_args() -> Vec<String> {
+    vec!["-il".into()]
+}
+
 #[cfg(all(test, unix))]
 mod check_program_available_tests {
     #[test]
     fn login_shell_finds_available_program() {
         assert!(super::login_shell_program_available("sh"));
+    }
+
+    #[test]
+    fn terminal_uses_interactive_login_shell() {
+        assert_eq!(super::interactive_login_shell_args(), vec!["-il"]);
     }
 }
 
@@ -3588,7 +3598,14 @@ async fn create_pty_session(
             }
         } else {
             // Bare shell session
-            (shell.clone(), Vec::new())
+            #[cfg(windows)]
+            {
+                (shell.clone(), Vec::new())
+            }
+            #[cfg(not(windows))]
+            {
+                (shell.clone(), interactive_login_shell_args())
+            }
         };
 
         // Optionally provision a Hephaestus isolation environment and rewrite the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3438,6 +3438,25 @@ fn resolve_shell() -> String {
     }
 }
 
+#[cfg(not(windows))]
+fn agent_shell_args(agent_invocation: String) -> Vec<String> {
+    vec![
+        "-lic".into(),
+        format!("{}; exec $SHELL -il", agent_invocation),
+    ]
+}
+
+#[cfg(all(test, not(windows)))]
+mod agent_shell_args_tests {
+    #[test]
+    fn launches_agent_from_interactive_login_shell() {
+        assert_eq!(
+            super::agent_shell_args("codex".into()),
+            vec!["-lic", "codex; exec $SHELL -il"]
+        );
+    }
+}
+
 #[tauri::command]
 async fn create_pty_session(
     session_id: String,
@@ -3565,10 +3584,7 @@ async fn create_pty_session(
             }
             #[cfg(not(windows))]
             {
-                (shell.clone(), vec![
-                    "-c".into(),
-                    format!("{}; exec $SHELL -i", agent_invocation),
-                ])
+                (shell.clone(), agent_shell_args(agent_invocation))
             }
         } else {
             // Bare shell session
@@ -3673,6 +3689,9 @@ async fn create_pty_session(
             c.cwd(&cwd);
             c
         };
+
+        #[cfg(not(windows))]
+        cmd.env("TERM", "xterm-256color");
 
         // Project env from tempest.yml. Applied before the DB block below so an
         // isolated session's DATABASE_URL can never be shadowed by the repo.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2441,11 +2441,48 @@ fn check_program_available(program: String) -> bool {
     let check_cmd = if cfg!(windows) { "where" } else { "which" };
     // Multi-word hints like "gh copilot" — only check the base executable name.
     let first = program.split_whitespace().next().unwrap_or(&program);
-    new_command(check_cmd)
+    let available_on_path = new_command(check_cmd)
         .arg(first)
         .output()
         .map(|o| o.status.success())
+        .unwrap_or(false);
+    if available_on_path {
+        return true;
+    }
+
+    #[cfg(unix)]
+    {
+        return login_shell_program_available(first);
+    }
+    #[cfg(not(unix))]
+    false
+}
+
+#[cfg(unix)]
+fn login_shell_program_available(program: &str) -> bool {
+    #[cfg(target_os = "macos")]
+    let fallback_shell = "/bin/zsh";
+    #[cfg(not(target_os = "macos"))]
+    let fallback_shell = "/bin/sh";
+
+    let shell = std::env::var("SHELL")
+        .ok()
+        .filter(|s| std::path::Path::new(s).is_file())
+        .unwrap_or_else(|| fallback_shell.to_string());
+    new_command(&shell)
+        .args(["-lic", "command -v \"$TEMPEST_PROGRAM\" >/dev/null 2>&1"])
+        .env("TEMPEST_PROGRAM", program)
+        .output()
+        .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+#[cfg(all(test, unix))]
+mod check_program_available_tests {
+    #[test]
+    fn login_shell_finds_available_program() {
+        assert!(super::login_shell_program_available("sh"));
+    }
 }
 
 #[tauri::command(async)]


### PR DESCRIPTION
## What changed

Fixed agent CLI availability detection for desktop-launched Tempest instances with a minimal `PATH`.

<img width="382" height="589" alt="image" src="https://github.com/user-attachments/assets/7fe47417-2e47-4628-b024-89061b2ddfc5" />


Tempest still performs the existing fast PATH check first. When that fails on Unix, it checks through the user's configured interactive login shell, allowing CLIs installed through NVM, Homebrew, Bun, Cargo, and user-local bin directories to appear in the agent picker.

The program name is passed through an environment variable instead of interpolated into the shell command. Windows retains its existing `where`-based behavior.

Added a focused regression test for login-shell availability detection.

## Related issue

Closes #89

## How was this tested

- `cargo test --lib check_program_available_tests::login_shell_finds_available_program`
- `cargo check`
- `npx tsc --noEmit`
- Verified a Finder-like minimal PATH cannot find Codex directly but the configured login shell can
- Built, installed, and launched the arm64 macOS app
- Tested on macOS Apple Silicon

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes (if backend changed)
- [x] I've tested this on my OS — noted which: macOS Apple Silicon
- [x] Docs updated if user-facing behaviour changed — N/A, bug fix only
- [x] No secrets, tokens, or personal paths in the diff
