### PR TITLE
feat: clone a remote repository and add it as a project

### DIFF
--- a/src-tauri/src/git_clone.rs
+++ b/src-tauri/src/git_clone.rs
@@ -1,0 +1,76 @@
+//! Clone a remote git repository into a local folder, streaming progress to
+//! the frontend as it runs. Registration of the cloned folder as a project
+//! happens on the frontend via the same `openProjectByPath` path "Add
+//! project" already uses — this module only runs `git clone` and reports
+//! what happened.
+
+use crate::new_command;
+use std::io::BufRead;
+use std::process::Stdio;
+use tauri::Emitter;
+
+/// Cheap pre-flight: does `parent_dir/folder_name` already exist and contain
+/// files? Non-authoritative — git's own error on the real clone is still the
+/// source of truth; this just lets the UI show an early warning before the
+/// user clicks Clone.
+#[tauri::command(async)]
+pub fn check_clone_target(parent_dir: String, folder_name: String) -> Result<bool, String> {
+    let target = std::path::Path::new(&parent_dir).join(&folder_name);
+    match std::fs::read_dir(&target) {
+        Ok(mut entries) => Ok(entries.next().is_some()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Clone `url` into `<parent_dir>/<folder_name>`, streaming `git clone
+/// --progress` stderr lines (git writes both progress and errors there) to
+/// the frontend as `git-clone:log` events tagged with `request_id`. Returns
+/// the cloned path on success; on failure returns the raw joined stderr —
+/// classifying it (auth / already-exists / network) is the frontend's job,
+/// see `src/lib/gitClone.ts::classifyCloneError`, so this stays a dumb
+/// passthrough like every other git command in `lib.rs`.
+#[tauri::command(async)]
+pub fn git_clone_repo(
+    app: tauri::AppHandle,
+    request_id: String,
+    url: String,
+    parent_dir: String,
+    folder_name: String,
+) -> Result<String, String> {
+    std::fs::create_dir_all(&parent_dir).map_err(|e| e.to_string())?;
+    let target = std::path::Path::new(&parent_dir).join(&folder_name);
+
+    let mut child = new_command("git")
+        .args(["clone", "--progress", &url, &target.to_string_lossy()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn git: {e}"))?;
+
+    let stderr = child.stderr.take();
+    let app_evt = app.clone();
+    let req_evt = request_id.clone();
+    let handle = std::thread::spawn(move || {
+        let mut lines = Vec::new();
+        if let Some(h) = stderr {
+            for line in std::io::BufReader::new(h).lines().map_while(Result::ok) {
+                let _ = app_evt.emit(
+                    "git-clone:log",
+                    serde_json::json!({ "requestId": req_evt, "line": &line }),
+                );
+                lines.push(line);
+            }
+        }
+        lines
+    });
+
+    let status = child.wait().map_err(|e| e.to_string())?;
+    let lines = handle.join().unwrap_or_default();
+
+    if !status.success() {
+        return Err(lines.join("\n"));
+    }
+    Ok(target.to_string_lossy().to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod agent_hooks;
 mod automations;
 mod canvas_mcp;
 mod claude_bridge;
+mod git_clone;
 mod node_ingest;
 mod notes;
 mod pairing_relay;
@@ -2052,7 +2053,7 @@ mod resolve_node_tests {
 
 /// Build a `Command` that never opens a console window on Windows.
 /// On every other platform this is identical to `std::process::Command::new`.
-fn new_command(program: &str) -> std::process::Command {
+pub(crate) fn new_command(program: &str) -> std::process::Command {
     #[cfg(windows)]
     {
         let mut cmd = std::process::Command::new(program);
@@ -4624,6 +4625,8 @@ pub fn run() {
             stop_atlas_daemon,
             write_canvas_mcp_config,
             register_service_route,
+            git_clone::check_clone_target,
+            git_clone::git_clone_repo,
             secrets::secret_get,
             secrets::secret_set,
             secrets::secret_delete,

--- a/src/components/CloneRepoModal.css
+++ b/src/components/CloneRepoModal.css
@@ -1,0 +1,65 @@
+.crm-modal {
+  width: 440px;
+}
+
+/* ── Progress panel (shown while cloning) ─────────────────────────────── */
+.crm-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+}
+
+.crm-spinner {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--tempest-border-subtle);
+  border-top-color: var(--tempest-accent-blue);
+  animation: crm-spin 0.7s linear infinite;
+}
+
+@keyframes crm-spin {
+  to { transform: rotate(360deg); }
+}
+
+.crm-line {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--tempest-fg-muted);
+  margin: 0;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Error panel ───────────────────────────────────────────────────────── */
+.crm-error-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.crm-error-detail {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--tempest-fg-subtle);
+  background: var(--tempest-bg-input);
+  border: 1px solid var(--tempest-border-default);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 0;
+  max-height: 120px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crm-spinner {
+    animation-duration: 0.001ms;
+    animation-iteration-count: 1;
+  }
+}

--- a/src/components/CloneRepoModal.tsx
+++ b/src/components/CloneRepoModal.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useRef, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { FolderOpen } from "lucide-react";
+import { parseCloneUrl, defaultFolderName, classifyCloneError, type ClassifiedCloneError } from "../lib/gitClone";
+import "./NewProjectModal.css";
+import "./CloneRepoModal.css";
+
+interface Props {
+  onClose: () => void;
+  /** Called with the freshly-cloned folder's path once `git clone` succeeds. */
+  onCloned: (path: string) => void;
+}
+
+const CATEGORY_COPY: Record<ClassifiedCloneError["category"], string> = {
+  auth: "Authentication failed — check your SSH key or credential helper for this host.",
+  exists: "That folder already has files in it.",
+  network: "Couldn't reach the remote — check your connection and the URL.",
+  unknown: "The clone failed.",
+};
+
+export function CloneRepoModal({ onClose, onCloned }: Props) {
+  const [url, setUrl] = useState("");
+  const [parentDir, setParentDir] = useState("");
+  const [folderName, setFolderName] = useState("");
+  const [folderNameTouched, setFolderNameTouched] = useState(false);
+  const [targetWarning, setTargetWarning] = useState(false);
+  const [gitMissing, setGitMissing] = useState(false);
+  const [phase, setPhase] = useState<"form" | "cloning" | "error">("form");
+  const [currentLine, setCurrentLine] = useState("Starting…");
+  const [error, setError] = useState<ClassifiedCloneError | null>(null);
+  const requestIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    invoke<boolean>("check_program_available", { program: "git" })
+      .then((available) => setGitMissing(!available))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && phase !== "cloning") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, phase]);
+
+  // Pre-flight check: does parentDir/folderName already exist and have files?
+  useEffect(() => {
+    if (!parentDir || !folderName) { setTargetWarning(false); return; }
+    const id = setTimeout(() => {
+      invoke<boolean>("check_clone_target", { parentDir, folderName })
+        .then(setTargetWarning)
+        .catch(() => setTargetWarning(false));
+    }, 300);
+    return () => clearTimeout(id);
+  }, [parentDir, folderName]);
+
+  function onUrlChange(value: string) {
+    setUrl(value);
+    setError(null);
+    if (!folderNameTouched) setFolderName(defaultFolderName(value));
+  }
+
+  async function browse() {
+    const path = await open({ directory: true, multiple: false, title: "Select parent folder" });
+    if (path) setParentDir(path);
+  }
+
+  async function clone() {
+    const requestId = crypto.randomUUID();
+    requestIdRef.current = requestId;
+    setPhase("cloning");
+    setCurrentLine("Starting…");
+
+    const unlisten = await listen<{ requestId: string; line: string }>("git-clone:log", (e) => {
+      if (e.payload.requestId === requestId) setCurrentLine(e.payload.line);
+    });
+
+    try {
+      const clonedPath = await invoke<string>("git_clone_repo", {
+        requestId,
+        url: url.trim(),
+        parentDir,
+        folderName,
+      });
+      onCloned(clonedPath);
+    } catch (e) {
+      setError(classifyCloneError(String(e)));
+      setPhase("error");
+    } finally {
+      unlisten();
+    }
+  }
+
+  const parsedUrl = parseCloneUrl(url);
+  const canClone = parsedUrl.valid && parentDir.length > 0 && folderName.trim().length > 0 && !gitMissing && phase === "form";
+
+  return (
+    <div className="modal-overlay" onClick={() => phase !== "cloning" && onClose()}>
+      <div className="modal crm-modal" onClick={(e) => e.stopPropagation()}>
+        <h2 className="modal-title">Clone from remote</h2>
+
+        {phase === "cloning" ? (
+          <div className="crm-progress">
+            <span className="crm-spinner" aria-hidden="true" />
+            <p className="crm-line" title={currentLine}>{currentLine}</p>
+          </div>
+        ) : (
+          <>
+            <div className="modal-field">
+              <label className="modal-label">Repository URL</label>
+              <input
+                className="modal-input"
+                placeholder="https://github.com/owner/repo"
+                value={url}
+                onChange={(e) => onUrlChange(e.target.value)}
+                autoFocus
+              />
+              {url.length > 0 && !parsedUrl.valid && (
+                <p className="modal-error">Not a valid repository URL.</p>
+              )}
+            </div>
+
+            <div className="modal-field">
+              <label className="modal-label">Parent folder</label>
+              <div className="modal-location-row">
+                <input
+                  className="modal-input modal-input--location"
+                  placeholder="Select a folder…"
+                  value={parentDir}
+                  readOnly
+                  onClick={browse}
+                />
+                <button className="modal-browse-btn" onClick={browse}>
+                  <FolderOpen size={14} />
+                </button>
+              </div>
+            </div>
+
+            <div className="modal-field">
+              <label className="modal-label">Folder name</label>
+              <input
+                className="modal-input"
+                placeholder="repo"
+                value={folderName}
+                onChange={(e) => { setFolderName(e.target.value); setFolderNameTouched(true); }}
+                onKeyDown={(e) => e.key === "Enter" && canClone && clone()}
+              />
+              {targetWarning && (
+                <p className="modal-error">A non-empty folder already exists at this location.</p>
+              )}
+            </div>
+
+            {gitMissing && (
+              <p className="modal-error">git was not found on your PATH — install git to clone a repository.</p>
+            )}
+
+            {phase === "error" && error && (
+              <div className="crm-error-panel">
+                <p className="modal-error">{CATEGORY_COPY[error.category]}</p>
+                <pre className="crm-error-detail">{error.message}</pre>
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="modal-footer">
+          {phase === "error" ? (
+            <>
+              <button className="modal-btn modal-btn--cancel" onClick={onClose}>Cancel</button>
+              <button className="modal-btn modal-btn--create" onClick={() => setPhase("form")}>Try again</button>
+            </>
+          ) : (
+            <>
+              <button className="modal-btn modal-btn--cancel" onClick={onClose} disabled={phase === "cloning"}>
+                Cancel
+              </button>
+              <button className="modal-btn modal-btn--create" onClick={clone} disabled={!canClone}>
+                {phase === "cloning" ? "Cloning…" : "Clone"}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@ import { createPortal } from "react-dom";
 import { useState, useMemo, useEffect, useRef } from "react";
 import {
   ChevronRight, ChevronLeft, PanelLeft, PanelRight, Columns,
-  Rows, FolderOpen, Plus, X, Radio, List, Settings, SunMoon,
+  Rows, FolderOpen, Plus, X, Radio, List, Settings, SunMoon, Download,
 } from "lucide-react";
 import type { ActionId } from "../store/keybindings";
 import { getBindings, formatShortcut } from "../store/keybindings";
@@ -26,6 +26,7 @@ export interface CommandPaletteProps {
   onToggleRightSidebar: () => void;
   onOpenSettings: () => void;
   onOpenProject: () => void;
+  onCloneRepo: () => void;
   onNewWorkspace: () => void;
   onCloseTab: () => void;
   onNextTab: () => void;
@@ -53,7 +54,7 @@ const SECTION_ORDER: Section[] = ["Navigation", "Layout", "Workspaces", "Appeara
 
 export function CommandPalette({
   onClose, onToggleLeftSidebar, onToggleRightSidebar, onOpenSettings,
-  onOpenProject, onNewWorkspace, onCloseTab, onNextTab, onPrevTab,
+  onOpenProject, onCloneRepo, onNewWorkspace, onCloseTab, onNextTab, onPrevTab,
   onBroadcast, onSplitV, onSplitH, onOpenQueue, onToggleTheme,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -71,6 +72,7 @@ export function CommandPalette({
     { id: "split-v",              section: "Layout",     label: "Split Pane Side by Side", icon: <Columns size={14} />,      actionId: "splitPaneV",         run: () => { onSplitV(); onClose(); } },
     { id: "split-h",              section: "Layout",     label: "Split Pane Top / Bottom", icon: <Rows size={14} />,         actionId: "splitPaneH",         run: () => { onSplitH(); onClose(); } },
     { id: "open-project",         section: "Workspaces", label: "Open Project",            icon: <FolderOpen size={14} />,   actionId: "openProject",        run: () => { onOpenProject(); onClose(); } },
+    { id: "clone-repo",           section: "Workspaces", label: "Clone from Remote",       icon: <Download size={14} />,     keywords: "git clone remote url", run: () => { onCloneRepo(); onClose(); } },
     { id: "new-workspace",        section: "Workspaces", label: "New Workspace",           icon: <Plus size={14} />,         actionId: "newWorkspace",       run: () => { onNewWorkspace(); onClose(); } },
     { id: "close-tab",            section: "Workspaces", label: "Close Tab",               icon: <X size={14} />,            actionId: "closeTab",           run: () => { onCloseTab(); onClose(); } },
     { id: "broadcast",            section: "Workspaces", label: "Broadcast to Agents",     icon: <Radio size={14} />,        actionId: "broadcast",          run: () => { onBroadcast(); onClose(); } },

--- a/src/components/WorkspaceView.css
+++ b/src/components/WorkspaceView.css
@@ -940,6 +940,12 @@
   gap: 8px;
 }
 
+.sidebar-section-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .sidebar-section-add {
   color: var(--tempest-fg-subtle);
   cursor: pointer;

--- a/src/components/WorkspaceView.tsx
+++ b/src/components/WorkspaceView.tsx
@@ -68,6 +68,7 @@ import { startModelManifestFetch } from "../lib/remoteConfig";
 import { startAgentHooks } from "../store/agentHooks";
 import { setWorkspaceApi } from "../lib/mobileBridge/workspaceApi";
 import { AtlasIndexModal } from "./AtlasIndexModal";
+import { CloneRepoModal } from "./CloneRepoModal";
 import { KnowledgeBasePage } from "./KnowledgeBasePage";
 import { TasksPage } from "./TasksPage";
 import { AutomationsPage } from "./Automations/AutomationsPage";
@@ -144,6 +145,7 @@ export function WorkspaceView({ zen, name, path }: Props) {
   const [rightSidebarOpen, setRightSidebarOpen] = useState(true);
   const [gitRevision, setGitRevision] = useState(0);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [cloneModalOpen, setCloneModalOpen] = useState(false);
   const [projectSettingsPanelId, setProjectSettingsPanelId] = useState<string | null>(null);
   const [compactOpen, setCompactOpen] = useState(false);
   const [settingsInitialSection, setSettingsInitialSection] = useState<string>("appearance");
@@ -1922,6 +1924,7 @@ export function WorkspaceView({ zen, name, path }: Props) {
   // to the latest closure, so callers see fresh state without new refs.
   const goToStable = useEvent(goTo);
   const addWorkspaceStable = useEvent(addWorkspace);
+  const onCloneRepoStable = useEvent(() => setCloneModalOpen(true));
   const openSessionMenuStable = useEvent(openSessionMenu);
   const openBranchSessionMenuStable = useEvent(openBranchSessionMenu);
   const openCtxMenuStable = useEvent(openCtxMenu);
@@ -1976,6 +1979,7 @@ export function WorkspaceView({ zen, name, path }: Props) {
           setSettingsOpen={setSettingsOpen}
           goTo={goToStable}
           addWorkspace={addWorkspaceStable}
+          onCloneRepo={onCloneRepoStable}
           openSessionMenu={openSessionMenuStable}
           openBranchSessionMenu={openBranchSessionMenuStable}
           openCtxMenu={openCtxMenuStable}
@@ -2578,6 +2582,12 @@ export function WorkspaceView({ zen, name, path }: Props) {
       )}
 
       {settingsOpen && <SettingsPanel onClose={() => setSettingsOpen(false)} initialSection={settingsInitialSection as any} />}
+      {cloneModalOpen && (
+        <CloneRepoModal
+          onClose={() => setCloneModalOpen(false)}
+          onCloned={(path) => { setCloneModalOpen(false); void openProjectByPath(path); }}
+        />
+      )}
       {projectSettingsPanelId && (() => {
         const p = projects.find((pr) => pr.id === projectSettingsPanelId);
         return p ? <ProjectSettingsPanel projectId={p.id} projectPath={p.path} projectName={p.name} onClose={() => setProjectSettingsPanelId(null)} /> : null;
@@ -2644,6 +2654,7 @@ export function WorkspaceView({ zen, name, path }: Props) {
           onToggleRightSidebar={() => setRightSidebarOpen((o) => !o)}
           onOpenSettings={() => setSettingsOpen(true)}
           onOpenProject={addWorkspace}
+          onCloneRepo={() => setCloneModalOpen(true)}
           onNewWorkspace={() => {
             const projId = activeSession?.projectId ?? (projects[0]?.id ?? null);
             openSessionMenu({ currentTarget: document.body } as unknown as React.MouseEvent<HTMLElement>, projId, "below");

--- a/src/components/WorkspaceView/LeftSidebar.tsx
+++ b/src/components/WorkspaceView/LeftSidebar.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useRef, useState, type CSSProperties } from "react";
 import {
   LayoutGrid, Brain, List, Workflow, FolderPlus, TerminalSquare, Cpu,
   ChevronDown, ChevronRight, GitBranch, Plus, Cog, Waypoints, Trash2,
-  Bug, Mail, SunMoon, Settings, FolderOpen, Eye, Globe, FileCode,
+  Bug, Mail, SunMoon, Settings, FolderOpen, Eye, Globe, FileCode, Download,
 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { Session, Worktree, Project, NavSection } from "../../types/workspace";
@@ -49,6 +49,7 @@ export interface LeftSidebarProps {
   // Handlers (defined in parent)
   goTo: (s: NavSection) => void;
   addWorkspace: () => void;
+  onCloneRepo: () => void;
   openSessionMenu: (e: React.MouseEvent<HTMLElement>, projectId: string | null, placement: NewSessionPlacement) => void;
   openBranchSessionMenu: (e: React.MouseEvent<HTMLElement>, worktreePath: string, projectId: string, label: string, isRoot: boolean) => void;
   openCtxMenu: (
@@ -87,7 +88,7 @@ function LeftSidebarImpl(props: LeftSidebarProps) {
     projects, sessions, activeSessionId, zenSidebarItems,
     gitProjectIds, atlasEnabled, threadsVersion, expandedWorktrees,
     setActiveSessionId, setProjects, setProjectSettingsPanelId, setSettingsOpen,
-    goTo, addWorkspace, openSessionMenu, openBranchSessionMenu, openCtxMenu,
+    goTo, addWorkspace, onCloneRepo, openSessionMenu, openBranchSessionMenu, openCtxMenu,
     openSession, openThreadTab, toggleProject, toggleWorktree, toggleTheme,
     ensureThreadsLoaded, createThread, renameThread, removeThread,
   } = props;
@@ -209,9 +210,14 @@ function LeftSidebarImpl(props: LeftSidebarProps) {
         <>
           <div className="sidebar-section-label sidebar-section-label--row">
             <span>Projects</span>
-            <Tooltip content="Add project" placement="top">
-              <FolderPlus size={13} className="sidebar-section-add" onClick={addWorkspace} />
-            </Tooltip>
+            <div className="sidebar-section-actions">
+              <Tooltip content="Add project" placement="top">
+                <FolderPlus size={13} className="sidebar-section-add" onClick={addWorkspace} />
+              </Tooltip>
+              <Tooltip content="Clone from remote" placement="top">
+                <Download size={13} className="sidebar-section-add" onClick={onCloneRepo} />
+              </Tooltip>
+            </div>
           </div>
           {projects.length === 0 ? (
             <div className="projects-empty-box">No projects added</div>
@@ -759,6 +765,11 @@ function LeftSidebarImpl(props: LeftSidebarProps) {
             ) : (
               <Tooltip content="Add project" placement="top">
                 <FolderPlus size={16} className="sidebar-bottom-icon" onClick={addWorkspace} />
+              </Tooltip>
+            )}
+            {!zen && (
+              <Tooltip content="Clone from remote" placement="top">
+                <Download size={16} className="sidebar-bottom-icon" onClick={onCloneRepo} />
               </Tooltip>
             )}
           </div>

--- a/src/lib/gitClone.check.ts
+++ b/src/lib/gitClone.check.ts
@@ -1,0 +1,52 @@
+// Self-check for src/lib/gitClone.ts. Run with `node src/lib/gitClone.check.ts`
+// (or `npm test gitClone`) — no framework, no Tauri invoke, no React.
+import assert from "node:assert";
+import { parseCloneUrl, defaultFolderName, classifyCloneError } from "./gitClone.ts";
+
+// ── parseCloneUrl / defaultFolderName: URL shapes ────────────────────────────
+{
+  assert.strictEqual(defaultFolderName("https://github.com/anthropics/claude-code"), "claude-code");
+  assert.strictEqual(defaultFolderName("https://github.com/anthropics/claude-code.git"), "claude-code");
+  assert.strictEqual(defaultFolderName("https://github.com/anthropics/claude-code/"), "claude-code");
+  assert.strictEqual(defaultFolderName("ssh://git@github.com/anthropics/claude-code.git"), "claude-code");
+  assert.strictEqual(defaultFolderName("git@github.com:anthropics/claude-code.git"), "claude-code");
+  assert.strictEqual(defaultFolderName("git@github.com:anthropics/claude-code"), "claude-code");
+  // self-hosted, non-standard port
+  assert.strictEqual(defaultFolderName("https://git.example.com:8443/team/widgets.git"), "widgets");
+
+  assert.strictEqual(parseCloneUrl("not a url").valid, false);
+  assert.strictEqual(parseCloneUrl("").valid, false);
+  assert.strictEqual(parseCloneUrl("https://github.com/").valid, false);
+  assert.strictEqual(parseCloneUrl("https://github.com/anthropics/claude-code").valid, true);
+}
+
+// ── classifyCloneError: each bucket, plus an unmatched fallback ──────────────
+{
+  assert.strictEqual(
+    classifyCloneError("fatal: destination path 'repo' already exists and is not an empty directory.").category,
+    "exists",
+  );
+  assert.strictEqual(
+    classifyCloneError("git@github.com: Permission denied (publickey).").category,
+    "auth",
+  );
+  assert.strictEqual(
+    classifyCloneError("remote: Repository not found.\nfatal: repository 'https://github.com/x/y.git/' not found").category,
+    "auth",
+  );
+  assert.strictEqual(
+    classifyCloneError("fatal: could not read Username for 'https://github.com': terminal prompts disabled").category,
+    "auth",
+  );
+  assert.strictEqual(
+    classifyCloneError("fatal: unable to access 'https://github.com/x/y.git/': Could not resolve host: github.com").category,
+    "network",
+  );
+  assert.strictEqual(
+    classifyCloneError("ssh: connect to host github.com port 22: Connection timed out").category,
+    "network",
+  );
+  assert.strictEqual(classifyCloneError("fatal: something completely unexpected happened").category, "unknown");
+}
+
+console.log("gitClone: all checks passed");

--- a/src/lib/gitClone.ts
+++ b/src/lib/gitClone.ts
@@ -1,0 +1,91 @@
+// Pure helpers for the "Clone from remote" feature (tempest#97). No Tauri
+// invoke, no React — see tests/README.md. The actual `git clone` runs in
+// Rust (src-tauri/src/git_clone.rs); this file only parses the URL the user
+// pastes and classifies the raw stderr git returns on failure.
+
+export interface CloneUrlInfo {
+  valid: boolean;
+  /** Last path segment of the URL, ".git" suffix stripped. "" if unparseable. */
+  defaultFolderName: string;
+}
+
+// https://host/owner/repo(.git), ssh://git@host/owner/repo(.git), and the
+// scp-like git@host:owner/repo(.git) form — covers GitHub, GitLab,
+// Bitbucket, and self-hosted servers on any of those three shapes.
+const HTTP_SSH_URL = /^(?:https?|ssh):\/\/[^/\s]+\/.+$/i;
+const SCP_LIKE_URL = /^[\w.-]+@[\w.-]+:.+$/;
+
+function lastSegment(pathPart: string): string {
+  const trimmed = pathPart.replace(/\/+$/, "");
+  const segment = trimmed.split("/").pop() ?? "";
+  return segment.replace(/\.git$/i, "");
+}
+
+export function parseCloneUrl(raw: string): CloneUrlInfo {
+  const url = raw.trim();
+  if (!url) return { valid: false, defaultFolderName: "" };
+
+  if (HTTP_SSH_URL.test(url)) {
+    const afterScheme = url.replace(/^[a-z]+:\/\//i, "");
+    const slash = afterScheme.indexOf("/");
+    if (slash === -1) return { valid: false, defaultFolderName: "" };
+    const name = lastSegment(afterScheme.slice(slash + 1));
+    return { valid: name.length > 0, defaultFolderName: name };
+  }
+
+  if (SCP_LIKE_URL.test(url)) {
+    const colon = url.indexOf(":");
+    const name = lastSegment(url.slice(colon + 1));
+    return { valid: name.length > 0, defaultFolderName: name };
+  }
+
+  return { valid: false, defaultFolderName: "" };
+}
+
+export function defaultFolderName(url: string): string {
+  return parseCloneUrl(url).defaultFolderName;
+}
+
+export type CloneErrorCategory = "auth" | "exists" | "network" | "unknown";
+
+export interface ClassifiedCloneError {
+  category: CloneErrorCategory;
+  message: string;
+}
+
+// Order matters: exists/auth are checked before the more generic network
+// patterns since some messages could otherwise overlap.
+const EXISTS_PATTERNS = ["already exists and is not an empty directory"];
+const AUTH_PATTERNS = [
+  "permission denied (publickey)",
+  "authentication failed",
+  "could not read username",
+  "could not read password",
+  "terminal prompts disabled",
+  "403",
+  "repository not found",
+];
+const NETWORK_PATTERNS = [
+  "could not resolve host",
+  "failed to connect",
+  "connection timed out",
+  "network is unreachable",
+  "could not resolve proxy",
+  "ssl certificate problem",
+];
+
+function matchesAny(haystack: string, patterns: string[]): boolean {
+  return patterns.some((p) => haystack.includes(p));
+}
+
+export function classifyCloneError(stderr: string): ClassifiedCloneError {
+  const message = stderr.trim();
+  const lower = message.toLowerCase();
+
+  let category: CloneErrorCategory = "unknown";
+  if (matchesAny(lower, EXISTS_PATTERNS)) category = "exists";
+  else if (matchesAny(lower, AUTH_PATTERNS)) category = "auth";
+  else if (matchesAny(lower, NETWORK_PATTERNS)) category = "network";
+
+  return { category, message };
+}


### PR DESCRIPTION
Adds a "Clone from remote" action next to Add project (sidebar, bottom bar, command palette): paste a URL, pick/edit a destination folder, watch git clone progress in a small panel with inline auth/exists/network error reporting, and land on the same registered-project state Add project produces today.

Closes #97

## What changed

- **Backend** (`src-tauri/src/git_clone.rs`, new): `check_clone_target` does a non-authoritative pre-flight check for an existing non-empty destination folder; `git_clone_repo` spawns `git clone --progress`, streams stderr line-by-line to the frontend as `git-clone:log` events (tagged with a request id), and returns either the cloned path or the raw git stderr on failure. Follows the same "shell out to the system `git` binary" convention as every other git command in `lib.rs` — no new crate dependency.
- **Pure logic** (`src/lib/gitClone.ts`): parses pasted URLs (https, ssh, and the scp-like `git@host:owner/repo` form) into a default destination folder name, and classifies raw git stderr into `auth` / `exists` / `network` / `unknown` for the UI. Covered by `src/lib/gitClone.check.ts`.
- **UI** (`src/components/CloneRepoModal.tsx`): form → streaming-progress → error-with-retry modal, modeled on the existing `NewProjectModal` / `AtlasIndexModal`. On success it hands the cloned path back to the same `openProjectByPath` flow "Add project" already uses, so registration/opening behavior is identical.
- **Entry points**: a second icon next to "Add project" in the sidebar header and bottom bar (`WorkspaceView/LeftSidebar.tsx`), plus a "Clone from Remote" entry in the command palette (`CommandPalette.tsx`).
- Auth for private repos relies entirely on whatever git already has configured on the machine (SSH key, credential helper, `gh auth`) — no new credential UI.

## Related issue

Closes #97

## How was this tested

- `npx tsc --noEmit` — clean.
- `cargo check` — clean.
- `npm test` — 11/11 self-checks pass, including new `src/lib/gitClone.check.ts` (URL parsing across https/ssh/scp-like shapes incl. self-hosted host+port, and error classification across all four categories against real git/OpenSSH stderr strings).


## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes (if backend changed)
- [x] I've tested this on my OS — noted which: Windows <!-- not yet manually run in the app; see "How was this tested" -->
- [ ] Docs updated if user-facing behaviour changed
- [x] No secrets, tokens, or personal paths in the diff